### PR TITLE
[Fix] Env detection for Tooltips

### DIFF
--- a/ui/core/wowhead.ts
+++ b/ui/core/wowhead.ts
@@ -88,7 +88,7 @@ export const WOWHEAD_EXPANSION_ENV = 15;
 export const buildWowheadTooltipDataset = async (options: WowheadTooltipItemParams | WowheadTooltipSpellParams) => {
 	const lang = getLanguageCode();
 	const params = new URLSearchParams();
-	const langPrefix = lang ? lang + '.' : '';
+	const langPrefix = lang && lang != 'en' ? lang + '.' : '';
 	params.set('domain', `${langPrefix}mop-classic`);
 	params.set('dataEnv', String(WOWHEAD_EXPANSION_ENV));
 


### PR DESCRIPTION
*  locale does not seem to be contained in the default locale list anymore
    * This cauesd locale / env parsing to fail and default to env 1