### PR TITLE
[i18n] Part1: centralize locale setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,15 @@ $(echo $MOP_CMD) make host
 ## Windows
 If you want to develop on Windows, we recommend setting up a Ubuntu virtual machine (VM) or running Docker using [this guide](https://docs.docker.com/desktop/windows/wsl/ "https://docs.docker.com/desktop/windows/wsl/") and then following the Ubuntu or Docker instructions, respectively.
 
+If you prefer working natively:
+
+- Install [Go](https://go.dev/dl/s), [NVM Windows](https://github.com/coreybutler/nvm-windows), and [make](https://gnuwin32.sourceforge.net/packages/make.htm) (you can also install it through Chocolate).
+- Install and use Node 20+ from NVM, for example `nvm install 20 && nvm use 20`
+- Setup GO workspace following [this guide](https://www.freecodecamp.org/news/setting-up-go-programming-language-on-windows-f02c8c14e2f/)
+- Download GO dependencies [protobuf](https://github.com/protocolbuffers/protobuf/releases), [gopls](https://github.com/golang/tools/releases), [air-verse](https://github.com/air-verse/air/releases), [protobuf-go](https://github.com/protocolbuffers/protobuf-go/releases), and [staticcheck](https://github.com/dominikh/go-tools/releases). Unzip them into your GO workspace directory.
+
+With all the dependencies setup, you should be able to run the `make` commands and compile the project.
+
 ## Mac OS
 * Docker is available in OS X as well, so in theory similar instructions should work for the Docker method
 * You can also use the Ubuntu setup instructions as above to run natively, with a few modifications:

--- a/ui/core/components/settings_menu.tsx
+++ b/ui/core/components/settings_menu.tsx
@@ -2,6 +2,7 @@ import tippy from 'tippy.js';
 import { ref } from 'tsx-vanilla';
 
 import { wowheadSupportedLanguages } from '../constants/lang.js';
+import { setCurrentLang } from '../locale_service';
 import { Sim } from '../sim.js';
 import { SimUI } from '../sim_ui.js';
 import { EventID, TypedEvent } from '../typed_event.js';
@@ -120,6 +121,7 @@ export class SettingsMenu extends BaseModal {
 				},
 				setValue: (eventID: EventID, sim: Sim, newValue: number) => {
 					sim.setLanguage(eventID, langs[newValue] || 'en');
+					setCurrentLang(langs[newValue] || 'en');
 				},
 			});
 			// Refresh page after language change, to apply the changes.

--- a/ui/core/constants/lang.ts
+++ b/ui/core/constants/lang.ts
@@ -1,3 +1,5 @@
+import { getCurrentLang, setCurrentLang } from '../locale_service';
+
 export const wowheadSupportedLanguages: Record<string, string> = {
 	'en': 'English',
 	'cn': '简体中文',
@@ -21,18 +23,14 @@ export function getBrowserLanguageCode(): string {
 }
 
 export function getLanguageCode(): string {
-	return cachedLanguageCode_;
+	return getCurrentLang();
 }
 
 export function getWowheadLanguagePrefix(): string {
-	return cachedWowheadLanguagePrefix_;
+	const lang = getCurrentLang();
+	return lang === 'en' ? '' : lang + '/';
 }
 
 export function setLanguageCode(newLang: string) {
-	// Use '' instead of 'en' because wowhead doesn't like having the en/ prefix.
-	cachedLanguageCode_ = newLang == 'en' ? '' : newLang;
-	cachedWowheadLanguagePrefix_ = cachedLanguageCode_ ? cachedLanguageCode_ + '/' : '';
+	setCurrentLang(newLang);
 }
-
-let cachedLanguageCode_ = '';
-let cachedWowheadLanguagePrefix_ = '';

--- a/ui/core/constants/lang.ts
+++ b/ui/core/constants/lang.ts
@@ -28,7 +28,7 @@ export function getLanguageCode(): string {
 
 export function getWowheadLanguagePrefix(): string {
 	const lang = getCurrentLang();
-	return lang === 'en' ? '' : lang + '/';
+	return lang === 'en' ? '' : `${lang}/`;
 }
 
 export function setLanguageCode(newLang: string) {

--- a/ui/core/locale_service.ts
+++ b/ui/core/locale_service.ts
@@ -1,0 +1,19 @@
+const LOCALE_KEY = 'wowsims_locale';
+
+export function getCurrentLang(): string {
+  const record = localStorage.getItem(LOCALE_KEY);
+  if (record) {
+    try {
+      return JSON.parse(record).lang || 'en';
+    } catch {
+      return 'en';
+    }
+  }
+  return 'en';
+}
+
+export function setCurrentLang(lang: string): void {
+  localStorage.setItem(LOCALE_KEY, JSON.stringify({ lang }));
+}
+
+export {};

--- a/ui/core/sim.ts
+++ b/ui/core/sim.ts
@@ -3,6 +3,7 @@ import { SimRequest } from '../worker/types';
 import { getBrowserLanguageCode, setLanguageCode } from './constants/lang';
 import * as OtherConstants from './constants/other';
 import { Encounter } from './encounter';
+import { getCurrentLang, setCurrentLang } from './locale_service';
 import { Player, UnitMetadata } from './player';
 import {
 	BulkSettings,
@@ -183,6 +184,8 @@ export class Sim {
 		this.changeEmitter = TypedEvent.onAny([this.settingsChangeEmitter, this.raid.changeEmitter, this.encounter.changeEmitter]);
 
 		TypedEvent.onAny([this.raid.changeEmitter, this.encounter.changeEmitter]).on(eventID => this.updateCharacterStats(eventID));
+
+		this.language = getCurrentLang();
 	}
 
 	waitForInit(): Promise<void> {
@@ -729,6 +732,7 @@ export class Sim {
 		newLanguage = newLanguage || getBrowserLanguageCode();
 		if (newLanguage != this.language) {
 			this.language = newLanguage;
+			setCurrentLang(this.language);
 			setLanguageCode(this.language);
 			this.languageChangeEmitter.emit(eventID);
 		}

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -117,7 +117,9 @@ export default defineConfig(({ command, mode }) => {
 			rollupOptions: {
 				input: {
 					...glob.sync(path.resolve(BASE_PATH, '**/index.html').replace(/\\/g, '/')).reduce<Record<string, string>>((acc, cur) => {
-						const name = path.relative(__dirname, cur);
+						const name = process.platform === 'win32'
+							? path.relative(__dirname, cur).replace(/\\/g, '/').replace(/\/+/g, '/')
+							: path.relative(__dirname, cur);
 						acc[name] = cur;
 						return acc;
 					}, {}),

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -117,9 +117,7 @@ export default defineConfig(({ command, mode }) => {
 			rollupOptions: {
 				input: {
 					...glob.sync(path.resolve(BASE_PATH, '**/index.html').replace(/\\/g, '/')).reduce<Record<string, string>>((acc, cur) => {
-						const name = process.platform === 'win32'
-							? path.relative(__dirname, cur).replace(/\\/g, '/').replace(/\/+/g, '/')
-							: path.relative(__dirname, cur);
+						const name = path.relative(__dirname, cur).split(path.sep).join('/');
 						acc[name] = cur;
 						return acc;
 					}, {}),


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6cc9daf9-59c4-4078-8ce0-52a497440f0f)

## Changes Made

- **Windows Build Fix:** Updated vite.config.mts to handle Windows paths correctly by normalizing backslashes to forward slashes, ensuring consistent path resolution during builds.
- **Locale Setting Centralization:** Moved language settings from per-class storage to a global locale_service.ts, providing a single source of truth for language preferences. Language change now should be working for every class sim page. 
- **Windows Instructions:** Added clear instructions for Windows users in the README, ensuring proper setup and compatibility.
