### PR TITLE
add endpoint for running series of sims

### DIFF
--- a/proto/api.proto
+++ b/proto/api.proto
@@ -363,12 +363,29 @@ message ErrorOutcome {
 }
 
 // RPC RaidSim
+
+// ChartInput describes the input for the chart generation
+// and all the data needed to run parallel sims.
+// I've also done integers everywhere to avoid having to deal with type conversions
+message ChartInput {
+	repeated int32 stats_to_compare = 100;
+	int32 lower_bound = 101;
+	int32 upper_bound = 102;
+	int32 step = 103;
+	int32 current_value = 104;
+	int32 current_value_other = 105;
+}
+
 message RaidSimRequest {
 	string request_id = 5;
 	Raid raid = 1;
 	Encounter encounter = 2;
 	SimOptions sim_options = 3;
 	SimType type = 4;
+
+	// extended RaidSimRequest with ChartInput to save myself
+	// from having to deal with new message
+	ChartInput chart_input = 1000;
 }
 
 // Result from running the raid sim.
@@ -386,6 +403,16 @@ message RaidSimResult {
 	ErrorOutcome error = 5;
 
 	int32 iterations_done = 7;
+
+	// I had to add ChartInput here as well. The sims finish in indeterministic order
+	// so we cannot guarantee that they will end up ordered in a sensible way
+	// including the ChartInput lets us correlate the input and output
+	ChartInput chart_input = 1000;
+}
+
+// ChartResult is a new response type for returning the aggregated sim results
+message ChartResult {
+	repeated RaidSimResult raid_sim_result = 1;
 }
 
 message RaidSimRequestSplitRequest {

--- a/ui/core/sim.ts
+++ b/ui/core/sim.ts
@@ -415,6 +415,15 @@ export class Sim {
 
 			const request = this.makeRaidSimRequest(false);
 
+			// this I added because I couldn't be assed to create an entirely
+			// new piece of UI to handle a new protobuf message type
+			request.chartInput = {
+				statsToCompare: [Stat.StatCritRating , Stat.StatHasteRating],
+				step: 160,
+				lowerBound: -1600,
+				upperBound: 1600,
+			}
+
 			let result;
 			// Only use worker base concurrency when running wasm. Local sim has native threading.
 			if (await this.shouldUseWasmConcurrency()) {

--- a/vite.build-workers.ts
+++ b/vite.build-workers.ts
@@ -22,7 +22,7 @@ const args = minimist(process.argv.slice(2), { boolean: ['watch'] });
 const buildWorkers = async () => {
 	const { stdout } = await execAsync('go env GOROOT');
 	const GO_ROOT = stdout.replace('\n', '');
-	const wasmExecutablePath = path.join(GO_ROOT, '/misc/wasm/wasm_exec.js');
+	const wasmExecutablePath = path.join(GO_ROOT, '/lib/wasm/wasm_exec.js');
 	const wasmFile = await fs.readFile(wasmExecutablePath, 'utf8');
 
 	Object.entries(workers).forEach(async ([name, sourcePath]) => {


### PR DESCRIPTION
Endpoint added by this PR allows for running a suite of sims that are identical besides the adjusted stats. 

Current implementation lets you specify which stats you want to compare, what is the increment by which each sim should change the value of both stats and what are the upper and lower bounds for the comparison. The output can later be put into a neat graphical form. 

