### PR TITLE
[Feature] Add native support for Spells with Stacks

### DIFF
--- a/proto/apl.proto
+++ b/proto/apl.proto
@@ -85,7 +85,7 @@ message APLAction {
     }
 }
 
-// NextIndex: 100
+// NextIndex: 99
 message APLValue {
 	UUID uuid = 87;
 
@@ -164,8 +164,8 @@ message APLValue {
         APLValueSpellIsChanneling spell_is_channeling = 56;
         APLValueSpellChanneledTicks spell_channeled_ticks = 57;
         APLValueSpellCurrentCost spell_current_cost = 62;
-        APLValueSpellNumCharges spell_num_charges = 98;
-        APLValueSpellTimeToCharge spell_time_to_charge = 99;
+        APLValueSpellNumCharges spell_num_charges = 97;
+        APLValueSpellTimeToCharge spell_time_to_charge = 98;
 
         // Aura values
         APLValueAuraIsKnown aura_is_known = 73;

--- a/proto/apl.proto
+++ b/proto/apl.proto
@@ -85,7 +85,7 @@ message APLAction {
     }
 }
 
-// NextIndex: 98
+// NextIndex: 100
 message APLValue {
 	UUID uuid = 87;
 
@@ -164,6 +164,8 @@ message APLValue {
         APLValueSpellIsChanneling spell_is_channeling = 56;
         APLValueSpellChanneledTicks spell_channeled_ticks = 57;
         APLValueSpellCurrentCost spell_current_cost = 62;
+        APLValueSpellNumCharges spell_num_charges = 98;
+        APLValueSpellTimeToCharge spell_time_to_charge = 99;
 
         // Aura values
         APLValueAuraIsKnown aura_is_known = 73;
@@ -211,7 +213,6 @@ message APLValue {
         APLValueShamanFireElementalDuration shaman_fire_elemental_duration = 83;
         APLValueMonkCurrentChi monk_current_chi = 95;
 		APLValueMonkMaxChi monk_max_chi = 96;
-		APLValueMonkNextChiBrewRecharge monk_next_chi_brew_recharge = 97;
     }
 }
 
@@ -576,6 +577,12 @@ message APLValueSpellChanneledTicks {
 message APLValueSpellCurrentCost {
     ActionID spell_id = 1;
 }
+message APLValueSpellNumCharges{
+    ActionID spell_id = 1;
+}
+message APLValueSpellTimeToCharge{
+    ActionID spell_id = 1;
+}
 
 message APLValueAuraIsKnown {
     UnitReference source_unit = 2;
@@ -695,4 +702,3 @@ message APLValueShamanFireElementalDuration {
 
 message APLValueMonkCurrentChi {}
 message APLValueMonkMaxChi {}
-message APLValueMonkNextChiBrewRecharge {}

--- a/sim/core/apl_value.go
+++ b/sim/core/apl_value.go
@@ -192,6 +192,10 @@ func (rot *APLRotation) newAPLValue(config *proto.APLValue) APLValue {
 		value = rot.newValueSpellChanneledTicks(config.GetSpellChanneledTicks(), config.Uuid)
 	case *proto.APLValue_SpellCurrentCost:
 		value = rot.newValueSpellCurrentCost(config.GetSpellCurrentCost(), config.Uuid)
+	case *proto.APLValue_SpellNumCharges:
+		value = rot.newValueSpellNumCharges(config.GetSpellNumCharges(), config.Uuid)
+	case *proto.APLValue_SpellTimeToCharge:
+		value = rot.newValueSpellTimeToCharge(config.GetSpellTimeToCharge(), config.Uuid)
 
 	// Auras
 	case *proto.APLValue_AuraIsKnown:

--- a/sim/core/apl_values_spell.go
+++ b/sim/core/apl_values_spell.go
@@ -255,3 +255,62 @@ func (value *APLValueSpellCurrentCost) GetFloat(_ *Simulation) float64 {
 func (value *APLValueSpellCurrentCost) String() string {
 	return fmt.Sprintf("CurrentCost(%s)", value.spell.ActionID)
 }
+
+// Spell Charges
+type APLValueSpellNumCharges struct {
+	DefaultAPLValueImpl
+	spell *Spell
+}
+
+func (rot *APLRotation) newValueSpellNumCharges(config *proto.APLValueSpellNumCharges, _ *proto.UUID) APLValue {
+	spell := rot.GetAPLSpell(config.SpellId)
+	if spell == nil {
+		return nil
+	}
+	return &APLValueSpellNumCharges{
+		spell: spell,
+	}
+}
+
+func (value *APLValueSpellNumCharges) Type() proto.APLValueType {
+	return proto.APLValueType_ValueTypeInt
+}
+
+func (value *APLValueSpellNumCharges) GetInt(_ *Simulation) int32 {
+	return int32(value.spell.GetNumCharges())
+}
+
+func (value *APLValueSpellNumCharges) String() string {
+	return fmt.Sprintf("SpellNumCharges(%s)", value.spell.ActionID)
+}
+
+type APLValueSpellTimeToCharge struct {
+	DefaultAPLValueImpl
+	spell *Spell
+}
+
+func (rot *APLRotation) newValueSpellTimeToCharge(config *proto.APLValueSpellTimeToCharge, _ *proto.UUID) APLValue {
+	spell := rot.GetAPLSpell(config.SpellId)
+	if spell == nil {
+		return nil
+	}
+	return &APLValueSpellTimeToCharge{
+		spell: spell,
+	}
+}
+
+func (value *APLValueSpellTimeToCharge) Type() proto.APLValueType {
+	return proto.APLValueType_ValueTypeDuration
+}
+
+func (value *APLValueSpellTimeToCharge) GetDuration(sim *Simulation) time.Duration {
+	return value.spell.NextChargeIn(sim)
+}
+
+func (value *APLValueSpellTimeToCharge) GetFloat(sim *Simulation) float64 {
+	return value.GetDuration(sim).Seconds()
+}
+
+func (value *APLValueSpellTimeToCharge) String() string {
+	return fmt.Sprintf("SpellTimeToCharge(%s)", value.spell.ActionID)
+}

--- a/sim/core/cast.go
+++ b/sim/core/cast.go
@@ -180,17 +180,12 @@ func (spell *Spell) makeCastFunc(config CastConfig) CastSuccessFunc {
 						spell.Cost.SpendCost(sim, spell)
 					}
 
-					if spell.charges > 0 {
+					if spell.MaxCharges > 0 {
 						spell.ConsumeCharge(sim)
 					}
 
-					if config.CD.Timer != nil && spell.charges == 0 {
-						if spell.MaxCharges > 0 {
-							// spell.CdMultiplier would be concidered within the the recharge time if we ever need that
-							spell.CD.Set(sim.CurrentTime + spell.NextChargeIn(sim))
-						} else {
-							spell.CD.Set(sim.CurrentTime + time.Duration(float64(spell.CD.Duration)*spell.CdMultiplier))
-						}
+					if config.CD.Timer != nil {
+						spell.triggerCooldown(sim)
 					}
 
 					if config.SharedCD.Timer != nil {
@@ -221,17 +216,12 @@ func (spell *Spell) makeCastFunc(config CastConfig) CastSuccessFunc {
 			spell.Cost.SpendCost(sim, spell)
 		}
 
-		if spell.charges > 0 {
+		if spell.MaxCharges > 0 {
 			spell.ConsumeCharge(sim)
 		}
 
-		if config.CD.Timer != nil && spell.charges == 0 {
-			if spell.MaxCharges > 0 {
-				// spell.CdMultiplier would be concidered within the the recharge time if we ever need that
-				spell.CD.Set(sim.CurrentTime + spell.NextChargeIn(sim))
-			} else {
-				spell.CD.Set(sim.CurrentTime + time.Duration(float64(spell.CD.Duration)*spell.CdMultiplier))
-			}
+		if config.CD.Timer != nil {
+			spell.triggerCooldown(sim)
 		}
 
 		if config.SharedCD.Timer != nil {
@@ -246,6 +236,18 @@ func (spell *Spell) makeCastFunc(config CastConfig) CastSuccessFunc {
 
 		return true
 	}
+}
+
+func (spell *Spell) triggerCooldown(sim *Simulation) {
+	cd := time.Duration(float64(spell.CD.Duration) * spell.CdMultiplier)
+
+	// if recharge timer is higher than the actual cooldown of the spell we use
+	if spell.MaxCharges > 0 && spell.charges == 0 {
+		// spell.CdMultiplier would be considered within the the recharge time if we ever need that
+		cd = TernaryDuration(cd > spell.NextChargeIn(sim), cd, spell.NextChargeIn(sim))
+	}
+
+	spell.CD.Set(sim.CurrentTime + cd)
 }
 
 func (spell *Spell) makeCastFuncSimple() CastSuccessFunc {
@@ -280,17 +282,12 @@ func (spell *Spell) makeCastFuncSimple() CastSuccessFunc {
 			spell.Unit.Log(sim, "Completed cast %s", spell.ActionID)
 		}
 
-		if spell.charges > 0 {
+		if spell.MaxCharges > 0 {
 			spell.ConsumeCharge(sim)
 		}
 
-		if spell.CD.Timer != nil && spell.charges == 0 {
-			if spell.MaxCharges > 0 {
-				// spell.CdMultiplier would be concidered within the the recharge time if we ever need that
-				spell.CD.Set(sim.CurrentTime + spell.NextChargeIn(sim))
-			} else {
-				spell.CD.Set(sim.CurrentTime + time.Duration(float64(spell.CD.Duration)*spell.CdMultiplier))
-			}
+		if spell.CD.Timer != nil {
+			spell.triggerCooldown(sim)
 		}
 
 		if spell.SharedCD.Timer != nil {

--- a/sim/core/cast.go
+++ b/sim/core/cast.go
@@ -185,7 +185,12 @@ func (spell *Spell) makeCastFunc(config CastConfig) CastSuccessFunc {
 					}
 
 					if config.CD.Timer != nil && spell.charges == 0 {
-						spell.CD.Set(sim.CurrentTime + time.Duration(float64(spell.CD.Duration)*spell.CdMultiplier))
+						if spell.MaxCharges > 0 {
+							// spell.CdMultiplier would be concidered within the the recharge time if we ever need that
+							spell.CD.Set(sim.CurrentTime + spell.NextChargeIn(sim))
+						} else {
+							spell.CD.Set(sim.CurrentTime + time.Duration(float64(spell.CD.Duration)*spell.CdMultiplier))
+						}
 					}
 
 					if config.SharedCD.Timer != nil {
@@ -221,7 +226,12 @@ func (spell *Spell) makeCastFunc(config CastConfig) CastSuccessFunc {
 		}
 
 		if config.CD.Timer != nil && spell.charges == 0 {
-			spell.CD.Set(sim.CurrentTime + time.Duration(float64(spell.CD.Duration)*spell.CdMultiplier))
+			if spell.MaxCharges > 0 {
+				// spell.CdMultiplier would be concidered within the the recharge time if we ever need that
+				spell.CD.Set(sim.CurrentTime + spell.NextChargeIn(sim))
+			} else {
+				spell.CD.Set(sim.CurrentTime + time.Duration(float64(spell.CD.Duration)*spell.CdMultiplier))
+			}
 		}
 
 		if config.SharedCD.Timer != nil {
@@ -275,7 +285,12 @@ func (spell *Spell) makeCastFuncSimple() CastSuccessFunc {
 		}
 
 		if spell.CD.Timer != nil && spell.charges == 0 {
-			spell.CD.Set(sim.CurrentTime + time.Duration(float64(spell.CD.Duration)*spell.CdMultiplier))
+			if spell.MaxCharges > 0 {
+				// spell.CdMultiplier would be concidered within the the recharge time if we ever need that
+				spell.CD.Set(sim.CurrentTime + spell.NextChargeIn(sim))
+			} else {
+				spell.CD.Set(sim.CurrentTime + time.Duration(float64(spell.CD.Duration)*spell.CdMultiplier))
+			}
 		}
 
 		if spell.SharedCD.Timer != nil {

--- a/sim/core/cast.go
+++ b/sim/core/cast.go
@@ -184,7 +184,7 @@ func (spell *Spell) makeCastFunc(config CastConfig) CastSuccessFunc {
 						spell.ConsumeCharge(sim)
 					}
 
-					if config.CD.Timer != nil {
+					if config.CD.Timer != nil || spell.rechargeTimer != nil {
 						spell.triggerCooldown(sim)
 					}
 
@@ -220,7 +220,7 @@ func (spell *Spell) makeCastFunc(config CastConfig) CastSuccessFunc {
 			spell.ConsumeCharge(sim)
 		}
 
-		if config.CD.Timer != nil {
+		if config.CD.Timer != nil || spell.rechargeTimer != nil {
 			spell.triggerCooldown(sim)
 		}
 
@@ -247,7 +247,9 @@ func (spell *Spell) triggerCooldown(sim *Simulation) {
 		cd = TernaryDuration(cd > spell.NextChargeIn(sim), cd, spell.NextChargeIn(sim))
 	}
 
-	spell.CD.Set(sim.CurrentTime + cd)
+	if cd > 0 {
+		spell.CD.Set(sim.CurrentTime + cd)
+	}
 }
 
 func (spell *Spell) makeCastFuncSimple() CastSuccessFunc {
@@ -286,7 +288,7 @@ func (spell *Spell) makeCastFuncSimple() CastSuccessFunc {
 			spell.ConsumeCharge(sim)
 		}
 
-		if spell.CD.Timer != nil {
+		if spell.CD.Timer != nil || spell.rechargeTimer != nil {
 			spell.triggerCooldown(sim)
 		}
 

--- a/sim/core/spell.go
+++ b/sim/core/spell.go
@@ -465,6 +465,7 @@ func (spell *Spell) reset(sim *Simulation) {
 	if spell.rechargeTimer != nil {
 		spell.rechargeTimer.Cancel(sim)
 		spell.rechargeTimer = nil
+		spell.charges = spell.MaxCharges
 	}
 }
 

--- a/sim/core/spell.go
+++ b/sim/core/spell.go
@@ -288,6 +288,11 @@ func (unit *Unit) RegisterSpell(config SpellConfig) *Spell {
 		spell.Cost = newFocusCost(spell, config.FocusCost)
 	}
 
+	// Create timer to track recharge time if none given
+	if spell.CD.Timer == nil && spell.RechargeTime > 0 {
+		spell.CD.Timer = spell.Unit.NewTimer()
+	}
+
 	spell.createDots(config.Dot, false)
 	spell.createDots(config.Hot, true)
 	spell.createShields(config.Shield)

--- a/sim/monk/apl_values.go
+++ b/sim/monk/apl_values.go
@@ -2,7 +2,6 @@ package monk
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/wowsims/mop/sim/core"
 	"github.com/wowsims/mop/sim/core/proto"
@@ -14,8 +13,6 @@ func (monk *Monk) NewAPLValue(_ *core.APLRotation, config *proto.APLValue) core.
 		return monk.newValueCurrentChi(config.GetMonkCurrentChi(), config.Uuid)
 	case *proto.APLValue_MonkMaxChi:
 		return monk.newValueMaxChi(config.GetMonkMaxChi(), config.Uuid)
-	case *proto.APLValue_MonkNextChiBrewRecharge:
-		return monk.newValueNextChiBrewRecharge(config.GetMonkNextChiBrewRecharge(), config.Uuid)
 	default:
 		return nil
 	}
@@ -59,28 +56,4 @@ func (value *APLValueMaxChi) GetInt(_ *core.Simulation) int32 {
 }
 func (value *APLValueMaxChi) String() string {
 	return fmt.Sprintf("Max Chi(%d)", value.maxChi)
-}
-
-type APLValueNextChiBrewRecharge struct {
-	core.DefaultAPLValueImpl
-	monk *Monk
-}
-
-func (monk *Monk) newValueNextChiBrewRecharge(_ *proto.APLValueMonkNextChiBrewRecharge, _ *proto.UUID) core.APLValue {
-	return &APLValueNextChiBrewRecharge{
-		monk: monk,
-	}
-}
-func (value *APLValueNextChiBrewRecharge) Type() proto.APLValueType {
-	return proto.APLValueType_ValueTypeDuration
-}
-func (value *APLValueNextChiBrewRecharge) GetDuration(sim *core.Simulation) time.Duration {
-	if value.monk.chiBrewRecharge != nil && value.monk.chiBrewRecharge.NextActionAt > sim.CurrentTime {
-		return value.monk.chiBrewRecharge.NextActionAt - sim.CurrentTime
-	}
-
-	return 0
-}
-func (value *APLValueNextChiBrewRecharge) String() string {
-	return "Time To Next Chi Brew Recharge"
 }

--- a/sim/monk/monk.go
+++ b/sim/monk/monk.go
@@ -48,7 +48,6 @@ type Monk struct {
 	onStanceChanged OnStanceChanged
 	onChiSpent      OnChiSpent
 	onNewBrewStacks OnNewBrewStacks
-	chiBrewRecharge *core.PendingAction
 }
 
 func (monk *Monk) ChangeStance(sim *core.Simulation, newStance Stance) {

--- a/sim/monk/talents.go
+++ b/sim/monk/talents.go
@@ -572,14 +572,10 @@ func (monk *Monk) registerChiBrew() {
 			DefaultCast: core.Cast{
 				NonEmpty: true,
 			},
-			CD: core.Cooldown{
-				Duration: time.Second * 45,
-				Timer:    monk.NewTimer(),
-			},
 		},
 
-		Charges: 2,
-
+		Charges:      2,
+		RechargeTime: time.Second * 45,
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			// TODO: Add 5 Elusive Brew stacks for Brewmasters
 			// TODO: Add 2 Mana Tea stacks for Mistweavers

--- a/sim/monk/talents.go
+++ b/sim/monk/talents.go
@@ -563,57 +563,6 @@ func (monk *Monk) registerChiBrew() {
 
 	actionID := core.ActionID{SpellID: 115399}
 	chiMetrics := monk.NewChiMetrics(actionID)
-
-	chiBrewAura := monk.RegisterAura(core.Aura{
-		Label:     "Chi Brew" + monk.Label,
-		ActionID:  actionID,
-		Duration:  core.NeverExpires,
-		MaxStacks: 2,
-
-		OnReset: func(aura *core.Aura, sim *core.Simulation) {
-			if monk.chiBrewRecharge != nil {
-				monk.chiBrewRecharge.Cancel(sim)
-			}
-
-			aura.Activate(sim)
-			aura.SetStacks(sim, 2)
-		},
-
-		OnStacksChange: func(aura *core.Aura, sim *core.Simulation, oldStacks, newStacks int32) {
-			if !aura.IsActive() {
-				return
-			}
-
-			if newStacks < oldStacks {
-				nextRecharge := &core.PendingAction{
-					NextActionAt: sim.CurrentTime + time.Second*45,
-					OnAction: func(sim *core.Simulation) {
-						aura.Activate(sim)
-						aura.AddStack(sim)
-					},
-				}
-
-				if monk.chiBrewRecharge != nil {
-					// If we have an existing stack recharging, set this new one as current when it's done.
-					// This way we can always check next recharge time from the APL.
-					oldAction := monk.chiBrewRecharge.OnAction
-					monk.chiBrewRecharge.OnAction = func(sim *core.Simulation) {
-						monk.chiBrewRecharge = nextRecharge
-						oldAction(sim)
-					}
-				} else {
-					monk.chiBrewRecharge = nextRecharge
-				}
-
-				sim.AddPendingAction(nextRecharge)
-			} else if newStacks > oldStacks {
-				if newStacks == 2 || monk.chiBrewRecharge.IsConsumed() {
-					monk.chiBrewRecharge = nil
-				}
-			}
-		},
-	})
-
 	monk.RegisterSpell(core.SpellConfig{
 		ActionID:       actionID,
 		Flags:          core.SpellFlagNoOnCastComplete | core.SpellFlagAPL,
@@ -623,11 +572,13 @@ func (monk *Monk) registerChiBrew() {
 			DefaultCast: core.Cast{
 				NonEmpty: true,
 			},
+			CD: core.Cooldown{
+				Duration: time.Second * 45,
+				Timer:    monk.NewTimer(),
+			},
 		},
 
-		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
-			return chiBrewAura.GetStacks() >= 1
-		},
+		Charges: 2,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			// TODO: Add 5 Elusive Brew stacks for Brewmasters
@@ -635,8 +586,6 @@ func (monk *Monk) registerChiBrew() {
 
 			monk.AddChi(sim, spell, 2, chiMetrics)
 			monk.AddBrewStacks(sim, 2)
-
-			chiBrewAura.RemoveStack(sim)
 		},
 	})
 }

--- a/ui/core/components/individual_sim_ui/apl_values.ts
+++ b/ui/core/components/individual_sim_ui/apl_values.ts
@@ -65,7 +65,6 @@ import {
 	APLValueMin,
 	APLValueMonkCurrentChi,
 	APLValueMonkMaxChi,
-	APLValueMonkNextChiBrewRecharge,
 	APLValueNextRuneCooldown,
 	APLValueNot,
 	APLValueNumberTargets,
@@ -97,6 +96,8 @@ import {
 	APLValueUnitIsMoving,
 	APLValueWarlockShouldRecastDrainSoul,
 	APLValueWarlockShouldRefreshCorruption,
+	APLValueSpellNumCharges,
+	APLValueSpellTimeToCharge,
 } from '../../proto/apl.js';
 import { Class, Spec } from '../../proto/common.js';
 import { ShamanTotems_TotemType as TotemType } from '../../proto/shaman.js';
@@ -1044,6 +1045,20 @@ const valueKindFactories: { [f in NonNullable<APLValueKind>]: ValueKindConfig<AP
 		newValue: APLValueSpellChanneledTicks.create,
 		fields: [AplHelpers.actionIdFieldConfig('spellId', 'channel_spells', '')],
 	}),
+	spellNumCharges: inputBuilder({
+		label: 'Number of Charges',
+		submenu: ['Spell'],
+		shortDescription: 'The number of charges that are currently available for the spell.',
+		newValue: APLValueSpellNumCharges.create,
+		fields: [AplHelpers.actionIdFieldConfig('spellId', 'castable_spells', '')],
+	}),
+	spellTimeToCharge: inputBuilder({
+		label: 'Time to next Charge',
+		submenu: ['Spell'],
+		shortDescription: 'The time until the next charge is available. 0 if spell has all charges avaialable.',
+		newValue: APLValueSpellTimeToCharge.create,
+		fields: [AplHelpers.actionIdFieldConfig('spellId', 'castable_spells', '')],
+	}),
 	channelClipDelay: inputBuilder({
 		label: 'Channel Clip Delay',
 		submenu: ['Spell'],
@@ -1146,14 +1161,6 @@ const valueKindFactories: { [f in NonNullable<APLValueKind>]: ValueKindConfig<AP
 				labelTooltip: 'Maximum amount of time before the aura expires when it may be refreshed.',
 			}),
 		],
-	}),
-	monkNextChiBrewRecharge: inputBuilder({
-		label: 'Next Chi Brew Recharge',
-		submenu: ['Aura'],
-		shortDescription: 'Returns the amount of time until the next Chi Brew stack will be ready.',
-		newValue: APLValueMonkNextChiBrewRecharge.create,
-		includeIf: (player: Player<any>, _isPrepull: boolean) => player.getClass() == Class.ClassMonk,
-		fields: [],
 	}),
 
 	// Aura Sets

--- a/ui/monk/windwalker/apls/default.apl.json
+++ b/ui/monk/windwalker/apls/default.apl.json
@@ -37,60 +37,100 @@
 		},
 		{ "action": { "autocastOtherCooldowns": {} } },
 		{
-			"action": {
-				"condition": {
-					"and": {
-						"vals": [
-							{ "cmp": { "op": "OpLe", "lhs": { "monkCurrentChi": {} }, "rhs": { "const": { "val": "2" } } } },
-							{ "auraIsInactiveWithReactionTime": { "auraId": { "spellId": 101546 } } },
-							{ "auraIsInactiveWithReactionTime": { "auraId": { "spellId": 113656 } } },
-							{
-								"or": {
-									"vals": [
-										{
-											"and": {
-												"vals": [
-													{
-														"cmp": {
-															"op": "OpEq",
-															"lhs": { "auraNumStacks": { "auraId": { "spellId": 115399 } } },
-															"rhs": { "const": { "val": "1" } }
-														}
-													},
-													{ "cmp": { "op": "OpLe", "lhs": { "monkNextChiBrewRecharge": {} }, "rhs": { "const": { "val": "10s" } } } }
-												]
-											}
-										},
-										{
-											"cmp": {
-												"op": "OpEq",
-												"lhs": { "auraNumStacks": { "auraId": { "spellId": 115399 } } },
-												"rhs": { "const": { "val": "2" } }
-											}
-										},
-										{
-											"cmp": {
-												"op": "OpLt",
-												"lhs": { "remainingTime": {} },
-												"rhs": {
-													"math": {
-														"op": "OpMul",
-														"lhs": { "auraNumStacks": { "auraId": { "spellId": 115399 } } },
-														"rhs": { "const": { "val": "10" } }
-													}
-												}
-											}
-										},
-										{ "allTrinketStatProcsActive": { "statType1": 1, "statType2": -1, "statType3": -1 } }
-									]
-								}
-							}
-						]
-					}
-				},
-				"castSpell": { "spellId": { "spellId": 115399 } }
-			}
-		},
+    "action": {
+      "condition": {
+        "and": {
+          "vals": [
+            {
+              "cmp": {
+                "op": "OpLe",
+                "lhs": { "monkCurrentChi": {} },
+                "rhs": { "const": { "val": "2" } }
+              }
+            },
+            {
+              "auraIsInactiveWithReactionTime": {
+                "auraId": { "spellId": 101546 }
+              }
+            },
+            {
+              "auraIsInactiveWithReactionTime": {
+                "auraId": { "spellId": 113656 }
+              }
+            },
+            {
+              "or": {
+                "vals": [
+                  {
+                    "and": {
+                      "vals": [
+                        {
+                          "cmp": {
+                            "op": "OpEq",
+                            "lhs": {
+                              "spellNumCharges": {
+                                "spellId": { "spellId": 115399 }
+                              }
+                            },
+                            "rhs": { "const": { "val": "1" } }
+                          }
+                        },
+                        {
+                          "cmp": {
+                            "op": "OpLe",
+                            "lhs": {
+                              "spellTimeToCharge": {
+                                "spellId": { "spellId": 115399 }
+                              }
+                            },
+                            "rhs": { "const": { "val": "10s" } }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "cmp": {
+                      "op": "OpEq",
+                      "lhs": {
+                        "spellNumCharges": { "spellId": { "spellId": 115399 } }
+                      },
+                      "rhs": { "const": { "val": "2" } }
+                    }
+                  },
+                  {
+                    "cmp": {
+                      "op": "OpLt",
+                      "lhs": { "remainingTime": {} },
+                      "rhs": {
+                        "math": {
+                          "op": "OpMul",
+                          "lhs": {
+                            "spellNumCharges": {
+                              "spellId": { "spellId": 115399 }
+                            }
+                          },
+                          "rhs": { "const": { "val": "10" } }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "allTrinketStatProcsActive": {
+                      "statType1": 1,
+                      "statType2": -1,
+                      "statType3": -1
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "castSpell": { "spellId": { "spellId": 115399 } }
+    }
+  },
 		{
 			"action": {
 				"condition": {


### PR DESCRIPTION
Adds support for spells with Stacks.

* ~he cooldown of the spell is equal to the recharge time
* ~The actual CD is set to the remaining recharge duration upon reaching 0 charges~
* The max stacks are simply passed as a parameter of the spell config
* APL Support for 
  * Time until next charge
  * Current charges

## Update
* During the Warlock implementation I realized spells can have a cooldown and a different recharge time the implementation has been adjusted to reflect that
* If a `Charge` count `>0` is given now a `RechargeTime` must be passed
* Also a spell mod to modify the amount of charges a spell has was added talents like Double TIme from Warrior or Archimond's Darkness can modify the Stacks a spell has