### PR TITLE
[Hunter] Thrill of the Hunt (-20 Focus cost)

### DIFF
--- a/sim/hunter/talents.go
+++ b/sim/hunter/talents.go
@@ -15,9 +15,9 @@ func (hunter *Hunter) applyThrillOfTheHunt() {
 	procChance := 0.30
 
 	tothMod := hunter.AddDynamicMod(core.SpellModConfig{
-		Kind:       core.SpellMod_PowerCost_Pct,
+		Kind:       core.SpellMod_PowerCost_Flat,
 		ClassMask:  HunterSpellMultiShot | HunterSpellArcaneShot,
-		FloatValue: -0.5,
+		FloatValue: -20,
 	})
 
 	tothAura := hunter.RegisterAura(core.Aura{


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1951e230-e9cb-4d02-a6ef-16c1e117cc59)
Was incorrect for Arcane shot.
Multishot was technically correct `40 -> 20`, but arcane was `30 -> 15` instead of `30 -> 10`.