### PR TITLE
Fixed wowsims/mop#329 and wowsims/mop#328

### DIFF
--- a/sim/druid/balance/astral_communion.go
+++ b/sim/druid/balance/astral_communion.go
@@ -37,9 +37,9 @@ func (moonkin *BalanceDruid) registerAstralCommunionSpell() {
 			TickLength:          time.Second * 1,
 			AffectedByCastSpeed: false,
 			OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
-				if moonkin.CanGainEnergy(SolarAndLunarEnergy) {
+				if moonkin.CanGainEnergy(LunarEnergy) {
 					moonkin.AddEclipseEnergy(eclipseEnergyGain, LunarEnergy, sim, lunarMetric, dot.Spell)
-				} else {
+				} else if moonkin.CanGainEnergy(SolarEnergy) {
 					moonkin.AddEclipseEnergy(eclipseEnergyGain, SolarEnergy, sim, solarMetric, dot.Spell)
 				}
 			},

--- a/sim/druid/balance/eclipse.go
+++ b/sim/druid/balance/eclipse.go
@@ -202,9 +202,9 @@ func (moonkin *BalanceDruid) RegisterEclipseEnergyGainAura() {
 				case druid.DruidSpellWrath:
 					moonkin.AddEclipseEnergy(energyGain, LunarEnergy, sim, lunarMetric, spell)
 				case druid.DruidSpellStarsurge:
-					if moonkin.CanGainEnergy(SolarAndLunarEnergy) {
+					if moonkin.CanGainEnergy(LunarEnergy) {
 						moonkin.AddEclipseEnergy(energyGain, LunarEnergy, sim, solarMetric, spell)
-					} else {
+					} else if moonkin.CanGainEnergy(SolarEnergy) {
 						moonkin.AddEclipseEnergy(energyGain, SolarEnergy, sim, lunarMetric, spell)
 					}
 				}


### PR DESCRIPTION
Fixed Astral Communion and Starsurge not giving energy while in Lunar eclipse.
The sim was only trying to add lunar energy even in Lunar eclipse.