### PR TITLE
[Prot] Fix interaction between Ultimatum and Glyph of Incite and remove Shield Slam cost

### DIFF
--- a/sim/warrior/protection/passives.go
+++ b/sim/warrior/protection/passives.go
@@ -66,31 +66,34 @@ func (war *ProtectionWarrior) registerSwordAndBoard() {
 }
 
 func (war *ProtectionWarrior) registerUltimatum() {
-	aura := war.GetOrRegisterAura(core.Aura{
+	war.UltimatumAura = war.GetOrRegisterAura(core.Aura{
 		Label:    "Ultimatum",
 		ActionID: core.ActionID{SpellID: 122510},
 		Duration: 10 * time.Second,
-	}).AttachSpellMod(core.SpellModConfig{
-		ClassMask:  warrior.SpellMaskHeroicStrike | warrior.SpellMaskCleave,
-		Kind:       core.SpellMod_PowerCost_Pct,
-		FloatValue: -2,
+
+		OnGain: func(aura *core.Aura, sim *core.Simulation) {
+			war.HeroicStrikeCleaveCostMod.Activate()
+		},
+		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
+			if !war.InciteAura.IsActive() {
+				war.HeroicStrikeCleaveCostMod.Deactivate()
+			}
+		},
 	}).AttachSpellMod(core.SpellModConfig{
 		ClassMask:  warrior.SpellMaskHeroicStrike | warrior.SpellMaskCleave,
 		Kind:       core.SpellMod_BonusCrit_Percent,
 		FloatValue: 100,
-	})
-
-	aura.AttachProcTrigger(core.ProcTrigger{
+	}).AttachProcTrigger(core.ProcTrigger{
 		Name:           "Ultimatum - Consume",
 		ClassSpellMask: warrior.SpellMaskHeroicStrike | warrior.SpellMaskCleave,
-		Callback:       core.CallbackOnSpellHitDealt,
+		Callback:       core.CallbackOnCastComplete,
 
 		ExtraCondition: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) bool {
 			return spell.CurCast.Cost <= 0
 		},
 
 		Handler: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-			aura.Deactivate(sim)
+			war.UltimatumAura.Deactivate(sim)
 		},
 	})
 
@@ -101,7 +104,7 @@ func (war *ProtectionWarrior) registerUltimatum() {
 		Callback:       core.CallbackOnSpellHitDealt,
 		Outcome:        core.OutcomeCrit,
 		Handler: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-			aura.Activate(sim)
+			war.UltimatumAura.Activate(sim)
 		},
 	})
 }

--- a/sim/warrior/protection/shield_slam.go
+++ b/sim/warrior/protection/shield_slam.go
@@ -19,10 +19,6 @@ func (war *ProtectionWarrior) registerShieldSlam() {
 		ClassSpellMask: warrior.SpellMaskShieldSlam,
 		MaxRange:       core.MaxMeleeRange,
 
-		RageCost: core.RageCostOptions{
-			Cost:   20,
-			Refund: 0.8,
-		},
 		Cast: core.CastConfig{
 			DefaultCast: core.Cast{
 				GCD: core.GCDDefault,

--- a/sim/warrior/warrior.go
+++ b/sim/warrior/warrior.go
@@ -90,6 +90,8 @@ type Warrior struct {
 	Stance              Stance
 	CriticalBlockChance []float64 // Can be gained as non-prot via certain talents and spells
 
+	HeroicStrikeCleaveCostMod *core.SpellMod
+
 	BattleShout     *core.Spell
 	CommandingShout *core.Spell
 	BattleStance    *core.Spell
@@ -109,6 +111,8 @@ type Warrior struct {
 	DefensiveStanceAura *core.Aura
 	BerserkerStanceAura *core.Aura
 
+	InciteAura          *core.Aura
+	UltimatumAura       *core.Aura
 	SweepingStrikesAura *core.Aura
 	EnrageAura          *core.Aura
 	BerserkerRageAura   *core.Aura
@@ -223,6 +227,12 @@ func NewWarrior(character *core.Character, options *proto.WarriorOptions, talent
 	warrior.PseudoStats.BaseParryChance += 0.03
 	warrior.PseudoStats.BaseBlockChance += 0.03
 	warrior.CriticalBlockChance = append(warrior.CriticalBlockChance, 0.0, 0.0)
+
+	warrior.HeroicStrikeCleaveCostMod = warrior.AddDynamicMod(core.SpellModConfig{
+		ClassMask:  SpellMaskHeroicStrike | SpellMaskCleave,
+		Kind:       core.SpellMod_PowerCost_Pct,
+		FloatValue: -2,
+	})
 
 	return warrior
 }


### PR DESCRIPTION
Having Glyph of Incite as a Prot Warrior caused the two -100% cost modifiers to basically cancel each other out, resulting in Heroic Strikes that still cost 30 rage.

I solved this by having a shared spell mod that only gets deactivated once both auras are inactive.
The order of these two procs matter since the Incite consume trigger has an ExtraCondition that checks if Ultimatum is active, which means it has to be run first, hence the `CallbackOnSpellHitDealt` for that one and `CallbackOnCastComplete` on Ultimatum.

Also, removed a Cata leftover which made Shield Slam cost rage :)