### PR TITLE
[Prot][Blood] Riposte and other passive fixes

### DIFF
--- a/sim/death_knight/blood/TestBlood.results
+++ b/sim/death_knight/blood/TestBlood.results
@@ -10,7 +10,7 @@ character_stats_results: {
   final_stats: 552
   final_stats: 512
   final_stats: 2555
-  final_stats: 2804
+  final_stats: 2804.00009
   final_stats: 14140.63264
   final_stats: 15919
   final_stats: 27865.64
@@ -627,8 +627,8 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-Xing-Ho,BreathofYu'lon-102246"
  value: {
-  dps: 122087.19903
-  tps: 738875.42995
+  dps: 122094.08747
+  tps: 738923.64908
   dtps: 96775.37067
   hps: 90138.08345
  }

--- a/sim/death_knight/blood/riposte.go
+++ b/sim/death_knight/blood/riposte.go
@@ -1,36 +1,9 @@
 package blood
 
 import (
-	"math"
-	"time"
-
-	"github.com/wowsims/mop/sim/core"
-	"github.com/wowsims/mop/sim/core/stats"
+	"github.com/wowsims/mop/sim/common/shared"
 )
 
 func (bdk *BloodDeathKnight) registerRiposte() {
-	riposteAura := bdk.RegisterAura(core.Aura{
-		Label:     "Riposte" + bdk.Label,
-		ActionID:  core.ActionID{SpellID: 145677},
-		Duration:  time.Second * 20,
-		MaxStacks: math.MaxInt32,
-
-		OnStacksChange: func(aura *core.Aura, sim *core.Simulation, oldStacks, newStacks int32) {
-			bdk.AddStatDynamic(sim, stats.CritRating, float64(newStacks-oldStacks))
-		},
-	})
-
-	core.MakeProcTriggerAura(&bdk.Unit, core.ProcTrigger{
-		Name:     "Riposte Trigger" + bdk.Label,
-		ActionID: core.ActionID{SpellID: 145676},
-		Callback: core.CallbackOnSpellHitTaken,
-		Outcome:  core.OutcomeDodge | core.OutcomeParry,
-		ICD:      time.Second * 1,
-
-		Handler: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-			bonusCrit := math.Round((bdk.GetStat(stats.DodgeRating) + bdk.GetParryRatingWithoutStrength()) * 0.75)
-			riposteAura.Activate(sim)
-			riposteAura.SetStacks(sim, int32(bonusCrit))
-		},
-	})
+	shared.RegisterRiposteEffect(&bdk.Character, 145677, 145676)
 }

--- a/sim/death_knight/death_knight.go
+++ b/sim/death_knight/death_knight.go
@@ -178,6 +178,7 @@ func NewDeathKnight(character *core.Character, inputs DeathKnightInputs, talents
 
 	dk.AddStat(stats.ParryRating, -dk.GetBaseStats()[stats.Strength]*core.StrengthToParryRating) // Does not apply to base Strength
 	dk.AddStatDependency(stats.Strength, stats.ParryRating, core.StrengthToParryRating)
+	dk.AddStatDependency(stats.Agility, stats.DodgeRating, 0.1/10000.0/100.0)
 
 	dk.AddStatDependency(stats.BonusArmor, stats.Armor, 1)
 

--- a/sim/death_knight/frost/TestFrostMasterfrost.results
+++ b/sim/death_knight/frost/TestFrostMasterfrost.results
@@ -10,7 +10,7 @@ character_stats_results: {
   final_stats: 2468
   final_stats: 4546
   final_stats: 2568
-  final_stats: 0
+  final_stats: 2e-05
   final_stats: 17733.98734
   final_stats: 12547
   final_stats: 42672.74

--- a/sim/death_knight/frost/TestFrostTwoHand.results
+++ b/sim/death_knight/frost/TestFrostTwoHand.results
@@ -10,7 +10,7 @@ character_stats_results: {
   final_stats: 7568
   final_stats: 6719
   final_stats: 2574
-  final_stats: 0
+  final_stats: 2e-05
   final_stats: 17935.04703
   final_stats: 6163
   final_stats: 43148.138

--- a/sim/death_knight/unholy/TestUnholy.results
+++ b/sim/death_knight/unholy/TestUnholy.results
@@ -10,7 +10,7 @@ character_stats_results: {
   final_stats: 7218
   final_stats: 4853
   final_stats: 2565
-  final_stats: 0
+  final_stats: 2e-05
   final_stats: 25355.99596
   final_stats: 6163
   final_stats: 60694.6901

--- a/sim/paladin/paladin.go
+++ b/sim/paladin/paladin.go
@@ -164,6 +164,7 @@ func NewPaladin(character *core.Character, talentsStr string, options *proto.Pal
 
 	paladin.AddStat(stats.ParryRating, -paladin.GetBaseStats()[stats.Strength]*core.StrengthToParryRating) // Does not apply to base Strength
 	paladin.AddStatDependency(stats.Strength, stats.ParryRating, core.StrengthToParryRating)
+	paladin.AddStatDependency(stats.Agility, stats.DodgeRating, 0.1/10000.0/100.0)
 
 	paladin.PseudoStats.BaseBlockChance += 0.03
 	paladin.PseudoStats.BaseDodgeChance += 0.03

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -10,7 +10,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 7725
   final_stats: 5117
-  final_stats: 1971
+  final_stats: 1971.00001
   final_stats: 15314.43125
   final_stats: 6286
   final_stats: 32943.02

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -10,7 +10,7 @@ character_stats_results: {
   final_stats: 3058
   final_stats: 9282
   final_stats: 2550
-  final_stats: 0
+  final_stats: 2e-05
   final_stats: 18177.71385
   final_stats: 7329
   final_stats: 43640.5145

--- a/sim/warrior/protection/protection.go
+++ b/sim/warrior/protection/protection.go
@@ -77,6 +77,7 @@ func (war *ProtectionWarrior) registerPassives() {
 	war.registerUnwaveringSentinel()
 	war.registerBastionOfDefense()
 	war.registerSwordAndBoard()
+	war.registerUltimatum()
 	war.registerRiposte()
 
 	// Vengeance


### PR DESCRIPTION
Moved Riposte to shared helper since the Prot Warrior and Blood DK ones are identical in behavior (also, the Prot one was just not even really implemented).
Fixed armor scaling of Unwavering Sentinel
Fixed Ultimatum consume-trigger and cost reduction mod
Added a tiny agi->dodge conversion for Blood DKs and Prot Palas
