### PR TITLE
[Buffs] Fixup Lust affecting pets directly

### DIFF
--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -669,12 +669,6 @@ func BloodlustAura(character *Character, actionTag int32) *Aura {
 		Duration: time.Minute * 10,
 	})
 
-	for _, pet := range character.Pets {
-		if !pet.IsGuardian() {
-			BloodlustAura(&pet.Character, actionTag)
-		}
-	}
-
 	aura := character.GetOrRegisterAura(Aura{
 		Label:    "Bloodlust-" + actionID.String(),
 		Tag:      BloodlustAuraTag,
@@ -683,12 +677,6 @@ func BloodlustAura(character *Character, actionTag int32) *Aura {
 		OnGain: func(aura *Aura, sim *Simulation) {
 			aura.Unit.MultiplyAttackSpeed(sim, 1.3)
 			aura.Unit.MultiplyResourceRegenSpeed(sim, 1.3)
-			for _, pet := range character.Pets {
-				if pet.IsEnabled() && !pet.IsGuardian() {
-					pet.GetAura(aura.Label).Activate(sim)
-				}
-			}
-
 			sated.Activate(sim)
 		},
 		OnExpire: func(aura *Aura, sim *Simulation) {


### PR DESCRIPTION
* With MoP Lust is no longer applied non-player targets.
* Any pet scaling with owner's haste does so through dynamic stat scaling