### PR TITLE
[Pala] Move HP spenders to their respective spec

### DIFF
--- a/sim/paladin/cata_items.go
+++ b/sim/paladin/cata_items.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/wowsims/mop/sim/common/cata"
 	"github.com/wowsims/mop/sim/core"
+	"github.com/wowsims/mop/sim/core/proto"
 	"github.com/wowsims/mop/sim/core/stats"
 )
 
@@ -146,6 +147,9 @@ var ItemSetBattlearmorOfImmolation = core.NewItemSet(core.ItemSet{
 		// Your Shield of the Righteous deals 20% additional damage as Fire damage.
 		2: func(agent core.Agent, setBonusAura *core.Aura) {
 			paladin := agent.(PaladinAgent).GetPaladin()
+			if paladin.Spec != proto.Spec_SpecProtectionPaladin {
+				return
+			}
 
 			procDamage := 0.0
 
@@ -231,6 +235,10 @@ var ItemSetBattleplateOfRadiantGlory = core.NewItemSet(core.ItemSet{
 		},
 		// Increases damage done by your Templar's Verdict by 20%.
 		4: func(agent core.Agent, setBonusAura *core.Aura) {
+			if agent.GetCharacter().Spec != proto.Spec_SpecRetributionPaladin {
+				return
+			}
+
 			setBonusAura.AttachSpellMod(core.SpellModConfig{
 				Kind:       core.SpellMod_DamageDone_Pct,
 				ClassMask:  SpellMaskTemplarsVerdict,

--- a/sim/paladin/glyphs.go
+++ b/sim/paladin/glyphs.go
@@ -620,6 +620,10 @@ func (paladin *Paladin) registerGlyphOfProtectorOfTheInnocent() {
 
 // You take 10% less damage for 6 sec after dealing damage with Templar's Verdict or Exorcism.
 func (paladin *Paladin) registerGlyphOfTemplarsVerdict() {
+	if paladin.Spec != proto.Spec_SpecRetributionPaladin {
+		return
+	}
+
 	glyphOfTemplarVerdictAura := paladin.RegisterAura(core.Aura{
 		Label:    "Glyph of Templar's Verdict" + paladin.Label,
 		ActionID: core.ActionID{SpellID: 115668},
@@ -640,6 +644,10 @@ func (paladin *Paladin) registerGlyphOfTemplarsVerdict() {
 
 // Your successful blocks increase the damage of your next Shield of the Righteous by 10%. Stacks up to 3 times.
 func (paladin *Paladin) registerGlyphOfTheAlabasterShield() {
+	if paladin.Spec != proto.Spec_SpecProtectionPaladin {
+		return
+	}
+
 	spellMod := paladin.AddDynamicMod(core.SpellModConfig{
 		Kind:       core.SpellMod_DamageDone_Pct,
 		ClassMask:  SpellMaskShieldOfTheRighteous,

--- a/sim/paladin/items.go
+++ b/sim/paladin/items.go
@@ -56,6 +56,10 @@ var ItemSetWhiteTigerBattlegear = core.NewItemSet(core.ItemSet{
 	Bonuses: map[int32]core.ApplySetBonus{
 		// Increases the damage done by your Templar's Verdict ability by 15%.
 		2: func(agent core.Agent, setBonusAura *core.Aura) {
+			if agent.GetCharacter().Spec != proto.Spec_SpecRetributionPaladin {
+				return
+			}
+
 			setBonusAura.AttachSpellMod(core.SpellModConfig{
 				Kind:       core.SpellMod_DamageDone_Pct,
 				ClassMask:  SpellMaskTemplarsVerdict,
@@ -201,6 +205,9 @@ var ItemSetBattlegearOfTheLightningEmperor = core.NewItemSet(core.ItemSet{
 		// Your Crusader Strike has a 40% chance to make your next Templar's Verdict deal all Holy damage.
 		4: func(agent core.Agent, setBonusAura *core.Aura) {
 			paladin := agent.(PaladinAgent).GetPaladin()
+			if paladin.Spec != proto.Spec_SpecRetributionPaladin {
+				return
+			}
 
 			templarsVerdictAura := paladin.RegisterAura(core.Aura{
 				Label:    "Templar's Verdict" + paladin.Label,
@@ -425,6 +432,9 @@ var ItemSetPlateOfWingedTriumph = core.NewItemSet(core.ItemSet{
 		// While at 3 or more stacks of Bastion of Glory, your next [Eternal Flame / Word of Glory] will consume no Holy Power and count as if 3 Holy Power were consumed.
 		4: func(agent core.Agent, setBonusAura *core.Aura) {
 			paladin := agent.(PaladinAgent).GetPaladin()
+			if paladin.Spec != proto.Spec_SpecProtectionPaladin {
+				return
+			}
 
 			paladin.BastionOfPowerAura = paladin.RegisterAura(core.Aura{
 				Label:    "Bastion of Power" + paladin.Label,

--- a/sim/paladin/paladin.go
+++ b/sim/paladin/paladin.go
@@ -121,8 +121,6 @@ func (paladin *Paladin) registerSpells() {
 	paladin.registerSealOfInsight()
 	paladin.registerSealOfRighteousness()
 	paladin.registerSealOfTruth()
-	paladin.registerShieldOfTheRighteous()
-	paladin.registerTemplarsVerdict()
 	paladin.registerWordOfGlory()
 }
 

--- a/sim/paladin/protection/protection.go
+++ b/sim/paladin/protection/protection.go
@@ -61,6 +61,7 @@ func (prot *ProtectionPaladin) Initialize() {
 	prot.registerJudgmentsOfTheWise()
 	prot.registerRighteousFury()
 	prot.registerSanctuary()
+	prot.registerShieldOfTheRighteous()
 
 	// Vengeance
 	prot.RegisterVengeance(84839, nil)

--- a/sim/paladin/retribution/retribution.go
+++ b/sim/paladin/retribution/retribution.go
@@ -58,6 +58,7 @@ func (ret *RetributionPaladin) Initialize() {
 	ret.registerJudgmentsOfTheBold()
 	ret.registerSealOfJustice()
 	ret.registerSwordOfLight()
+	ret.registerTemplarsVerdict()
 }
 
 func (ret *RetributionPaladin) ApplyTalents() {

--- a/sim/paladin/retribution/templars_verdict.go
+++ b/sim/paladin/retribution/templars_verdict.go
@@ -1,19 +1,20 @@
-package paladin
+package retribution
 
 import (
 	"github.com/wowsims/mop/sim/core"
+	"github.com/wowsims/mop/sim/paladin"
 )
 
 // A powerful weapon strike that consumes 3 charges of Holy Power to deal 275% weapon damage plus 628.
-func (paladin *Paladin) registerTemplarsVerdict() {
+func (ret *RetributionPaladin) registerTemplarsVerdict() {
 	actionID := core.ActionID{SpellID: 85256}
 
-	paladin.RegisterSpell(core.SpellConfig{
+	ret.RegisterSpell(core.SpellConfig{
 		ActionID:       actionID,
 		SpellSchool:    core.SpellSchoolPhysical,
 		ProcMask:       core.ProcMaskMeleeMHSpecial,
 		Flags:          core.SpellFlagMeleeMetrics | core.SpellFlagAPL,
-		ClassSpellMask: SpellMaskTemplarsVerdict,
+		ClassSpellMask: paladin.SpellMaskTemplarsVerdict,
 
 		Cast: core.CastConfig{
 			DefaultCast: core.Cast{
@@ -22,26 +23,26 @@ func (paladin *Paladin) registerTemplarsVerdict() {
 			IgnoreHaste: true,
 		},
 		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
-			return paladin.HolyPower.CanSpend(3)
+			return ret.HolyPower.CanSpend(3)
 		},
 
 		DamageMultiplier: 2.75,
-		CritMultiplier:   paladin.DefaultCritMultiplier(),
+		CritMultiplier:   ret.DefaultCritMultiplier(),
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			if paladin.T15Ret4pc.IsActive() {
-				paladin.T15Ret4pcTemplarsVerdict.Cast(sim, target)
+			if ret.T15Ret4pc.IsActive() {
+				ret.T15Ret4pcTemplarsVerdict.Cast(sim, target)
 				spell.SpellMetrics[target.UnitIndex].Casts--
 				return
 			}
 
-			baseDamage := paladin.MHNormalizedWeaponDamage(sim, spell.MeleeAttackPower()) + paladin.CalcScalingSpellDmg(0.55000001192)
+			baseDamage := ret.MHNormalizedWeaponDamage(sim, spell.MeleeAttackPower()) + ret.CalcScalingSpellDmg(0.55000001192)
 
 			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeMeleeSpecialHitAndCrit)
 
 			if result.Landed() {
-				paladin.HolyPower.Spend(sim, 3, actionID)
+				ret.HolyPower.Spend(sim, 3, actionID)
 			}
 
 			spell.DealDamage(sim, result)


### PR DESCRIPTION
Forgot to make these spec-specific like they are ingame, bloated the results and APL pickers