### PR TITLE
Deploy to Cloudflare Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ on:
     push:
         branches:
             - master
+    workflow_dispatch:
 jobs:
     build-and-deploy:
         runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,7 +64,7 @@ jobs:
                   repository-name: wowsims/pages-deploy
                   branch: main
                   folder: dist/mop
-                  destination_dir: mop
+                  target-folder: mop
                   single-commit: true
                   token: ${{ secrets.DEPLOY_REPO_TOKEN }}
                   clean: false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ on:
     push:
         branches:
             - master
+            - cloudflaretest
     workflow_dispatch:
 jobs:
     build-and-deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,7 +61,7 @@ jobs:
                   make test
 
             - name: Deploy 🚀
-              uses: JamesIves/github-pages-deploy-action@4.7.3
+              uses: JamesIves/github-pages-deploy-action@v4
               with:
                   repository-name: wowsims/pages-deploy
                   branch: main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,8 @@ jobs:
 
             - name: Checkout 🛎️
               uses: actions/checkout@v2.3.1
+              with:
+                  persist-credentials: false
 
             - name: Build 🔧
               run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,7 +61,7 @@ jobs:
                   make test
 
             - name: Deploy 🚀
-              uses: JamesIves/github-pages-deploy-action@4.1.5
+              uses: JamesIves/github-pages-deploy-action@4.7.3
               with:
                   repository-name: wowsims/pages-deploy
                   branch: main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,10 @@ jobs:
             - name: Deploy 🚀
               uses: JamesIves/github-pages-deploy-action@4.1.5
               with:
-                  branch: gh-pages
+                  repository-name: wowsims/pages-deploy
+                  branch: main
                   folder: dist/mop
+                  destination_dir: mop
                   single-commit: true
+                  token: ${{ secrets.DEPLOY_REPO_TOKEN }}
+                  clean: false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,6 @@ on:
     push:
         branches:
             - master
-            - cloudflaretest
-    workflow_dispatch:
 jobs:
     build-and-deploy:
         runs-on: ubuntu-latest


### PR DESCRIPTION
To achieve this, we deploy to a second repository `wowsims/pages-deploy` under a folder `mop`.

Other sims or things we want on these pages would simply follow the same standard but push to different branches.