### PR TITLE
Tank attack table fix

### DIFF
--- a/sim/core/TestProtoVersioning.results
+++ b/sim/core/TestProtoVersioning.results
@@ -1,1 +1,0 @@
-saved_version_number: 1

--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -618,7 +618,7 @@ func (character *Character) GetPseudoStatsProto() []float64 {
 		// Base values are modified by Enemy attackTables, but we display for LVL 80 enemy as paperdoll default
 		proto.PseudoStat_PseudoStatDodgePercent: (character.PseudoStats.BaseDodgeChance + character.GetDiminishedDodgeChance()) * 100,
 		proto.PseudoStat_PseudoStatParryPercent: (character.PseudoStats.BaseParryChance + character.GetDiminishedParryChance()) * 100,
-		proto.PseudoStat_PseudoStatBlockPercent: 5 + character.GetStat(stats.BlockPercent),
+		proto.PseudoStat_PseudoStatBlockPercent: (character.PseudoStats.BaseBlockChance + character.GetDiminishedBlockChance()) * 100,
 
 		// Used by UI to incorporate multiplicative Haste buffs into final character stats display.
 		proto.PseudoStat_PseudoStatRangedSpeedMultiplier: character.PseudoStats.RangedSpeedMultiplier,

--- a/sim/core/stats/stats.go
+++ b/sim/core/stats/stats.go
@@ -436,7 +436,7 @@ type PseudoStats struct {
 	// probabilities (between 0 and 1).
 	BaseDodgeChance float64
 	BaseParryChance float64
-	//BaseMiss is not needed, this is always 5%
+	BaseBlockChance float64
 
 	ReducedCritTakenChance float64 // Reduces chance to be crit.
 

--- a/sim/core/target.go
+++ b/sim/core/target.go
@@ -255,9 +255,9 @@ func NewAttackTable(attacker *Unit, defender *Unit) *AttackTable {
 	} else {
 		table.BaseSpellMissChance = UnitLevelFloat64(attacker.Level, 0.06, 0.03, 0, -0.03)
 		table.BaseMissChance = UnitLevelFloat64(attacker.Level, 0.03, 0.015, 0, -0.015)
-		table.BaseBlockChance = UnitLevelFloat64(attacker.Level, 0.03, 0.015, 0, -0.015)
-		table.BaseDodgeChance = UnitLevelFloat64(attacker.Level, 0.03, 0.015, 0, -0.015)
-		table.BaseParryChance = UnitLevelFloat64(attacker.Level, 0.03, 0.015, 0, -0.015)
+		table.BaseBlockChance = UnitLevelFloat64(attacker.Level, 0, -0.015, -0.03, -0.045)
+		table.BaseDodgeChance = UnitLevelFloat64(attacker.Level, 0, -0.015, -0.03, -0.045)
+		table.BaseParryChance = UnitLevelFloat64(attacker.Level, 0, -0.015, -0.03, -0.045)
 	}
 
 	return table

--- a/sim/core/unit.go
+++ b/sim/core/unit.go
@@ -721,7 +721,8 @@ func (unit *Unit) GetTotalChanceToBeMissedAsDefender(atkTable *AttackTable) floa
 }
 
 func (unit *Unit) GetTotalBlockChanceAsDefender(atkTable *AttackTable) float64 {
-	chance := atkTable.BaseBlockChance +
+	chance := unit.PseudoStats.BaseBlockChance +
+		atkTable.BaseBlockChance +
 		unit.GetDiminishedBlockChance()
 	return math.Max(chance, 0.0)
 }

--- a/sim/monk/brewmaster/TestBrewmaster.results
+++ b/sim/monk/brewmaster/TestBrewmaster.results
@@ -3086,10 +3086,10 @@ dps_results: {
 dps_results: {
  key: "TestBrewmaster-Average-Default"
  value: {
-  dps: 116510.47879
-  tps: 116510.47879
-  dtps: 46610.76715
-  hps: 12007.64212
+  dps: 116511.51533
+  tps: 116511.51533
+  dtps: 46625.34082
+  hps: 12006.42408
  }
 }
 dps_results: {

--- a/sim/monk/monk.go
+++ b/sim/monk/monk.go
@@ -232,6 +232,8 @@ func NewMonk(character *core.Character, options *proto.MonkOptions, talents stri
 	core.FillTalentsProto(monk.Talents.ProtoReflect(), talents)
 
 	monk.PseudoStats.CanParry = true
+	monk.PseudoStats.BaseParryChance += 0.03
+	monk.PseudoStats.BaseDodgeChance += 0.03
 	monk.XuenPet = monk.NewXuen()
 
 	monk.registerSEFPets()


### PR DESCRIPTION
Added BaseBlockChance PseudoStat to track undiminished sources, and fixed base attack table Dodge/Parry/Block values to be offset by the base player PseudoStat.

 On branch guardian
 Changes to be committed:
	deleted:    sim/core/TestProtoVersioning.results
	modified:   sim/core/character.go
	modified:   sim/core/stats/stats.go
	modified:   sim/core/target.go
	modified:   sim/core/unit.go
	modified:   sim/monk/brewmaster/TestBrewmaster.results
	modified:   sim/monk/monk.go