### PR TITLE
[Druid] Treant code refactor + fixes

### DIFF
--- a/sim/druid/druid.go
+++ b/sim/druid/druid.go
@@ -16,12 +16,14 @@ const (
 type Druid struct {
 	core.Character
 	SelfBuffs
-	// eclipseEnergyBar
+
 	Talents *proto.DruidTalents
 
 	ClassSpellScaling float64
 
 	StartingForm DruidForm
+
+	Treants TreantAgents
 
 	EclipseEnergyMap EclipseEnergyMap
 
@@ -38,6 +40,7 @@ type Druid struct {
 	CatCharge             *DruidSpell
 	FaerieFire            *DruidSpell
 	FerociousBite         *DruidSpell
+	ForceOfNature         *DruidSpell
 	FrenziedRegeneration  *DruidSpell
 	Hurricane             *DruidSpell
 	HurricaneTickSpell    *DruidSpell
@@ -203,10 +206,6 @@ func (druid *Druid) HasMajorGlyph(glyph proto.DruidMajorGlyph) bool {
 func (druid *Druid) HasMinorGlyph(glyph proto.DruidMinorGlyph) bool {
 	return druid.HasGlyph(int32(glyph))
 }
-
-// func (druid *Druid) TryMaul(sim *core.Simulation, mhSwingSpell *core.Spell) *core.Spell {
-// 	return druid.MaulReplaceMH(sim, mhSwingSpell)
-// }
 
 func (druid *Druid) RegisterSpell(formMask DruidForm, config core.SpellConfig) *DruidSpell {
 	prev := config.ExtraCastCondition

--- a/sim/druid/guardian/TestGuardian.results
+++ b/sim/druid/guardian/TestGuardian.results
@@ -3390,55 +3390,55 @@ dps_results: {
 dps_results: {
  key: "TestGuardian-Settings-Worgen-preraid-FoN-Default-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.70100365765e+06
-  tps: 1.178264459612e+07
-  dtps: 1.13577646771e+06
-  hps: 78574.88573
+  dps: 1.70164804656e+06
+  tps: 1.178328295756e+07
+  dtps: 1.13742376865e+06
+  hps: 78983.63605
  }
 }
 dps_results: {
  key: "TestGuardian-Settings-Worgen-preraid-FoN-Default-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 91426.16957
-  tps: 617395.41195
-  dtps: 57330.71362
-  hps: 21669.89388
+  dps: 91778.87435
+  tps: 617807.02977
+  dtps: 57293.12398
+  hps: 21720.59426
  }
 }
 dps_results: {
  key: "TestGuardian-Settings-Worgen-preraid-FoN-Default-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 89412.13648
-  tps: 570158.48973
-  dtps: 53522.66424
-  hps: 19049.61027
+  dps: 90300.6979
+  tps: 572519.43678
+  dtps: 53953.55743
+  hps: 18497.18447
  }
 }
 dps_results: {
  key: "TestGuardian-Settings-Worgen-preraid-FoN-Default-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.27146562881e+06
-  tps: 8.85283064582e+06
-  dtps: 1.21922221756e+06
-  hps: 48510.91188
+  dps: 1.27097052566e+06
+  tps: 8.85066559861e+06
+  dtps: 1.21534395413e+06
+  hps: 49112.2959
  }
 }
 dps_results: {
  key: "TestGuardian-Settings-Worgen-preraid-FoN-Default-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 75206.97063
-  tps: 513040.68719
-  dtps: 61176.53653
-  hps: 14837.44657
+  dps: 75326.14628
+  tps: 514370.15219
+  dtps: 61409.09172
+  hps: 15309.99908
  }
 }
 dps_results: {
  key: "TestGuardian-Settings-Worgen-preraid-FoN-Default-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 65942.00928
-  tps: 444822.42972
-  dtps: 61062.25755
-  hps: 11970.3636
+  dps: 65967.73844
+  tps: 445707.47466
+  dtps: 60950.73045
+  hps: 12243.47534
  }
 }
 dps_results: {

--- a/sim/druid/guardian/TestGuardian.results
+++ b/sim/druid/guardian/TestGuardian.results
@@ -3390,55 +3390,55 @@ dps_results: {
 dps_results: {
  key: "TestGuardian-Settings-Worgen-preraid-FoN-Default-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.71394186164e+06
-  tps: 1.177877011552e+07
-  dtps: 1.13221917487e+06
-  hps: 81406.33685
+  dps: 1.70100365765e+06
+  tps: 1.178264459612e+07
+  dtps: 1.13577646771e+06
+  hps: 78574.88573
  }
 }
 dps_results: {
  key: "TestGuardian-Settings-Worgen-preraid-FoN-Default-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 94912.57772
-  tps: 616453.33835
-  dtps: 56567.5628
-  hps: 21506.06543
+  dps: 91426.16957
+  tps: 617395.41195
+  dtps: 57330.71362
+  hps: 21669.89388
  }
 }
 dps_results: {
  key: "TestGuardian-Settings-Worgen-preraid-FoN-Default-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 92348.49842
-  tps: 569421.6127
-  dtps: 53965.06729
-  hps: 19262.62178
+  dps: 89412.13648
+  tps: 570158.48973
+  dtps: 53522.66424
+  hps: 19049.61027
  }
 }
 dps_results: {
  key: "TestGuardian-Settings-Worgen-preraid-FoN-Default-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.28213425729e+06
-  tps: 8.85704521015e+06
-  dtps: 1.21919407752e+06
-  hps: 48876.14166
+  dps: 1.27146562881e+06
+  tps: 8.85283064582e+06
+  dtps: 1.21922221756e+06
+  hps: 48510.91188
  }
 }
 dps_results: {
  key: "TestGuardian-Settings-Worgen-preraid-FoN-Default-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 78605.71338
-  tps: 515591.74559
-  dtps: 61577.03386
-  hps: 15541.78144
+  dps: 75206.97063
+  tps: 513040.68719
+  dtps: 61176.53653
+  hps: 14837.44657
  }
 }
 dps_results: {
  key: "TestGuardian-Settings-Worgen-preraid-FoN-Default-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 68369.94858
-  tps: 446120.97768
-  dtps: 61959.14559
-  hps: 12520.0972
+  dps: 65942.00928
+  tps: 444822.42972
+  dtps: 61062.25755
+  hps: 11970.3636
  }
 }
 dps_results: {

--- a/sim/druid/guardian/talents.go
+++ b/sim/druid/guardian/talents.go
@@ -77,30 +77,3 @@ func (bear *GuardianDruid) registerIncarnation() {
 		},
 	})
 }
-
-func (bear *GuardianDruid) registerForceOfNature() {
-	if !bear.Talents.ForceOfNature {
-		return
-	}
-
-	bear.ForceOfNature = bear.RegisterSpell(druid.Any, core.SpellConfig{
-		ActionID: core.ActionID{SpellID: 102706},
-		Flags:    core.SpellFlagAPL,
-
-		Cast: core.CastConfig{
-			CD: core.Cooldown{
-				Timer:    bear.NewTimer(),
-				Duration: time.Second * 20,
-			},
-		},
-
-		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, _ *core.Spell) {
-			bear.Treants.Enable(sim)
-		},
-	})
-
-	bear.AddMajorCooldown(core.MajorCooldown{
-		Spell: bear.ForceOfNature.Spell,
-		Type:  core.CooldownTypeDPS,
-	})
-}

--- a/sim/druid/guardian/tank.go
+++ b/sim/druid/guardian/tank.go
@@ -55,8 +55,6 @@ type GuardianDruid struct {
 
 	Options *proto.GuardianDruid_Options
 
-	Treants GuardianTreants
-
 	// Aura references
 	EnrageAura          *core.Aura
 	SavageDefenseAura   *core.Aura
@@ -66,7 +64,6 @@ type GuardianDruid struct {
 
 	// Spell references
 	Enrage        *druid.DruidSpell
-	ForceOfNature *druid.DruidSpell
 	SavageDefense *druid.DruidSpell
 	SonOfUrsoc    *druid.DruidSpell
 }
@@ -86,7 +83,6 @@ func (bear *GuardianDruid) ApplyTalents() {
 	bear.applyLeatherSpecialization()
 	bear.RegisterVengeance(84840, bear.BearFormAura)
 	bear.registerIncarnation()
-	bear.registerForceOfNature()
 }
 
 func (bear *GuardianDruid) applyMastery() {

--- a/sim/druid/talents.go
+++ b/sim/druid/talents.go
@@ -174,20 +174,13 @@ func (druid *Druid) registerForceOfNature() {
 	}
 
 	druid.ForceOfNature = druid.RegisterSpell(Any, core.SpellConfig{
-		ActionID: core.ActionID{SpellID: 106737},
-		Flags:    core.SpellFlagAPL,
+		ActionID:     core.ActionID{SpellID: 106737},
+		Flags:        core.SpellFlagAPL,
+		Charges:      3,
+		RechargeTime: time.Second * 20,
 
-		Cast: core.CastConfig{
-			CD: core.Cooldown{
-				Timer:    druid.NewTimer(),
-				Duration: time.Second * 20,
-			},
-		},
-
-		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, _ *core.Spell) {
-			for _, treant := range druid.Treants {
-				treant.Enable(sim)
-			}
+		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, spell *core.Spell) {
+			druid.Treants[spell.GetNumCharges()].Enable(sim)
 		},
 	})
 

--- a/sim/druid/talents.go
+++ b/sim/druid/talents.go
@@ -10,6 +10,8 @@ func (druid *Druid) ApplyTalents() {
 	druid.registerYserasGift()
 	druid.registerRenewal()
 	druid.registerCenarionWard()
+
+	druid.registerForceOfNature()
 }
 
 func (druid *Druid) registerYserasGift() {
@@ -163,5 +165,34 @@ func (druid *Druid) registerCenarionWard() {
 			spSnapshot = cenarionWardHot.HealingPower(target)
 			cenarionWardBuffs.Get(target).Activate(sim)
 		},
+	})
+}
+
+func (druid *Druid) registerForceOfNature() {
+	if !druid.Talents.ForceOfNature {
+		return
+	}
+
+	druid.ForceOfNature = druid.RegisterSpell(Any, core.SpellConfig{
+		ActionID: core.ActionID{SpellID: 106737},
+		Flags:    core.SpellFlagAPL,
+
+		Cast: core.CastConfig{
+			CD: core.Cooldown{
+				Timer:    druid.NewTimer(),
+				Duration: time.Second * 20,
+			},
+		},
+
+		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, _ *core.Spell) {
+			for _, treant := range druid.Treants {
+				treant.Enable(sim)
+			}
+		},
+	})
+
+	druid.AddMajorCooldown(core.MajorCooldown{
+		Spell: druid.ForceOfNature.Spell,
+		Type:  core.CooldownTypeDPS,
 	})
 }

--- a/sim/druid/treants.go
+++ b/sim/druid/treants.go
@@ -71,7 +71,16 @@ func (druid *Druid) NewDefaultTreant(config TreantConfig) *DefaultTreantImpl {
 	})
 
 	treant.OnPetEnable = func(sim *core.Simulation) {
-		treant.AutoAttacks.PauseMeleeBy(sim, 500 * time.Millisecond)
+		// Treant spawns in front of boss but moves behind after first swing.
+		treant.PseudoStats.InFrontOfTarget = true
+
+		sim.AddPendingAction(&core.PendingAction{
+			NextActionAt: sim.CurrentTime + time.Millisecond * 500,
+
+			OnAction: func(_ *core.Simulation) {
+				treant.PseudoStats.InFrontOfTarget = false
+			},
+		})
 	}
 
 	return treant

--- a/sim/druid/treants.go
+++ b/sim/druid/treants.go
@@ -1,0 +1,80 @@
+package druid
+
+import (
+	"time"
+
+	"github.com/wowsims/mop/sim/core"
+)
+
+// Extension of PetAgent interface, for treants.
+type TreantAgent interface {
+	core.PetAgent
+
+	Enable(sim *core.Simulation)
+}
+
+// Embed this in spec-specific treant structs.
+type DefaultTreantImpl struct {
+	core.Pet
+}
+
+// Overwrite these for spec variants that register spells.
+func (treant *DefaultTreantImpl) Initialize() {}
+func (treant *DefaultTreantImpl) ExecuteCustomRotation(_ *core.Simulation) {}
+
+func (treant *DefaultTreantImpl) Reset(sim *core.Simulation) {
+	treant.Disable(sim)
+}
+
+func (treant *DefaultTreantImpl) GetPet() *core.Pet {
+	return &treant.Pet
+}
+
+func (treant *DefaultTreantImpl) Enable(sim *core.Simulation) {
+	treant.EnableWithTimeout(sim, treant, time.Second * 15)
+}
+
+type TreantConfig struct {
+	StatInheritance         core.PetStatInheritance
+	EnableAutos             bool
+	WeaponDamageCoefficient float64
+}
+
+func (druid *Druid) NewDefaultTreant(config TreantConfig) *DefaultTreantImpl {
+	treant := &DefaultTreantImpl{
+		Pet: core.NewPet(core.PetConfig{
+			Name:                            "Treant",
+			Owner:                           &druid.Character,
+			StatInheritance:                 config.StatInheritance,
+			HasDynamicMeleeSpeedInheritance: true,
+			HasDynamicCastSpeedInheritance:  true,
+		}),
+	}
+
+	if !config.EnableAutos {
+		return treant
+	}
+
+	baseWeaponDamage := config.WeaponDamageCoefficient * druid.ClassSpellScaling
+
+	treant.EnableAutoAttacks(treant, core.AutoAttackOptions{
+		MainHand: core.Weapon{
+			BaseDamageMin:        baseWeaponDamage,
+			BaseDamageMax:        baseWeaponDamage,
+			SwingSpeed:           2,
+			NormalizedSwingSpeed: 2,
+			CritMultiplier:       druid.DefaultCritMultiplier(),
+			SpellSchool:          core.SpellSchoolPhysical,
+		},
+
+		AutoSwingMelee: true,
+	})
+
+	treant.OnPetEnable = func(sim *core.Simulation) {
+		treant.AutoAttacks.PauseMeleeBy(sim, 500 * time.Millisecond)
+	}
+
+	return treant
+}
+
+type TreantAgents [3]TreantAgent


### PR DESCRIPTION
- Refactored Treant code to use a shared class-level interface.
- Fixed Force of Nature to use spell charges system with only one Treant regenerated every 20s rather than all three.
- Toggle `InFrontOfTarget` so that only the first Treant auto-attack can get parried.