### PR TITLE
[Buffs] Fixup raid buffs

### DIFF
--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -140,9 +140,7 @@ func applyBuffEffects(agent Agent, raidBuffs *proto.RaidBuffs, _ *proto.PartyBuf
 	if raidBuffs.MindQuickening {
 		MindQuickeningAura(u)
 	}
-	if raidBuffs.ShadowForm {
-		ShadowFormAura(u)
-	}
+
 	if raidBuffs.ElementalOath {
 		ElementalOath(u)
 	}

--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -481,12 +481,6 @@ func MindQuickeningAura(u *Unit) *Aura {
 	return aura
 }
 
-func ShadowFormAura(u *Unit) *Aura {
-	aura := makeExclusiveBuff(u, BuffConfig{"Shadow Form", ActionID{SpellID: 15473}, nil})
-	registerExclusiveSpellHaste(aura, 0.05)
-	return aura
-}
-
 func ElementalOath(u *Unit) *Aura {
 	aura := makeExclusiveBuff(u, BuffConfig{"Elemental Oath", ActionID{SpellID: 51470}, nil})
 	registerExclusiveSpellHaste(aura, 0.05)
@@ -502,7 +496,7 @@ func ElementalOath(u *Unit) *Aura {
 func StillWaterAura(u *Unit) *Aura {
 	return makeExclusiveBuff(u, BuffConfig{"Still Water", ActionID{SpellID: 126309},
 		[]StatConfig{
-			{stats.SpellPower, 0.10, true},
+			{stats.SpellPower, 1.10, true},
 			{stats.PhysicalCritPercent, 5, false},
 			{stats.SpellCritPercent, 5, false}}})
 }
@@ -510,15 +504,15 @@ func ArcaneBrilliance(u *Unit) *Aura {
 	// Mages: +10% Spell Power
 	return makeExclusiveBuff(u, BuffConfig{"Arcane Brilliance", ActionID{SpellID: 1459},
 		[]StatConfig{
-			{stats.SpellPower, 0.10, true},
+			{stats.SpellPower, 1.10, true},
 			{stats.PhysicalCritPercent, 5, false},
 			{stats.SpellCritPercent, 5, false}}})
 }
 func BurningWrathAura(u *Unit) *Aura {
-	return makeExclusiveBuff(u, BuffConfig{"Burning Wrath", ActionID{SpellID: 77747}, []StatConfig{{stats.SpellPower, 0.10, true}}})
+	return makeExclusiveBuff(u, BuffConfig{"Burning Wrath", ActionID{SpellID: 77747}, []StatConfig{{stats.SpellPower, 1.10, true}}})
 }
 func DarkIntentAura(u *Unit) *Aura {
-	return makeExclusiveBuff(u, BuffConfig{"Dark Intent", ActionID{SpellID: 109773}, []StatConfig{{stats.SpellPower, 0.10, true}, {stats.Stamina, 0.10, true}}})
+	return makeExclusiveBuff(u, BuffConfig{"Dark Intent", ActionID{SpellID: 109773}, []StatConfig{{stats.SpellPower, 1.10, true}, {stats.Stamina, 1.10, true}}})
 }
 
 /////////////


### PR DESCRIPTION
* Removed Shadowform as that's the Priest's own buff only. Mind Quickening is the Aura everyone has
* Spell Power fix. Was reducing spell by 90% right now 😁 