### PR TITLE
Fixed Crash Report -1930652445 #256

### DIFF
--- a/sim/core/apl_values_operators.go
+++ b/sim/core/apl_values_operators.go
@@ -377,7 +377,7 @@ type APLValueMath struct {
 
 func (rot *APLRotation) newValueMath(config *proto.APLValueMath, uuid *proto.UUID) APLValue {
 	lhs, rhs := rot.newAPLValue(config.Lhs), rot.newAPLValue(config.Rhs)
-	if config.Op == proto.APLValueMath_OpAdd || config.Op == proto.APLValueMath_OpSub {
+	if config.Op == proto.APLValueMath_OpAdd || config.Op == proto.APLValueMath_OpSub || config.Op == proto.APLValueMath_OpMul || config.Op == proto.APLValueMath_OpDiv {
 		lhs, rhs = rot.coerceToSameType(lhs, rhs)
 	}
 	if lhs == nil || rhs == nil {

--- a/sim/druid/balance/eclipse.go
+++ b/sim/druid/balance/eclipse.go
@@ -1,6 +1,7 @@
 package balance
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/wowsims/mop/sim/core"
@@ -202,9 +203,9 @@ func (moonkin *BalanceDruid) RegisterEclipseEnergyGainAura() {
 				case druid.DruidSpellWrath:
 					moonkin.AddEclipseEnergy(energyGain, LunarEnergy, sim, lunarMetric, spell)
 				case druid.DruidSpellStarsurge:
-					if moonkin.CanGainEnergy(SolarAndLunarEnergy) {
+					if moonkin.CanGainEnergy(LunarEnergy) {
 						moonkin.AddEclipseEnergy(energyGain, LunarEnergy, sim, solarMetric, spell)
-					} else {
+					} else if moonkin.CanGainEnergy(SolarEnergy) {
 						moonkin.AddEclipseEnergy(energyGain, SolarEnergy, sim, lunarMetric, spell)
 					}
 				}
@@ -232,12 +233,15 @@ func (eb *eclipseEnergyBar) AddEclipseCallback(callback EclipseCallback) {
 }
 
 func (eb *eclipseEnergyBar) AddEclipseEnergy(amount float64, kind EclipseEnergy, sim *core.Simulation, metrics *core.ResourceMetrics, spell *core.Spell) {
+	//debug output spell
+	fmt.Printf("Adding %0.0f eclipse energy of kind %d for spell %s\n", amount, kind, spell.ActionID)
 	if eb.moonkin == nil {
 		return
 	}
 
 	// unit currently can not gain the specified energy
 	if kind&eb.gainMask == 0 {
+		fmt.Printf("Unit can not gain eclipse energy of kind %d, gain mask is %d\n", kind, eb.gainMask)
 		return
 	}
 

--- a/sim/druid/balance/eclipse.go
+++ b/sim/druid/balance/eclipse.go
@@ -1,7 +1,6 @@
 package balance
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/wowsims/mop/sim/core"
@@ -233,15 +232,12 @@ func (eb *eclipseEnergyBar) AddEclipseCallback(callback EclipseCallback) {
 }
 
 func (eb *eclipseEnergyBar) AddEclipseEnergy(amount float64, kind EclipseEnergy, sim *core.Simulation, metrics *core.ResourceMetrics, spell *core.Spell) {
-	//debug output spell
-	fmt.Printf("Adding %0.0f eclipse energy of kind %d for spell %s\n", amount, kind, spell.ActionID)
 	if eb.moonkin == nil {
 		return
 	}
 
 	// unit currently can not gain the specified energy
 	if kind&eb.gainMask == 0 {
-		fmt.Printf("Unit can not gain eclipse energy of kind %d, gain mask is %d\n", kind, eb.gainMask)
 		return
 	}
 


### PR DESCRIPTION
Fixed hard crash on multiplying integers by durations by requiring both arguments to APLValueMath_OpMul and APLValueMath_OpDiv to be coerced to the same type.