### PR TITLE
[Core] Mark Pending Action as consumed before sim advance

### DIFF
--- a/sim/core/sim.go
+++ b/sim/core/sim.go
@@ -513,10 +513,11 @@ func (sim *Simulation) Step() bool {
 		return true
 	}
 
+	pa.consumed = true
+
 	if pa.NextActionAt > sim.CurrentTime {
 		sim.advance(pa.NextActionAt)
 	}
-	pa.consumed = true
 
 	if pa.cancelled {
 		return false


### PR DESCRIPTION
While this change does not seem to have an immediate effect on the already implemented specs, this solves an edge case we faced in the mage branch.

Right now the `PendingAction` is marked as `consumed` after the `sim.advance` call. This can lead to issues.
If the pending action advancing the sim time is the `rotationAction` and the advancement of the `AuraHolder` is expiring a channeled spell (which we have plenty with Arcane Missles), then we trigger the following code path

```go
	if dot.isChanneled {
		// Note: even if the clip delay is 0ms, need a WaitUntil so that APL is called after the channel aura fades.
		if dot.remainingTicks == 0 && dot.Spell.Unit.GCD.IsReady(sim) {
			dot.Spell.Unit.WaitUntil(sim, sim.CurrentTime+dot.Spell.Unit.ChannelClipDelay)
```

This will cancel a non existing action in the list and add the reference of the PA into the pending actions again.

```go
func (unit *Unit) SetRotationTimer(sim *Simulation, rotationReadyAt time.Duration) {
	if unit.rotationAction == nil {
		return
	}

	unit.RotationTimer.Set(rotationReadyAt)

	if !unit.rotationAction.consumed {
		unit.rotationAction.Cancel(sim)
	}

	unit.rotationAction.cancelled = false
	unit.rotationAction.NextActionAt = rotationReadyAt
	sim.AddPendingAction(unit.rotationAction)
}
```

After we return from the `advance` call, the `rotationAction` is marked as `consumed` indicating it's no longer part of the PendingAction list, which it actually is. This causes a call to `SetRotationTimer` within the `OnAction` call path to not cancel it as it's already marked as consumed and we add a second instance.

This leads to all kinds of problems, as we always expect the last element to be the next element. As we directly modify the NextActionAt of an element within the `PendingAction` list however, the sim will jump to unintended timestamps. This causes the mage sim to sometimes skip DoT ticks.