### PR TITLE
Gara'jal Model Updates

### DIFF
--- a/sim/core/target.go
+++ b/sim/core/target.go
@@ -262,6 +262,12 @@ func (target *Target) Disable(sim *Simulation, expireAuras bool) {
 
 	target.CancelGCDTimer(sim)
 	target.AutoAttacks.CancelAutoSwing(sim)
+
+	if (target.hardcastAction != nil) && !target.hardcastAction.consumed {
+		target.hardcastAction.Cancel(sim)
+		target.hardcastAction = nil
+	}
+
 	target.enabled = false
 	sim.Encounter.removeInactiveTarget(target)
 

--- a/sim/druid/guardian/TestGuardian.results
+++ b/sim/druid/guardian/TestGuardian.results
@@ -33,2944 +33,2944 @@ character_stats_results: {
 dps_results: {
  key: "TestGuardian-AllItems-AgilePrimalDiamond"
  value: {
-  dps: 92911.13079
-  tps: 615951.66664
-  dtps: 27427.53873
-  hps: 15195.56865
+  dps: 91067.66717
+  tps: 601302.07216
+  dtps: 30281.3758
+  hps: 15073.74241
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-AlacrityofXuen-103989"
  value: {
-  dps: 93493.1291
-  tps: 617922.11035
-  dtps: 26860.70201
-  hps: 15272.46208
+  dps: 91596.29763
+  tps: 603518.8356
+  dtps: 29931.97425
+  hps: 15442.42485
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ArcaneBadgeoftheShieldwall-93347"
  value: {
-  dps: 91163.2934
-  tps: 603386.61013
-  dtps: 26962.88043
-  hps: 14947.38621
+  dps: 89680.0202
+  tps: 591867.51764
+  dtps: 30065.14445
+  hps: 15230.47872
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ArrowflightMedallion-93258"
  value: {
-  dps: 96539.59353
-  tps: 638475.59144
-  dtps: 26459.73075
-  hps: 15078.05335
+  dps: 94209.10555
+  tps: 620948.6329
+  dtps: 29637.86542
+  hps: 14823.02732
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-AssuranceofConsequence-105472"
  value: {
-  dps: 96026.91645
-  tps: 636351.58759
-  dtps: 24491.07244
-  hps: 14156.32701
+  dps: 90731.91007
+  tps: 597974.23764
+  dtps: 26937.98437
+  hps: 13592.90714
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-AusterePrimalDiamond"
  value: {
-  dps: 91368.7205
-  tps: 605544.30441
-  dtps: 26836.27007
-  hps: 14794.33237
+  dps: 89590.41678
+  tps: 591312.62685
+  dtps: 29908.45774
+  hps: 14827.42116
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-BadJuju-96781"
  value: {
-  dps: 96321.94811
-  tps: 637554.4946
-  dtps: 25410.21524
-  hps: 14781.35594
+  dps: 94165.06945
+  tps: 620641.84816
+  dtps: 28530.42805
+  hps: 14681.62722
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-BadgeofKypariZar-84079"
  value: {
-  dps: 93438.43718
-  tps: 618271.8344
-  dtps: 26745.08807
-  hps: 14916.76266
+  dps: 91573.87403
+  tps: 603309.59765
+  dtps: 29831.35822
+  hps: 14807.01931
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-BlossomofPureSnow-89081"
  value: {
-  dps: 93670.68283
-  tps: 618651.83364
-  dtps: 27032.08087
-  hps: 15123.03088
+  dps: 91697.39973
+  tps: 603705.01122
+  dtps: 30224.78657
+  hps: 15547.9547
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-BottleofInfiniteStars-87057"
  value: {
-  dps: 94691.48468
-  tps: 626675.94149
-  dtps: 26327.06775
-  hps: 14639.77515
+  dps: 93018.42624
+  tps: 613192.6371
+  dtps: 29050.28642
+  hps: 14534.11886
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-BraidofTenSongs-84072"
  value: {
-  dps: 91640.97441
-  tps: 607615.27662
-  dtps: 26593.17549
-  hps: 14827.71388
+  dps: 90165.33547
+  tps: 595618.59012
+  dtps: 29334.41516
+  hps: 14617.91433
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Brawler'sStatue-87571"
  value: {
-  dps: 91523.71031
-  tps: 606467.66327
-  dtps: 26543.30034
-  hps: 14652.39068
+  dps: 89426.17778
+  tps: 590394.08524
+  dtps: 29605.29024
+  hps: 14591.5471
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-BreathoftheHydra-96827"
  value: {
-  dps: 91773.5482
-  tps: 607116.34724
-  dtps: 26983.35597
-  hps: 15020.72204
+  dps: 89836.32888
+  tps: 591955.76337
+  dtps: 29726.98993
+  hps: 14898.78177
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-BroochofMunificentDeeds-87500"
  value: {
-  dps: 91126.66775
-  tps: 603961.31844
-  dtps: 27405.37384
-  hps: 15331.85941
+  dps: 89317.77567
+  tps: 589146.23104
+  dtps: 30323.14598
+  hps: 15010.28719
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-BrutalTalismanoftheShado-PanAssault-94508"
  value: {
-  dps: 92599.52476
-  tps: 613119.23442
-  dtps: 27243.99557
-  hps: 15014.72032
+  dps: 90581.30031
+  tps: 597146.21822
+  dtps: 30305.6308
+  hps: 14930.11621
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-BurningPrimalDiamond"
  value: {
-  dps: 92435.42882
-  tps: 612659.47418
-  dtps: 27571.69799
-  hps: 15289.44401
+  dps: 90655.42534
+  tps: 598303.70893
+  dtps: 30376.7933
+  hps: 15089.40866
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CapacitivePrimalDiamond"
  value: {
-  dps: 91933.26377
-  tps: 609531.25545
-  dtps: 27247.41685
-  hps: 15065.14842
+  dps: 90013.19067
+  tps: 594330.1363
+  dtps: 30209.23798
+  hps: 15111.79776
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CarbonicCarbuncle-81138"
  value: {
-  dps: 94154.37787
-  tps: 621978.16113
-  dtps: 27195.86878
-  hps: 14954.25101
+  dps: 92251.2461
+  tps: 606906.59667
+  dtps: 30145.03886
+  hps: 15293.72667
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Cha-Ye'sEssenceofBrilliance-96888"
  value: {
-  dps: 95536.49581
-  tps: 631278.98534
-  dtps: 26775.35045
-  hps: 15018.48224
+  dps: 93461.17694
+  tps: 615396.17219
+  dtps: 29943.28887
+  hps: 15374.33201
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CharmofTenSongs-84071"
  value: {
-  dps: 93715.99673
-  tps: 620618.40485
-  dtps: 26640.30602
-  hps: 14787.9757
+  dps: 91390.06234
+  tps: 603662.24431
+  dtps: 29456.07555
+  hps: 14940.91783
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CommunalIdolofDestruction-101168"
  value: {
-  dps: 91446.42036
-  tps: 605781.32173
-  dtps: 26890.3208
-  hps: 14781.75831
+  dps: 89606.70736
+  tps: 591641.49193
+  dtps: 29777.60108
+  hps: 14478.2486
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CommunalStoneofDestruction-101171"
  value: {
-  dps: 91170.8077
-  tps: 604022.88288
-  dtps: 27239.17272
-  hps: 15190.11512
+  dps: 89331.02842
+  tps: 589378.34244
+  dtps: 30186.91683
+  hps: 14926.87646
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CommunalStoneofWisdom-101183"
  value: {
-  dps: 91244.17005
-  tps: 604349.58262
-  dtps: 27438.21654
-  hps: 15008.74675
+  dps: 89461.14505
+  tps: 590021.90291
+  dtps: 30239.92983
+  hps: 14804.5925
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ContemplationofChi-Ji-103688"
  value: {
-  dps: 91147.59809
-  tps: 603860.42312
-  dtps: 27417.30584
-  hps: 15241.6569
+  dps: 89373.8236
+  tps: 589678.02168
+  dtps: 30251.83972
+  hps: 14848.97429
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ContemplationofChi-Ji-103988"
  value: {
-  dps: 91231.30974
-  tps: 604308.05889
-  dtps: 27367.78782
-  hps: 15048.77136
+  dps: 89525.68135
+  tps: 590532.41584
+  dtps: 30163.88493
+  hps: 14810.99293
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Coren'sColdChromiumCoaster-87574"
  value: {
-  dps: 95091.279
-  tps: 628789.96571
-  dtps: 26695.15109
-  hps: 14731.80939
+  dps: 92734.9076
+  tps: 611199.72278
+  dtps: 30044.94893
+  hps: 14855.99253
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CoreofDecency-87497"
  value: {
-  dps: 91344.65263
-  tps: 605166.7904
-  dtps: 27273.8895
-  hps: 15053.11759
+  dps: 89415.4693
+  tps: 589826.35975
+  dtps: 30350.28525
+  hps: 14911.77412
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CourageousPrimalDiamond"
  value: {
-  dps: 91133.68463
-  tps: 603830.37412
-  dtps: 27571.69799
-  hps: 15283.51345
+  dps: 89402.87328
+  tps: 589851.80267
+  dtps: 30388.13381
+  hps: 15045.75569
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CraftedDreadfulGladiator'sBadgeofConquest-93419"
  value: {
-  dps: 93441.42619
-  tps: 619157.28308
-  dtps: 26670.83858
-  hps: 14619.21485
+  dps: 90954.67066
+  tps: 599824.0693
+  dtps: 29801.93126
+  hps: 14901.53425
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CraftedDreadfulGladiator'sBadgeofDominance-93600"
  value: {
-  dps: 91379.33457
-  tps: 605448.6391
-  dtps: 27322.81744
-  hps: 15033.36287
+  dps: 89412.87808
+  tps: 589918.72861
+  dtps: 30108.92705
+  hps: 14745.84424
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CraftedDreadfulGladiator'sBadgeofVictory-93606"
  value: {
-  dps: 91880.02044
-  tps: 608730.74167
-  dtps: 27211.48489
-  hps: 14878.86608
+  dps: 89850.41268
+  tps: 592687.4083
+  dtps: 30342.80788
+  hps: 14894.49642
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CraftedDreadfulGladiator'sEmblemofCruelty-93485"
  value: {
-  dps: 93699.01111
-  tps: 620061.89021
-  dtps: 26845.20646
-  hps: 14807.74811
+  dps: 91220.78935
+  tps: 601535.21844
+  dtps: 30079.32708
+  hps: 14803.4071
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CraftedDreadfulGladiator'sEmblemofMeditation-93487"
  value: {
-  dps: 91442.73865
-  tps: 606005.43212
-  dtps: 27298.33991
-  hps: 14874.6692
+  dps: 89253.28565
+  tps: 588832.90127
+  dtps: 30430.10597
+  hps: 15042.15258
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CraftedDreadfulGladiator'sEmblemofTenacity-93486"
  value: {
-  dps: 91067.12492
-  tps: 603544.65358
-  dtps: 27347.35691
-  hps: 15287.83039
+  dps: 89353.3711
+  tps: 589395.55275
+  dtps: 30236.22214
+  hps: 14945.38001
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CraftedDreadfulGladiator'sInsigniaofConquest-93424"
  value: {
-  dps: 93943.56702
-  tps: 621758.36381
-  dtps: 26614.57757
-  hps: 14794.31427
+  dps: 91815.4319
+  tps: 605297.64029
+  dtps: 29871.27553
+  hps: 14863.48358
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CraftedDreadfulGladiator'sInsigniaofDominance-93601"
  value: {
-  dps: 91332.61025
-  tps: 605121.45861
-  dtps: 27242.09599
-  hps: 14973.36951
+  dps: 89344.58163
+  tps: 589372.11871
+  dtps: 30364.50513
+  hps: 15030.57927
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CraftedDreadfulGladiator'sInsigniaofVictory-93611"
  value: {
-  dps: 92135.94172
-  tps: 610381.26067
-  dtps: 27206.84322
-  hps: 14889.34669
+  dps: 90071.01922
+  tps: 594093.75923
+  dtps: 30338.59343
+  hps: 14903.66003
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CraftedMalevolentGladiator'sBadgeofConquest-98755"
  value: {
-  dps: 93613.45008
-  tps: 620028.41258
-  dtps: 26649.19032
-  hps: 14722.13186
+  dps: 91392.88393
+  tps: 602549.54013
+  dtps: 29745.46021
+  hps: 14846.5795
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CraftedMalevolentGladiator'sBadgeofDominance-98910"
  value: {
-  dps: 91379.33457
-  tps: 605448.64734
-  dtps: 27337.51329
-  hps: 15056.78408
+  dps: 89412.87808
+  tps: 589918.72861
+  dtps: 30108.92705
+  hps: 14758.93861
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CraftedMalevolentGladiator'sBadgeofVictory-98912"
  value: {
-  dps: 91988.90791
-  tps: 609431.05874
-  dtps: 27204.03566
-  hps: 14830.6381
+  dps: 89948.47316
+  tps: 593312.50613
+  dtps: 30339.83752
+  hps: 14897.11565
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CraftedMalevolentGladiator'sEmblemofCruelty-98811"
  value: {
-  dps: 93996.55479
-  tps: 622217.16104
-  dtps: 26774.96488
-  hps: 14866.9821
+  dps: 91686.82255
+  tps: 604617.37108
+  dtps: 30097.65454
+  hps: 14643.87291
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CraftedMalevolentGladiator'sEmblemofMeditation-98813"
  value: {
-  dps: 91442.73865
-  tps: 606005.43212
-  dtps: 27298.33991
-  hps: 14874.6692
+  dps: 89253.28565
+  tps: 588832.90127
+  dtps: 30430.10597
+  hps: 15042.15258
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CraftedMalevolentGladiator'sEmblemofTenacity-98812"
  value: {
-  dps: 91236.85139
-  tps: 604476.9868
-  dtps: 27402.23886
-  hps: 15398.90087
+  dps: 89449.97883
+  tps: 589964.82507
+  dtps: 30379.85872
+  hps: 14983.56198
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CraftedMalevolentGladiator'sInsigniaofConquest-98760"
  value: {
-  dps: 94328.2173
-  tps: 624471.91681
-  dtps: 26463.76185
-  hps: 14924.05414
+  dps: 92183.81735
+  tps: 607890.89329
+  dtps: 29759.11831
+  hps: 14731.34536
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CraftedMalevolentGladiator'sInsigniaofDominance-98911"
  value: {
-  dps: 91341.49492
-  tps: 605121.45861
-  dtps: 27242.09599
-  hps: 15036.91428
+  dps: 89357.4962
+  tps: 589466.34872
+  dtps: 30332.86562
+  hps: 14921.60415
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CraftedMalevolentGladiator'sInsigniaofVictory-98917"
  value: {
-  dps: 92314.44315
-  tps: 611538.35647
-  dtps: 27203.22086
-  hps: 14891.70137
+  dps: 90289.34013
+  tps: 595526.65956
+  dtps: 30299.57145
+  hps: 14870.44258
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CurseofHubris-102307"
  value: {
-  dps: 96617.96955
-  tps: 638331.84045
-  dtps: 26487.57696
-  hps: 15135.73669
+  dps: 94659.81484
+  tps: 623474.65727
+  dtps: 29889.93253
+  hps: 15292.10292
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CurseofHubris-104649"
  value: {
-  dps: 97347.56996
-  tps: 642791.68695
-  dtps: 26430.00153
-  hps: 15142.84
+  dps: 95585.04557
+  tps: 629282.74278
+  dtps: 29930.23947
+  hps: 15346.94446
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CurseofHubris-104898"
  value: {
-  dps: 96275.89597
-  tps: 635690.04562
-  dtps: 26429.62713
-  hps: 14994.22361
+  dps: 94292.64634
+  tps: 620572.08985
+  dtps: 30022.15803
+  hps: 15268.81592
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CurseofHubris-105147"
  value: {
-  dps: 95843.44836
-  tps: 633586.13721
-  dtps: 26614.16307
-  hps: 15069.55988
+  dps: 93756.37766
+  tps: 617267.63762
+  dtps: 30046.13373
+  hps: 15154.73785
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CurseofHubris-105396"
  value: {
-  dps: 96946.74871
-  tps: 640199.91121
-  dtps: 26467.51189
-  hps: 15150.33548
+  dps: 94993.68845
+  tps: 625376.54003
+  dtps: 29946.15927
+  hps: 15261.99027
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CurseofHubris-105645"
  value: {
-  dps: 97728.75919
-  tps: 645460.0135
-  dtps: 26448.70467
-  hps: 15369.38094
+  dps: 95926.542
+  tps: 631663.07927
+  dtps: 29916.42571
+  hps: 15356.39864
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CutstitcherMedallion-93255"
  value: {
-  dps: 91147.59809
-  tps: 603860.42312
-  dtps: 27417.30584
-  hps: 15241.6569
+  dps: 89373.8236
+  tps: 589678.02168
+  dtps: 30251.83972
+  hps: 14848.97429
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Daelo'sFinalWords-87496"
  value: {
-  dps: 91965.9229
-  tps: 609256.79497
-  dtps: 27207.96427
-  hps: 14879.00465
+  dps: 89899.32627
+  tps: 592958.70733
+  dtps: 30337.11206
+  hps: 14983.52912
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-DarkglowEmbroidery(Rank3)-4893"
  value: {
-  dps: 91407.23878
-  tps: 605813.63536
-  dtps: 26915.91708
-  hps: 14795.80982
+  dps: 89541.01202
+  tps: 590859.77662
+  dtps: 29957.2943
+  hps: 14774.43694
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-DarkmistVortex-87172"
  value: {
-  dps: 92871.921
-  tps: 614823.16311
-  dtps: 26955.7232
-  hps: 15066.82451
+  dps: 91140.94286
+  tps: 601046.09841
+  dtps: 29874.8131
+  hps: 15171.89818
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-DeadeyeBadgeoftheShieldwall-93346"
  value: {
-  dps: 93487.53759
-  tps: 620030.11828
-  dtps: 26286.15891
-  hps: 14552.64132
+  dps: 91128.27418
+  tps: 602042.19264
+  dtps: 29440.80722
+  hps: 14515.82453
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-DelicateVialoftheSanguinaire-96895"
  value: {
-  dps: 91633.41093
-  tps: 607345.2021
-  dtps: 25638.238
-  hps: 14398.97401
+  dps: 89315.271
+  tps: 589617.71629
+  dtps: 28784.33095
+  hps: 14193.09599
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-DestructivePrimalDiamond"
  value: {
-  dps: 92350.88652
-  tps: 611954.42837
-  dtps: 27120.69879
-  hps: 15033.23085
+  dps: 90223.70281
+  tps: 595352.32864
+  dtps: 30250.92124
+  hps: 14979.11986
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-DisciplineofXuen-103986"
  value: {
-  dps: 95788.44239
-  tps: 634796.37324
-  dtps: 25508.7672
-  hps: 14369.52898
+  dps: 93458.93495
+  tps: 617036.87513
+  dtps: 28846.47032
+  hps: 14828.76431
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Dominator'sArcaneBadge-93342"
  value: {
-  dps: 91163.2934
-  tps: 603386.61013
-  dtps: 26962.88043
-  hps: 14947.38621
+  dps: 89680.0202
+  tps: 591867.51764
+  dtps: 30065.14445
+  hps: 15230.47872
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Dominator'sDeadeyeBadge-93341"
  value: {
-  dps: 93487.53759
-  tps: 620030.11828
-  dtps: 26286.15891
-  hps: 14552.64132
+  dps: 91128.27418
+  tps: 602042.19264
+  dtps: 29440.80722
+  hps: 14515.82453
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Dominator'sDurableBadge-93345"
  value: {
-  dps: 91560.98447
-  tps: 606847.19259
-  dtps: 26551.92577
-  hps: 14477.8917
+  dps: 89393.72334
+  tps: 590166.70362
+  dtps: 29476.66325
+  hps: 14385.40582
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Dominator'sKnightlyBadge-93344"
  value: {
-  dps: 92058.2665
-  tps: 610079.4337
-  dtps: 27073.72009
-  hps: 14784.11675
+  dps: 89904.48462
+  tps: 593151.75874
+  dtps: 30016.85943
+  hps: 14633.08302
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Dominator'sMendingBadge-93343"
  value: {
-  dps: 91244.30727
-  tps: 604585.9428
-  dtps: 27307.48079
-  hps: 15099.92027
+  dps: 89341.75628
+  tps: 589503.09063
+  dtps: 30255.9439
+  hps: 14769.09848
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-DreadfulGladiator'sBadgeofConquest-84344"
  value: {
-  dps: 93441.42619
-  tps: 619157.28308
-  dtps: 26670.83858
-  hps: 14619.21485
+  dps: 90954.67066
+  tps: 599824.0693
+  dtps: 29801.93126
+  hps: 14901.53425
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-DreadfulGladiator'sBadgeofDominance-84488"
  value: {
-  dps: 91379.33457
-  tps: 605448.6391
-  dtps: 27322.81744
-  hps: 15033.36287
+  dps: 89412.87808
+  tps: 589918.72861
+  dtps: 30108.92705
+  hps: 14745.84424
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-DreadfulGladiator'sBadgeofVictory-84490"
  value: {
-  dps: 91880.02044
-  tps: 608730.74167
-  dtps: 27211.48489
-  hps: 14878.86608
+  dps: 89850.41268
+  tps: 592687.4083
+  dtps: 30342.80788
+  hps: 14894.49642
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-DreadfulGladiator'sEmblemofCruelty-84399"
  value: {
-  dps: 93699.01111
-  tps: 620061.89021
-  dtps: 26845.20646
-  hps: 14807.74811
+  dps: 91220.78935
+  tps: 601535.21844
+  dtps: 30079.32708
+  hps: 14803.4071
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-DreadfulGladiator'sEmblemofMeditation-84401"
  value: {
-  dps: 91442.73865
-  tps: 606005.43212
-  dtps: 27298.33991
-  hps: 14874.6692
+  dps: 89253.28565
+  tps: 588832.90127
+  dtps: 30430.10597
+  hps: 15042.15258
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-DreadfulGladiator'sEmblemofTenacity-84400"
  value: {
-  dps: 91067.12492
-  tps: 603544.65358
-  dtps: 27347.35691
-  hps: 15287.83039
+  dps: 89353.3711
+  tps: 589395.55275
+  dtps: 30236.22214
+  hps: 14945.38001
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-DreadfulGladiator'sInsigniaofConquest-84349"
  value: {
-  dps: 93912.25582
-  tps: 621590.51062
-  dtps: 26580.77979
-  hps: 14798.38977
+  dps: 91807.20675
+  tps: 605194.66213
+  dtps: 29928.47674
+  hps: 14873.69455
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-DreadfulGladiator'sInsigniaofDominance-84489"
  value: {
-  dps: 91321.00901
-  tps: 605121.45861
-  dtps: 27242.09599
-  hps: 14891.40629
+  dps: 89332.81859
+  tps: 589372.11871
+  dtps: 30367.71425
+  hps: 15030.35805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-DreadfulGladiator'sInsigniaofVictory-84495"
  value: {
-  dps: 92123.69586
-  tps: 610278.64002
-  dtps: 27206.83165
-  hps: 14887.98937
+  dps: 90067.25838
+  tps: 594051.84385
+  dtps: 30310.69488
+  hps: 14897.18228
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-DurableBadgeoftheShieldwall-93350"
  value: {
-  dps: 91560.98447
-  tps: 606847.19259
-  dtps: 26551.92577
-  hps: 14477.8917
+  dps: 89393.72334
+  tps: 590166.70362
+  dtps: 29476.66325
+  hps: 14385.40582
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-EffulgentPrimalDiamond"
  value: {
-  dps: 91351.66249
-  tps: 605278.17504
-  dtps: 27435.5102
-  hps: 15201.88009
+  dps: 89314.12025
+  tps: 589337.76752
+  dtps: 30360.26225
+  hps: 15181.5123
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-EmberPrimalDiamond"
  value: {
-  dps: 91133.68463
-  tps: 603830.37412
-  dtps: 27566.21807
-  hps: 15249.01354
+  dps: 89386.03407
+  tps: 589733.89289
+  dtps: 30376.7933
+  hps: 15066.94814
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-EmblemofKypariZar-84077"
  value: {
-  dps: 93035.85814
-  tps: 617224.17067
-  dtps: 26620.38657
-  hps: 14857.32183
+  dps: 91699.94163
+  tps: 605913.66323
+  dtps: 29325.66137
+  hps: 14799.28176
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-EmblemoftheCatacombs-83733"
  value: {
-  dps: 90894.04304
-  tps: 602911.88751
-  dtps: 26575.21937
-  hps: 14548.29549
+  dps: 89278.17167
+  tps: 589813.36768
+  dtps: 29884.68667
+  hps: 15090.73527
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-EmptyFruitBarrel-81133"
  value: {
-  dps: 91197.38284
-  tps: 604260.37773
-  dtps: 27303.3931
-  hps: 15070.82858
+  dps: 89433.01421
+  tps: 590074.97142
+  dtps: 30159.62966
+  hps: 14878.79877
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-EnchantWeapon-BloodyDancingSteel-5125"
  value: {
-  dps: 93596.41396
-  tps: 620394.43702
-  dtps: 27136.2119
-  hps: 15072.59563
+  dps: 91369.64147
+  tps: 602902.60351
+  dtps: 30143.27538
+  hps: 14692.18246
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-EnchantWeapon-DancingSteel-4444"
  value: {
-  dps: 93789.19328
-  tps: 621663.41421
-  dtps: 26852.76757
-  hps: 15041.91957
+  dps: 91264.41924
+  tps: 602088.13544
+  dtps: 30188.44109
+  hps: 15173.50496
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-EnchantWeapon-JadeSpirit-4442"
  value: {
-  dps: 91409.29151
-  tps: 605624.96641
-  dtps: 27735.90873
-  hps: 15275.24103
+  dps: 89490.17007
+  tps: 590338.62572
+  dtps: 30812.11079
+  hps: 15139.92761
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-EnchantWeapon-River'sSong-4446"
  value: {
-  dps: 91396.23602
-  tps: 605849.05038
-  dtps: 27316.232
-  hps: 15195.70471
+  dps: 89363.56378
+  tps: 589900.21296
+  dtps: 30299.90771
+  hps: 15113.41465
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-EnchantWeapon-SpiritofConquest-5124"
  value: {
-  dps: 91368.90911
-  tps: 605502.56197
-  dtps: 27826.49053
-  hps: 15300.58304
+  dps: 89399.33328
+  tps: 589934.21354
+  dtps: 30797.71725
+  hps: 15168.10387
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-EnchantWeapon-Windsong-4441"
  value: {
-  dps: 91987.98122
-  tps: 608691.79946
-  dtps: 27324.30246
-  hps: 15173.78692
+  dps: 89967.41622
+  tps: 593495.8174
+  dtps: 30558.41786
+  hps: 15609.52716
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-EnigmaticPrimalDiamond"
  value: {
-  dps: 92350.88652
-  tps: 611954.42837
-  dtps: 27120.69879
-  hps: 15033.23085
+  dps: 90223.70281
+  tps: 595352.32864
+  dtps: 30250.92124
+  hps: 14979.11986
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-EssenceofTerror-87175"
  value: {
-  dps: 92119.79714
-  tps: 609358.18437
-  dtps: 26749.35928
-  hps: 14974.35967
+  dps: 89464.05466
+  tps: 589471.58414
+  dtps: 30489.17555
+  hps: 15668.53741
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-EternalPrimalDiamond"
  value: {
-  dps: 91324.69991
-  tps: 605298.81728
-  dtps: 27170.57945
-  hps: 15046.22037
+  dps: 89227.32281
+  tps: 589019.39597
+  dtps: 30072.2285
+  hps: 14999.5361
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-EvilEyeofGalakras-105491"
  value: {
-  dps: 91928.19997
-  tps: 609011.43461
-  dtps: 27286.59943
-  hps: 14936.4038
+  dps: 89978.79992
+  tps: 593520.12221
+  dtps: 30254.50748
+  hps: 14774.06279
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-FabledFeatherofJi-Kun-96842"
  value: {
-  dps: 92260.35754
-  tps: 611068.5995
-  dtps: 27238.82774
-  hps: 14985.13495
+  dps: 90249.49515
+  tps: 595158.7937
+  dtps: 30319.6988
+  hps: 14920.79898
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-FearwurmBadge-84074"
  value: {
-  dps: 93203.10986
-  tps: 618126.18248
-  dtps: 26449.57264
-  hps: 14702.26067
+  dps: 91752.37298
+  tps: 606069.70795
+  dtps: 29343.20802
+  hps: 14772.82384
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-FearwurmRelic-84070"
  value: {
-  dps: 93155.82464
-  tps: 618905.90793
-  dtps: 27118.81431
-  hps: 15386.68719
+  dps: 91245.90896
+  tps: 603683.00483
+  dtps: 29899.54642
+  hps: 15058.98288
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-FelsoulIdolofDestruction-101263"
  value: {
-  dps: 91506.87722
-  tps: 606473.63455
-  dtps: 26522.79595
-  hps: 14606.36376
+  dps: 89381.87023
+  tps: 590127.61758
+  dtps: 29752.31026
+  hps: 14828.65538
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-FelsoulStoneofDestruction-101266"
  value: {
-  dps: 91148.29608
-  tps: 603865.26464
-  dtps: 27227.22022
-  hps: 15165.2446
+  dps: 89331.02842
+  tps: 589378.34158
+  dtps: 30156.49113
+  hps: 14893.42086
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Fen-Yu,FuryofXuen-102248"
  value: {
-  dps: 101463.72096
-  tps: 675731.67136
-  dtps: 25224.63795
-  hps: 15045.9943
+  dps: 99114.5247
+  tps: 657269.45747
+  dtps: 28289.49612
+  hps: 15126.8656
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-FlashfrozenResinGlobule-100951"
  value: {
-  dps: 91374.67979
-  tps: 605121.45861
-  dtps: 27228.78736
-  hps: 14866.14505
+  dps: 89429.33444
+  tps: 589663.94978
+  dtps: 30354.77053
+  hps: 14908.68354
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-FlashfrozenResinGlobule-81263"
  value: {
-  dps: 91407.42384
-  tps: 605121.45861
-  dtps: 27228.78736
-  hps: 14866.14505
+  dps: 89463.59931
+  tps: 589663.94978
+  dtps: 30354.77053
+  hps: 14908.68354
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-FlashingSteelTalisman-81265"
  value: {
-  dps: 94044.83969
-  tps: 622011.33437
-  dtps: 26700.96605
-  hps: 14837.71134
+  dps: 91726.16468
+  tps: 604425.23332
+  dtps: 29775.4273
+  hps: 14848.84543
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-FleetPrimalDiamond"
  value: {
-  dps: 91133.31164
-  tps: 603854.50421
-  dtps: 27384.34236
-  hps: 15173.32742
+  dps: 89317.70316
+  tps: 589294.42106
+  dtps: 30270.92743
+  hps: 15048.2734
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ForlornPrimalDiamond"
  value: {
-  dps: 91133.68463
-  tps: 603830.37412
-  dtps: 27566.21807
-  hps: 15249.01354
+  dps: 89386.03407
+  tps: 589733.89289
+  dtps: 30376.7933
+  hps: 15066.94814
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-FortitudeoftheZandalari-94516"
  value: {
-  dps: 91162.2476
-  tps: 604210.63729
-  dtps: 26841.40628
-  hps: 14972.05709
+  dps: 89316.33139
+  tps: 589284.9619
+  dtps: 29830.10506
+  hps: 14823.79912
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-FortitudeoftheZandalari-95677"
  value: {
-  dps: 91115.9655
-  tps: 603886.64891
-  dtps: 26866.34383
-  hps: 14772.95946
+  dps: 89199.89106
+  tps: 588468.88524
+  dtps: 29937.62859
+  hps: 14795.18379
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-FortitudeoftheZandalari-96049"
  value: {
-  dps: 91145.17717
-  tps: 604090.92538
-  dtps: 26800.25294
-  hps: 15000.16833
+  dps: 89316.33139
+  tps: 589284.95829
+  dtps: 29825.88015
+  hps: 14819.09144
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-FortitudeoftheZandalari-96421"
  value: {
-  dps: 91102.45164
-  tps: 603792.00045
-  dtps: 26787.71546
-  hps: 14968.09351
+  dps: 89346.38525
+  tps: 589346.81435
+  dtps: 29754.53666
+  hps: 14693.19887
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-FortitudeoftheZandalari-96793"
  value: {
-  dps: 91104.41707
-  tps: 603805.7792
-  dtps: 26792.66826
-  hps: 15057.53761
+  dps: 89419.30504
+  tps: 589857.1225
+  dtps: 29771.82192
+  hps: 14583.50549
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GazeoftheTwins-96915"
  value: {
-  dps: 96870.21445
-  tps: 639770.4631
-  dtps: 26888.86222
-  hps: 14986.66531
+  dps: 94305.72842
+  tps: 619967.50678
+  dtps: 30224.93157
+  hps: 15294.44948
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Gerp'sPerfectArrow-87495"
  value: {
-  dps: 94897.21691
-  tps: 626956.51481
-  dtps: 26719.03418
-  hps: 14870.87577
+  dps: 92828.49555
+  tps: 610929.7001
+  dtps: 29855.60392
+  hps: 15223.86839
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Gong-Lu,StrengthofXuen-102249"
  value: {
-  dps: 98993.35258
-  tps: 658703.369
-  dtps: 25981.22918
-  hps: 14720.42636
+  dps: 96775.25659
+  tps: 641662.53214
+  dtps: 28926.96308
+  hps: 14784.72499
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GrievousGladiator'sBadgeofConquest-100195"
  value: {
-  dps: 94770.89333
-  tps: 627008.49829
-  dtps: 26521.79372
-  hps: 14815.76478
+  dps: 92740.82387
+  tps: 611213.53906
+  dtps: 29641.6977
+  hps: 14946.24606
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GrievousGladiator'sBadgeofConquest-100603"
  value: {
-  dps: 94770.89333
-  tps: 627008.49829
-  dtps: 26521.79372
-  hps: 14815.76478
+  dps: 92740.82387
+  tps: 611213.53906
+  dtps: 29641.6977
+  hps: 14946.24606
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GrievousGladiator'sBadgeofConquest-102856"
  value: {
-  dps: 94770.89333
-  tps: 627008.49829
-  dtps: 26521.79372
-  hps: 14815.76478
+  dps: 92740.82387
+  tps: 611213.53906
+  dtps: 29641.6977
+  hps: 14946.24606
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GrievousGladiator'sBadgeofConquest-103145"
  value: {
-  dps: 94770.89333
-  tps: 627008.49829
-  dtps: 26521.79372
-  hps: 14815.76478
+  dps: 92740.82387
+  tps: 611213.53906
+  dtps: 29641.6977
+  hps: 14946.24606
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GrievousGladiator'sBadgeofDominance-100490"
  value: {
-  dps: 91400.20808
-  tps: 605448.63285
-  dtps: 27337.51329
-  hps: 15083.77301
+  dps: 89477.11011
+  tps: 590219.9025
+  dtps: 30074.55863
+  hps: 14771.96716
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GrievousGladiator'sBadgeofDominance-100576"
  value: {
-  dps: 91400.20808
-  tps: 605448.63285
-  dtps: 27337.51329
-  hps: 15083.77301
+  dps: 89477.11011
+  tps: 590219.9025
+  dtps: 30074.55863
+  hps: 14771.96716
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GrievousGladiator'sBadgeofDominance-102830"
  value: {
-  dps: 91400.20808
-  tps: 605448.63285
-  dtps: 27337.51329
-  hps: 15083.77301
+  dps: 89477.11011
+  tps: 590219.9025
+  dtps: 30074.55863
+  hps: 14771.96716
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GrievousGladiator'sBadgeofDominance-103308"
  value: {
-  dps: 91400.20808
-  tps: 605448.63285
-  dtps: 27337.51329
-  hps: 15083.77301
+  dps: 89477.11011
+  tps: 590219.9025
+  dtps: 30074.55863
+  hps: 14771.96716
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GrievousGladiator'sBadgeofVictory-100500"
  value: {
-  dps: 92345.48091
-  tps: 611716.98306
-  dtps: 27241.4998
-  hps: 14909.23016
+  dps: 90281.24768
+  tps: 595428.94208
+  dtps: 30281.18758
+  hps: 14866.1879
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GrievousGladiator'sBadgeofVictory-100579"
  value: {
-  dps: 92345.48091
-  tps: 611716.98306
-  dtps: 27241.4998
-  hps: 14909.23016
+  dps: 90281.24768
+  tps: 595428.94208
+  dtps: 30281.18758
+  hps: 14866.1879
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GrievousGladiator'sBadgeofVictory-102833"
  value: {
-  dps: 92345.48091
-  tps: 611716.98306
-  dtps: 27241.4998
-  hps: 14909.23016
+  dps: 90281.24768
+  tps: 595428.94208
+  dtps: 30281.18758
+  hps: 14866.1879
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GrievousGladiator'sBadgeofVictory-103314"
  value: {
-  dps: 92345.48091
-  tps: 611716.98306
-  dtps: 27241.4998
-  hps: 14909.23016
+  dps: 90281.24768
+  tps: 595428.94208
+  dtps: 30281.18758
+  hps: 14866.1879
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GrievousGladiator'sEmblemofCruelty-100305"
  value: {
-  dps: 94974.46766
-  tps: 628021.27197
-  dtps: 26908.39811
-  hps: 14870.97002
+  dps: 92672.01629
+  tps: 610591.07182
+  dtps: 30104.95499
+  hps: 15331.30504
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GrievousGladiator'sEmblemofCruelty-100626"
  value: {
-  dps: 94974.46766
-  tps: 628021.27197
-  dtps: 26908.39811
-  hps: 14870.97002
+  dps: 92672.01629
+  tps: 610591.07182
+  dtps: 30104.95499
+  hps: 15331.30504
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GrievousGladiator'sEmblemofCruelty-102877"
  value: {
-  dps: 94974.46766
-  tps: 628021.27197
-  dtps: 26908.39811
-  hps: 14870.97002
+  dps: 92672.01629
+  tps: 610591.07182
+  dtps: 30104.95499
+  hps: 15331.30504
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GrievousGladiator'sEmblemofCruelty-103210"
  value: {
-  dps: 94974.46766
-  tps: 628021.27197
-  dtps: 26908.39811
-  hps: 14870.97002
+  dps: 92672.01629
+  tps: 610591.07182
+  dtps: 30104.95499
+  hps: 15331.30504
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GrievousGladiator'sEmblemofMeditation-100307"
  value: {
-  dps: 91442.73865
-  tps: 606005.43212
-  dtps: 27298.33991
-  hps: 14874.6692
+  dps: 89253.28565
+  tps: 588832.90127
+  dtps: 30430.10597
+  hps: 15042.15258
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GrievousGladiator'sEmblemofMeditation-100559"
  value: {
-  dps: 91442.73865
-  tps: 606005.43212
-  dtps: 27298.33991
-  hps: 14874.6692
+  dps: 89253.28565
+  tps: 588832.90127
+  dtps: 30430.10597
+  hps: 15042.15258
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GrievousGladiator'sEmblemofMeditation-102813"
  value: {
-  dps: 91442.73865
-  tps: 606005.43212
-  dtps: 27298.33991
-  hps: 14874.6692
+  dps: 89253.28565
+  tps: 588832.90127
+  dtps: 30430.10597
+  hps: 15042.15258
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GrievousGladiator'sEmblemofMeditation-103212"
  value: {
-  dps: 91442.73865
-  tps: 606005.43212
-  dtps: 27298.33991
-  hps: 14874.6692
+  dps: 89253.28565
+  tps: 588832.90127
+  dtps: 30430.10597
+  hps: 15042.15258
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GrievousGladiator'sEmblemofTenacity-100306"
  value: {
-  dps: 91431.60874
-  tps: 606019.88532
-  dtps: 27122.54266
-  hps: 15111.56919
+  dps: 89371.15839
+  tps: 589861.11949
+  dtps: 30190.67806
+  hps: 15131.33391
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GrievousGladiator'sEmblemofTenacity-100652"
  value: {
-  dps: 91431.60874
-  tps: 606019.88532
-  dtps: 27122.54266
-  hps: 15111.56919
+  dps: 89371.15839
+  tps: 589861.11949
+  dtps: 30190.67806
+  hps: 15131.33391
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GrievousGladiator'sEmblemofTenacity-102903"
  value: {
-  dps: 91431.60874
-  tps: 606019.88532
-  dtps: 27122.54266
-  hps: 15111.56919
+  dps: 89371.15839
+  tps: 589861.11949
+  dtps: 30190.67806
+  hps: 15131.33391
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GrievousGladiator'sEmblemofTenacity-103211"
  value: {
-  dps: 91431.60874
-  tps: 606019.88532
-  dtps: 27122.54266
-  hps: 15111.56919
+  dps: 89371.15839
+  tps: 589861.11949
+  dtps: 30190.67806
+  hps: 15131.33391
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GrievousGladiator'sInsigniaofConquest-103150"
  value: {
-  dps: 96268.84809
-  tps: 636778.63479
-  dtps: 26399.62892
-  hps: 14834.81613
+  dps: 94163.66633
+  tps: 620153.28189
+  dtps: 29631.15664
+  hps: 15096.36249
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GrievousGladiator'sInsigniaofDominance-103309"
  value: {
-  dps: 91455.08421
-  tps: 605311.26809
-  dtps: 27242.09599
-  hps: 15085.70295
+  dps: 89388.45443
+  tps: 589169.52455
+  dtps: 30337.47718
+  hps: 15007.28092
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GrievousGladiator'sInsigniaofVictory-103319"
  value: {
-  dps: 92823.87618
-  tps: 614851.25256
-  dtps: 27185.78853
-  hps: 14850.3136
+  dps: 90644.5648
+  tps: 597739.34115
+  dtps: 30320.37965
+  hps: 14937.86862
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Hawkmaster'sTalon-89082"
  value: {
-  dps: 93515.79453
-  tps: 618042.05768
-  dtps: 26421.36459
-  hps: 14634.50501
+  dps: 92094.93286
+  tps: 607243.84841
+  dtps: 30038.32805
+  hps: 15253.0615
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Heart-LesionDefenderIdol-100999"
  value: {
-  dps: 91588.33631
-  tps: 606960.23378
-  dtps: 26470.42629
-  hps: 14816.83882
+  dps: 89559.36123
+  tps: 591179.09326
+  dtps: 29443.9025
+  hps: 14722.6708
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Heart-LesionDefenderStone-101002"
  value: {
-  dps: 91312.25029
-  tps: 605184.14036
-  dtps: 26981.10327
-  hps: 14981.0805
+  dps: 89506.2918
+  tps: 590807.28336
+  dtps: 29983.35683
+  hps: 15033.65678
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Heart-LesionIdolofBattle-100991"
  value: {
-  dps: 94956.74782
-  tps: 627984.71844
-  dtps: 26716.79105
-  hps: 14956.46619
+  dps: 92763.69623
+  tps: 611383.85104
+  dtps: 29914.84153
+  hps: 15057.28079
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Heart-LesionStoneofBattle-100990"
  value: {
-  dps: 92187.44096
-  tps: 610901.11874
-  dtps: 26974.57145
-  hps: 14830.44342
+  dps: 90053.52954
+  tps: 594129.82182
+  dtps: 30136.09823
+  hps: 14895.31815
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-HeartofFire-81181"
  value: {
-  dps: 91198.62415
-  tps: 604312.01793
-  dtps: 26900.33694
-  hps: 14654.74712
+  dps: 89383.59041
+  tps: 589755.10747
+  dtps: 29905.62706
+  hps: 14575.45964
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-HeartwarmerMedallion-93260"
  value: {
-  dps: 91147.59809
-  tps: 603860.42312
-  dtps: 27417.30584
-  hps: 15241.6569
+  dps: 89373.8236
+  tps: 589678.02168
+  dtps: 30251.83972
+  hps: 14848.97429
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-HelmbreakerMedallion-93261"
  value: {
-  dps: 94592.52591
-  tps: 625310.37815
-  dtps: 27081.51939
-  hps: 14979.99801
+  dps: 92369.60164
+  tps: 608266.46274
+  dtps: 30372.58449
+  hps: 15384.18334
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Horridon'sLastGasp-96757"
  value: {
-  dps: 91236.5037
-  tps: 604344.4017
-  dtps: 27347.88082
-  hps: 15087.80901
+  dps: 89560.07667
+  tps: 590773.21782
+  dtps: 30107.5492
+  hps: 14748.61953
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ImpassivePrimalDiamond"
  value: {
-  dps: 92350.88652
-  tps: 611954.42837
-  dtps: 27120.69879
-  hps: 15033.23085
+  dps: 90223.70281
+  tps: 595352.32864
+  dtps: 30250.92124
+  hps: 14979.11986
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-IndomitablePrimalDiamond"
  value: {
-  dps: 91351.66249
-  tps: 605278.17504
-  dtps: 27435.5102
-  hps: 15201.88009
+  dps: 89314.12025
+  tps: 589337.76752
+  dtps: 30360.26225
+  hps: 15181.5123
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-InscribedBagofHydra-Spawn-96828"
  value: {
-  dps: 91443.95338
-  tps: 605953.39508
-  dtps: 26712.21153
-  hps: 14695.33404
+  dps: 89161.31019
+  tps: 588267.93998
+  dtps: 29650.44764
+  hps: 14713.43648
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-InsigniaofKypariZar-84078"
  value: {
-  dps: 91363.63055
-  tps: 605346.65864
-  dtps: 27035.07178
-  hps: 14835.94469
+  dps: 89363.80337
+  tps: 589833.62682
+  dtps: 29865.94881
+  hps: 14652.26481
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-IronBellyWok-89083"
  value: {
-  dps: 92009.199
-  tps: 608123.47846
-  dtps: 26922.51362
-  hps: 14629.65098
+  dps: 90414.22817
+  tps: 595530.0495
+  dtps: 30618.45332
+  hps: 15163.88432
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-IronProtectorTalisman-85181"
  value: {
-  dps: 91319.1648
-  tps: 604897.90655
-  dtps: 27017.89388
-  hps: 15213.05508
+  dps: 89384.77452
+  tps: 589657.24893
+  dtps: 29767.47059
+  hps: 14783.53
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-JadeBanditFigurine-86043"
  value: {
-  dps: 93515.79453
-  tps: 618042.05768
-  dtps: 26421.36459
-  hps: 14634.50501
+  dps: 92094.93286
+  tps: 607243.84841
+  dtps: 30038.32805
+  hps: 15253.0615
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-JadeBanditFigurine-86772"
  value: {
-  dps: 93806.37571
-  tps: 619863.93697
-  dtps: 26707.08129
-  hps: 14878.16952
+  dps: 91990.26389
+  tps: 606166.97515
+  dtps: 29625.47821
+  hps: 14969.79604
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-JadeCharioteerFigurine-86042"
  value: {
-  dps: 92009.199
-  tps: 608123.47846
-  dtps: 26922.51362
-  hps: 14629.65098
+  dps: 90414.22817
+  tps: 595530.0495
+  dtps: 30618.45332
+  hps: 15163.88432
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-JadeCharioteerFigurine-86771"
  value: {
-  dps: 92125.43289
-  tps: 608251.81388
-  dtps: 27202.62277
-  hps: 14810.932
+  dps: 90282.83873
+  tps: 594656.6803
+  dtps: 30459.22134
+  hps: 15052.87846
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-JadeCourtesanFigurine-86045"
  value: {
-  dps: 91165.61374
-  tps: 603986.57128
-  dtps: 27400.47006
-  hps: 15209.67387
+  dps: 89373.8236
+  tps: 589678.02168
+  dtps: 30251.83972
+  hps: 14839.06215
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-JadeCourtesanFigurine-86774"
  value: {
-  dps: 91158.74006
-  tps: 603986.57128
-  dtps: 27398.07268
-  hps: 15157.25249
+  dps: 89366.73784
+  tps: 589678.0152
+  dtps: 30255.9439
+  hps: 14810.08063
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-JadeMagistrateFigurine-86044"
  value: {
-  dps: 93670.68283
-  tps: 618651.83364
-  dtps: 27032.08087
-  hps: 15123.03088
+  dps: 91697.39973
+  tps: 603705.01122
+  dtps: 30224.78657
+  hps: 15547.9547
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-JadeMagistrateFigurine-86773"
  value: {
-  dps: 93512.89877
-  tps: 617823.07777
-  dtps: 27038.51327
-  hps: 15106.57543
+  dps: 91366.25681
+  tps: 601591.23618
+  dtps: 30237.47662
+  hps: 15367.96582
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-JadeWarlordFigurine-86046"
  value: {
-  dps: 91569.9808
-  tps: 606701.12711
-  dtps: 26676.7828
-  hps: 14768.0407
+  dps: 89367.10374
+  tps: 589673.18795
+  dtps: 29989.45727
+  hps: 14954.73995
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-JadeWarlordFigurine-86775"
  value: {
-  dps: 91631.77153
-  tps: 607136.7115
-  dtps: 26689.32164
-  hps: 14682.28576
+  dps: 89330.20216
+  tps: 589414.53115
+  dtps: 29943.58645
+  hps: 14932.87145
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Ji-Kun'sRisingWinds-96843"
  value: {
-  dps: 91317.02512
-  tps: 605121.45861
-  dtps: 27228.78736
-  hps: 14874.11418
+  dps: 89330.31052
+  tps: 589382.43014
+  dtps: 30347.71331
+  hps: 14956.82158
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-KnightlyBadgeoftheShieldwall-93349"
  value: {
-  dps: 92058.2665
-  tps: 610079.4337
-  dtps: 27073.72009
-  hps: 14784.11675
+  dps: 89904.48462
+  tps: 593151.75874
+  dtps: 30016.85943
+  hps: 14633.08302
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-KnotofTenSongs-84073"
  value: {
-  dps: 91486.79738
-  tps: 606310.31484
-  dtps: 26745.01
-  hps: 14642.9792
+  dps: 89423.57272
+  tps: 590375.81547
+  dtps: 29929.16658
+  hps: 14733.4048
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Kor'kronBookofHurting-92785"
  value: {
-  dps: 91317.02512
-  tps: 605121.45861
-  dtps: 27228.78736
-  hps: 14866.14505
+  dps: 89370.48586
+  tps: 589663.94978
+  dtps: 30354.77053
+  hps: 14908.68354
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Lao-Chin'sLiquidCourage-89079"
  value: {
-  dps: 91569.9808
-  tps: 606701.12711
-  dtps: 26676.7828
-  hps: 14768.0407
+  dps: 89367.10374
+  tps: 589673.18795
+  dtps: 29989.45727
+  hps: 14954.73995
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-LeiShen'sFinalOrders-87072"
  value: {
-  dps: 92280.25291
-  tps: 611084.64314
-  dtps: 26797.08094
-  hps: 14801.81115
+  dps: 90719.31391
+  tps: 598904.22836
+  dtps: 29782.37132
+  hps: 14639.25782
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-LessonsoftheDarkmaster-81268"
  value: {
-  dps: 92017.96489
-  tps: 609389.02476
-  dtps: 27251.27227
-  hps: 14891.64448
+  dps: 90061.59729
+  tps: 593863.94607
+  dtps: 30296.69083
+  hps: 14810.0399
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-LightdrinkerIdolofRage-101200"
  value: {
-  dps: 93890.31423
-  tps: 621867.3605
-  dtps: 26338.61523
-  hps: 14670.2819
+  dps: 91804.80888
+  tps: 605628.4975
+  dtps: 29521.23595
+  hps: 14784.94214
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-LightdrinkerStoneofRage-101203"
  value: {
-  dps: 93943.62556
-  tps: 622956.96394
-  dtps: 26179.75591
-  hps: 14557.34032
+  dps: 91778.16114
+  tps: 606339.38004
+  dtps: 29349.5117
+  hps: 14521.09472
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-LightoftheCosmos-87065"
  value: {
-  dps: 91308.23711
-  tps: 604817.42724
-  dtps: 26792.74065
-  hps: 14782.12075
+  dps: 89791.08447
+  tps: 592945.62383
+  dtps: 29834.04474
+  hps: 14697.28547
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-LightweaveEmbroidery(Rank3)-4892"
  value: {
-  dps: 91442.41169
-  tps: 606139.03399
-  dtps: 26814.26455
-  hps: 14776.35627
+  dps: 89603.72589
+  tps: 591272.92229
+  dtps: 29895.81225
+  hps: 14797.80198
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-LordBlastington'sScopeofDoom-4699"
  value: {
-  dps: 91368.90911
-  tps: 605502.56197
-  dtps: 27826.49053
-  hps: 15300.58304
+  dps: 89399.33328
+  tps: 589934.21354
+  dtps: 30797.71725
+  hps: 15168.10387
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MalevolentGladiator'sBadgeofConquest-84934"
  value: {
-  dps: 93758.32851
-  tps: 620984.23027
-  dtps: 26638.11855
-  hps: 14749.17794
+  dps: 91585.52378
+  tps: 603839.19762
+  dtps: 29728.46575
+  hps: 14805.3664
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MalevolentGladiator'sBadgeofConquest-91452"
  value: {
-  dps: 93613.45008
-  tps: 620028.41258
-  dtps: 26649.19032
-  hps: 14722.13186
+  dps: 91392.88393
+  tps: 602549.54013
+  dtps: 29745.46021
+  hps: 14846.5795
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MalevolentGladiator'sBadgeofDominance-84940"
  value: {
-  dps: 91379.33457
-  tps: 605448.64734
-  dtps: 27337.51329
-  hps: 15062.59432
+  dps: 89412.87808
+  tps: 589918.72861
+  dtps: 30108.92705
+  hps: 14764.72284
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MalevolentGladiator'sBadgeofDominance-91753"
  value: {
-  dps: 91379.33457
-  tps: 605448.64734
-  dtps: 27337.51329
-  hps: 15056.78408
+  dps: 89412.87808
+  tps: 589918.72861
+  dtps: 30108.92705
+  hps: 14758.93861
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MalevolentGladiator'sBadgeofVictory-84942"
  value: {
-  dps: 92034.31526
-  tps: 609722.15876
-  dtps: 27202.6502
-  hps: 14831.57379
+  dps: 89991.78985
+  tps: 593588.63336
+  dtps: 30338.5269
+  hps: 14897.9643
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MalevolentGladiator'sBadgeofVictory-91763"
  value: {
-  dps: 91988.90791
-  tps: 609431.05874
-  dtps: 27204.03566
-  hps: 14830.6381
+  dps: 89948.47316
+  tps: 593312.50613
+  dtps: 30339.83752
+  hps: 14897.11565
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MalevolentGladiator'sEmblemofCruelty-84936"
  value: {
-  dps: 94093.85325
-  tps: 622740.7676
-  dtps: 26756.95286
-  hps: 14966.16962
+  dps: 91975.48515
+  tps: 606405.08352
+  dtps: 30101.38605
+  hps: 14959.22477
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MalevolentGladiator'sEmblemofCruelty-91562"
  value: {
-  dps: 93996.55479
-  tps: 622217.16104
-  dtps: 26774.96488
-  hps: 14866.9821
+  dps: 91686.82255
+  tps: 604617.37108
+  dtps: 30097.65454
+  hps: 14643.87291
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MalevolentGladiator'sEmblemofMeditation-84939"
  value: {
-  dps: 91442.73865
-  tps: 606005.43212
-  dtps: 27298.33991
-  hps: 14874.6692
+  dps: 89253.28565
+  tps: 588832.90127
+  dtps: 30430.10597
+  hps: 15042.15258
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MalevolentGladiator'sEmblemofMeditation-91564"
  value: {
-  dps: 91442.73865
-  tps: 606005.43212
-  dtps: 27298.33991
-  hps: 14874.6692
+  dps: 89253.28565
+  tps: 588832.90127
+  dtps: 30430.10597
+  hps: 15042.15258
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MalevolentGladiator'sEmblemofTenacity-84938"
  value: {
-  dps: 91286.38825
-  tps: 605002.7946
-  dtps: 27269.86373
-  hps: 15232.13543
+  dps: 89473.9995
+  tps: 590398.18413
+  dtps: 30198.92491
+  hps: 14893.95918
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MalevolentGladiator'sEmblemofTenacity-91563"
  value: {
-  dps: 91236.85139
-  tps: 604476.9868
-  dtps: 27402.23886
-  hps: 15398.90087
+  dps: 89449.97883
+  tps: 589964.82507
+  dtps: 30379.85872
+  hps: 14983.56198
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MalevolentGladiator'sInsigniaofConquest-91457"
  value: {
-  dps: 94349.70954
-  tps: 624632.60491
-  dtps: 26615.19742
-  hps: 14792.10262
+  dps: 92191.22953
+  tps: 607748.39084
+  dtps: 29683.06125
+  hps: 14776.09934
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MalevolentGladiator'sInsigniaofDominance-91754"
  value: {
-  dps: 91336.51494
-  tps: 605269.83482
-  dtps: 27186.69597
-  hps: 14940.95485
+  dps: 89362.89834
+  tps: 589458.49845
+  dtps: 30353.19253
+  hps: 14938.74118
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MalevolentGladiator'sInsigniaofVictory-91768"
  value: {
-  dps: 92320.17893
-  tps: 611587.77852
-  dtps: 27198.48271
-  hps: 14895.35318
+  dps: 90226.48362
+  tps: 595091.37677
+  dtps: 30359.94464
+  hps: 14917.9162
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MarkoftheCatacombs-83731"
  value: {
-  dps: 93065.07825
-  tps: 616308.96902
-  dtps: 26615.46063
-  hps: 14776.41139
+  dps: 90838.90209
+  tps: 599123.02865
+  dtps: 29610.8108
+  hps: 14565.11875
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MarkoftheHardenedGrunt-92783"
  value: {
-  dps: 91317.02512
-  tps: 605121.45861
-  dtps: 27228.78736
-  hps: 14866.14505
+  dps: 89370.48586
+  tps: 589663.94978
+  dtps: 30354.77053
+  hps: 14908.68354
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MedallionofMystifyingVapors-93257"
  value: {
-  dps: 91722.24488
-  tps: 607976.37827
-  dtps: 26208.30745
-  hps: 14349.31703
+  dps: 89405.52663
+  tps: 590249.38022
+  dtps: 29334.49273
+  hps: 14358.31779
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MedallionoftheCatacombs-83734"
  value: {
-  dps: 91214.51497
-  tps: 604421.32588
-  dtps: 27272.72533
-  hps: 14988.96473
+  dps: 89143.83693
+  tps: 588145.56973
+  dtps: 30019.23985
+  hps: 14571.09617
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MendingBadgeoftheShieldwall-93348"
  value: {
-  dps: 91244.30727
-  tps: 604585.9428
-  dtps: 27307.48079
-  hps: 15099.92027
+  dps: 89341.75628
+  tps: 589503.09063
+  dtps: 30255.9439
+  hps: 14769.09848
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MirrorScope-4700"
  value: {
-  dps: 91368.90911
-  tps: 605502.56197
-  dtps: 27826.49053
-  hps: 15300.58304
+  dps: 89399.33328
+  tps: 589934.21354
+  dtps: 30797.71725
+  hps: 15168.10387
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MistdancerDefenderIdol-101089"
  value: {
-  dps: 91588.33631
-  tps: 606960.23378
-  dtps: 26441.78009
-  hps: 14816.83882
+  dps: 89605.83915
+  tps: 591504.42025
+  dtps: 29554.94233
+  hps: 14865.36925
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MistdancerDefenderStone-101087"
  value: {
-  dps: 91312.25029
-  tps: 605184.14036
-  dtps: 26958.19753
-  hps: 14994.8527
+  dps: 89557.74121
+  tps: 591167.49661
+  dtps: 29879.28683
+  hps: 14974.21681
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MistdancerIdolofRage-101113"
  value: {
-  dps: 94502.8859
-  tps: 625830.23539
-  dtps: 26139.72225
-  hps: 14604.05624
+  dps: 91831.08146
+  tps: 605654.07362
+  dtps: 29381.09412
+  hps: 14316.03927
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MistdancerStoneofRage-101117"
  value: {
-  dps: 93862.4013
-  tps: 622388.17964
-  dtps: 26252.17626
-  hps: 14643.92884
+  dps: 91769.75333
+  tps: 606280.49001
+  dtps: 29388.9182
+  hps: 14596.34676
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MistdancerStoneofWisdom-101107"
  value: {
-  dps: 91265.65631
-  tps: 604823.70326
-  dtps: 27310.40164
-  hps: 15075.13799
+  dps: 89515.41376
+  tps: 590573.96576
+  dtps: 30255.39104
+  hps: 14944.83699
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MithrilWristwatch-87572"
  value: {
-  dps: 93837.94598
-  tps: 620818.04879
-  dtps: 26725.28026
-  hps: 14702.72301
+  dps: 91702.46469
+  tps: 604726.82221
+  dtps: 29929.84687
+  hps: 14676.24251
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MountainsageIdolofDestruction-101069"
  value: {
-  dps: 91836.4078
-  tps: 607914.62366
-  dtps: 26862.4832
-  hps: 14714.2481
+  dps: 89836.37851
+  tps: 592232.85471
+  dtps: 29898.68735
+  hps: 14521.22546
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MountainsageStoneofDestruction-101072"
  value: {
-  dps: 91170.8077
-  tps: 604022.88288
-  dtps: 27228.13436
-  hps: 15190.11512
+  dps: 89393.47294
+  tps: 589815.59839
+  dtps: 30138.62872
+  hps: 14808.86695
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-OathswornDefenderIdol-101303"
  value: {
-  dps: 91529.8648
-  tps: 606420.17756
-  dtps: 26539.09364
-  hps: 14922.50579
+  dps: 89613.79182
+  tps: 591776.63359
+  dtps: 29538.29739
+  hps: 14852.4973
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-OathswornDefenderStone-101306"
  value: {
-  dps: 91316.76261
-  tps: 605215.81706
-  dtps: 26855.3429
-  hps: 14924.42249
+  dps: 89438.71748
+  tps: 590325.32167
+  dtps: 29916.17124
+  hps: 15078.35587
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-OathswornIdolofBattle-101295"
  value: {
-  dps: 94956.78745
-  tps: 627960.41183
-  dtps: 26718.06209
-  hps: 14955.81623
+  dps: 92773.19574
+  tps: 611471.26111
+  dtps: 29895.64091
+  hps: 15005.93423
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-OathswornStoneofBattle-101294"
  value: {
-  dps: 92307.63588
-  tps: 611742.85521
-  dtps: 27067.91081
-  hps: 14976.17001
+  dps: 90096.55616
+  tps: 594431.12435
+  dtps: 30171.37886
+  hps: 14854.75303
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-PhaseFingers-4697"
  value: {
-  dps: 91463.50907
-  tps: 606005.0483
-  dtps: 26827.87611
-  hps: 14801.51225
+  dps: 89548.98458
+  tps: 590915.56984
+  dtps: 29891.3551
+  hps: 14808.67869
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-PouchofWhiteAsh-103639"
  value: {
-  dps: 91317.02512
-  tps: 605121.45861
-  dtps: 27228.78736
-  hps: 14866.14505
+  dps: 89370.48586
+  tps: 589663.94978
+  dtps: 30354.77053
+  hps: 14908.68354
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-PowerfulPrimalDiamond"
  value: {
-  dps: 91351.66249
-  tps: 605278.17504
-  dtps: 27435.5102
-  hps: 15201.88009
+  dps: 89314.12025
+  tps: 589337.76752
+  dtps: 30360.26225
+  hps: 15181.5123
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-PriceofProgress-81266"
  value: {
-  dps: 91244.30727
-  tps: 604585.9428
-  dtps: 27320.78941
-  hps: 15104.29857
+  dps: 89340.28045
+  tps: 589492.7772
+  dtps: 30255.9439
+  hps: 14746.89165
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-PridefulGladiator'sBadgeofConquest-102659"
  value: {
-  dps: 95848.14049
-  tps: 634028.45443
-  dtps: 26399.95769
-  hps: 14838.14465
+  dps: 93841.15204
+  tps: 618277.37628
+  dtps: 29515.41838
+  hps: 14971.59217
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-PridefulGladiator'sBadgeofConquest-103342"
  value: {
-  dps: 95848.14049
-  tps: 634028.45443
-  dtps: 26399.95769
-  hps: 14838.14465
+  dps: 93841.15204
+  tps: 618277.37628
+  dtps: 29515.41838
+  hps: 14971.59217
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-PridefulGladiator'sBadgeofDominance-102633"
  value: {
-  dps: 91531.38698
-  tps: 606120.99828
-  dtps: 27267.44456
-  hps: 14991.62041
+  dps: 89470.90551
+  tps: 589918.78555
+  dtps: 30129.42848
+  hps: 14855.38926
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-PridefulGladiator'sBadgeofDominance-103505"
  value: {
-  dps: 91531.38698
-  tps: 606120.99828
-  dtps: 27267.44456
-  hps: 14991.62041
+  dps: 89470.90551
+  tps: 589918.78555
+  dtps: 30129.42848
+  hps: 14855.38926
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-PridefulGladiator'sBadgeofVictory-102636"
  value: {
-  dps: 92650.51796
-  tps: 613672.53226
-  dtps: 27231.17869
-  hps: 14915.7445
+  dps: 90571.76247
+  tps: 597280.56328
+  dtps: 30272.73472
+  hps: 14873.86741
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-PridefulGladiator'sBadgeofVictory-103511"
  value: {
-  dps: 92650.51796
-  tps: 613672.53226
-  dtps: 27231.17869
-  hps: 14915.7445
+  dps: 90571.76247
+  tps: 597280.56328
+  dtps: 30272.73472
+  hps: 14873.86741
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-PridefulGladiator'sEmblemofCruelty-102680"
  value: {
-  dps: 95749.40124
-  tps: 633166.27118
-  dtps: 26620.65182
-  hps: 14766.83307
+  dps: 93910.45757
+  tps: 618811.59144
+  dtps: 29925.79318
+  hps: 15370.72202
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-PridefulGladiator'sEmblemofCruelty-103407"
  value: {
-  dps: 95749.40124
-  tps: 633166.27118
-  dtps: 26620.65182
-  hps: 14766.83307
+  dps: 93910.45757
+  tps: 618811.59144
+  dtps: 29925.79318
+  hps: 15370.72202
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-PridefulGladiator'sEmblemofMeditation-102616"
  value: {
-  dps: 91442.73865
-  tps: 606005.43212
-  dtps: 27298.33991
-  hps: 14874.6692
+  dps: 89253.28565
+  tps: 588832.90127
+  dtps: 30430.10597
+  hps: 15042.15258
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-PridefulGladiator'sEmblemofMeditation-103409"
  value: {
-  dps: 91442.73865
-  tps: 606005.43212
-  dtps: 27298.33991
-  hps: 14874.6692
+  dps: 89253.28565
+  tps: 588832.90127
+  dtps: 30430.10597
+  hps: 15042.15258
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-PridefulGladiator'sEmblemofTenacity-102706"
  value: {
-  dps: 91642.06546
-  tps: 607627.77144
-  dtps: 26799.82023
-  hps: 14830.52696
+  dps: 89195.71273
+  tps: 588632.71278
+  dtps: 30323.471
+  hps: 15198.41027
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-PridefulGladiator'sEmblemofTenacity-103408"
  value: {
-  dps: 91642.06546
-  tps: 607627.77144
-  dtps: 26799.82023
-  hps: 14830.52696
+  dps: 89195.71273
+  tps: 588632.71278
+  dtps: 30323.471
+  hps: 15198.41027
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-PridefulGladiator'sInsigniaofConquest-103347"
  value: {
-  dps: 97743.60005
-  tps: 646472.03274
-  dtps: 26166.5029
-  hps: 14857.17269
+  dps: 95248.44374
+  tps: 627077.04962
+  dtps: 29612.15654
+  hps: 15272.66153
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-PridefulGladiator'sInsigniaofDominance-103506"
  value: {
-  dps: 91416.84755
-  tps: 605228.82807
-  dtps: 27242.09599
-  hps: 15152.73651
+  dps: 89373.50117
+  tps: 589071.72276
+  dtps: 30374.39986
+  hps: 15153.04486
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-PridefulGladiator'sInsigniaofVictory-103516"
  value: {
-  dps: 93195.30737
-  tps: 617240.74846
-  dtps: 27220.16304
-  hps: 15011.86774
+  dps: 91062.71736
+  tps: 600436.17562
+  dtps: 30316.14003
+  hps: 14976.02483
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Primordius'TalismanofRage-96873"
  value: {
-  dps: 97186.59392
-  tps: 642492.76345
-  dtps: 26658.13095
-  hps: 14805.28287
+  dps: 94803.81758
+  tps: 624626.92836
+  dtps: 29962.52502
+  hps: 15373.44465
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Qian-Le,CourageofNiuzao-102245"
  value: {
-  dps: 95142.07539
-  tps: 630534.33406
-  dtps: 25421.95489
-  hps: 14826.97957
+  dps: 92977.57303
+  tps: 613842.00483
+  dtps: 28587.60416
+  hps: 15016.55812
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Qian-Ying,FortitudeofNiuzao-102250"
  value: {
-  dps: 90480.89456
-  tps: 599438.29735
-  dtps: 26667.93773
-  hps: 14870.06392
+  dps: 88443.68828
+  tps: 583864.21488
+  dtps: 29598.20504
+  hps: 15025.25369
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Qin-xi'sPolarizingSeal-87075"
  value: {
-  dps: 91122.2323
-  tps: 603562.61017
-  dtps: 27333.08365
-  hps: 15042.10996
+  dps: 89357.02013
+  tps: 589435.92729
+  dtps: 30452.53034
+  hps: 15225.31439
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-RegaliaoftheEternalBlossom"
  value: {
-  dps: 73059.50076
-  tps: 485298.66084
-  dtps: 29137.83103
-  hps: 15138.81608
+  dps: 72919.75323
+  tps: 482961.24588
+  dtps: 32389.15202
+  hps: 15755.43186
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-RegaliaoftheHauntedForest"
  value: {
-  dps: 75375.7818
-  tps: 499659.18787
-  dtps: 27636.99482
-  hps: 15814.4849
+  dps: 74905.83308
+  tps: 495453.11533
+  dtps: 30820.90427
+  hps: 15650.69172
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-RegaliaoftheShatteredVale"
  value: {
-  dps: 78630.18233
-  tps: 520632.02363
-  dtps: 26824.8016
-  hps: 16020.34336
+  dps: 78477.31811
+  tps: 518378.76239
+  dtps: 30224.67665
+  hps: 16162.29246
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-RelicofChi-Ji-79330"
  value: {
-  dps: 91147.59809
-  tps: 603860.42312
-  dtps: 27417.30584
-  hps: 15242.32995
+  dps: 89373.8236
+  tps: 589678.02168
+  dtps: 30251.83972
+  hps: 14849.6532
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-RelicofKypariZar-84075"
  value: {
-  dps: 92434.46167
-  tps: 613265.70469
-  dtps: 26502.95815
-  hps: 14888.66114
+  dps: 90602.41589
+  tps: 598400.77906
+  dtps: 29528.17944
+  hps: 15332.21607
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-RelicofXuen-79327"
  value: {
-  dps: 92694.29335
-  tps: 614093.77262
-  dtps: 27185.70577
-  hps: 14907.38997
+  dps: 90650.70571
+  tps: 597950.20257
+  dtps: 30281.45009
+  hps: 14876.46212
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-RelicofXuen-79328"
  value: {
-  dps: 95945.2944
-  tps: 635433.15509
-  dtps: 26088.43483
-  hps: 14943.6241
+  dps: 93281.54729
+  tps: 615578.06951
+  dtps: 29201.21037
+  hps: 14989.92539
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-RelicofYu'lon-79331"
  value: {
-  dps: 91162.27064
-  tps: 603986.57128
-  dtps: 27363.84059
-  hps: 15092.82563
+  dps: 89370.45443
+  tps: 589678.02397
+  dtps: 30283.01608
+  hps: 14838.10117
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Renataki'sSoulCharm-96741"
  value: {
-  dps: 96965.94936
-  tps: 642396.51804
-  dtps: 26040.63924
-  hps: 14544.16289
+  dps: 94572.40264
+  tps: 623491.49522
+  dtps: 29270.3772
+  hps: 14631.09411
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ResolveofNiuzao-103690"
  value: {
-  dps: 91235.78158
-  tps: 604572.31836
-  dtps: 26636.22353
-  hps: 14458.0968
+  dps: 89262.80175
+  tps: 588898.739
+  dtps: 29624.03198
+  hps: 14633.03236
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ResolveofNiuzao-103990"
  value: {
-  dps: 91127.47435
-  tps: 603863.6612
-  dtps: 26525.13823
-  hps: 14677.63499
+  dps: 89410.86041
+  tps: 589936.21398
+  dtps: 29272.91662
+  hps: 14560.55788
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ReverberatingPrimalDiamond"
  value: {
-  dps: 92603.86008
-  tps: 613800.01441
-  dtps: 27566.45521
-  hps: 15253.39724
+  dps: 90811.96841
+  tps: 599361.85365
+  dtps: 30371.92299
+  hps: 15056.02406
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-RevitalizingPrimalDiamond"
  value: {
-  dps: 92431.37742
-  tps: 612659.47418
-  dtps: 27571.69799
-  hps: 15248.04336
+  dps: 90567.27283
+  tps: 597716.13263
+  dtps: 30381.57011
+  hps: 15053.24301
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-SI:7Operative'sManual-92784"
  value: {
-  dps: 91317.02512
-  tps: 605121.45861
-  dtps: 27228.78736
-  hps: 14866.14505
+  dps: 89370.48586
+  tps: 589663.94978
+  dtps: 30354.77053
+  hps: 14908.68354
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ScrollofReveredAncestors-89080"
  value: {
-  dps: 91165.61374
-  tps: 603986.57128
-  dtps: 27400.47006
-  hps: 15209.67387
+  dps: 89373.8236
+  tps: 589678.02168
+  dtps: 30251.83972
+  hps: 14839.06215
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Shock-ChargerMedallion-93259"
  value: {
-  dps: 91153.50306
-  tps: 604212.14092
-  dtps: 26784.14581
-  hps: 15117.03312
+  dps: 89400.47823
+  tps: 590550.36608
+  dtps: 29739.81909
+  hps: 14930.79734
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-SigilofCompassion-83736"
  value: {
-  dps: 91214.51497
-  tps: 604421.32588
-  dtps: 27272.72533
-  hps: 14988.96473
+  dps: 89143.83693
+  tps: 588145.56973
+  dtps: 30019.23985
+  hps: 14571.09617
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-SigilofDevotion-83740"
  value: {
-  dps: 93232.92895
-  tps: 617419.76819
-  dtps: 26566.00772
-  hps: 14564.95591
+  dps: 90598.51776
+  tps: 597338.46621
+  dtps: 29853.96771
+  hps: 14790.2211
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-SigilofFidelity-83737"
  value: {
-  dps: 93457.19254
-  tps: 618850.41288
-  dtps: 26589.06742
-  hps: 14537.15813
+  dps: 91376.81301
+  tps: 603640.3563
+  dtps: 29578.18123
+  hps: 14856.11009
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-SigilofGrace-83738"
  value: {
-  dps: 91564.42765
-  tps: 607031.8853
-  dtps: 26671.11236
-  hps: 15117.99317
+  dps: 90231.21708
+  tps: 595808.40667
+  dtps: 29483.98023
+  hps: 14897.7987
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-SigilofKypariZar-84076"
  value: {
-  dps: 93159.32316
-  tps: 616954.91901
-  dtps: 26501.99369
-  hps: 14694.04291
+  dps: 90723.51155
+  tps: 598353.91868
+  dtps: 29739.44049
+  hps: 14769.65747
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-SigilofPatience-83739"
  value: {
-  dps: 91561.46553
-  tps: 606776.11437
-  dtps: 27127.7952
-  hps: 14845.17792
+  dps: 89054.63946
+  tps: 587452.55936
+  dtps: 30240.37932
+  hps: 14663.30365
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-SigiloftheCatacombs-83732"
  value: {
-  dps: 93303.57834
-  tps: 618073.15633
-  dtps: 26499.01165
-  hps: 15001.82635
+  dps: 91285.05164
+  tps: 601615.18266
+  dtps: 29710.27183
+  hps: 14781.38306
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-SinisterPrimalDiamond"
  value: {
-  dps: 91933.26377
-  tps: 609531.25545
-  dtps: 27247.41685
-  hps: 15065.14842
+  dps: 90013.19067
+  tps: 594330.1363
+  dtps: 30209.23798
+  hps: 15111.79776
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-SkullrenderMedallion-93256"
  value: {
-  dps: 94592.52591
-  tps: 625310.37815
-  dtps: 27081.51939
-  hps: 14979.99801
+  dps: 92369.60164
+  tps: 608266.46274
+  dtps: 30372.58449
+  hps: 15384.18334
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-SpiritsoftheSun-87163"
  value: {
-  dps: 91165.4694
-  tps: 603984.18693
-  dtps: 27341.79534
-  hps: 15067.36741
+  dps: 89403.00306
+  tps: 589882.31322
+  dtps: 30232.55895
+  hps: 14792.92088
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-SpringrainIdolofDestruction-101023"
  value: {
-  dps: 91811.45717
-  tps: 608019.56241
-  dtps: 26687.25389
-  hps: 14687.34652
+  dps: 89545.17638
+  tps: 590513.49092
+  dtps: 29877.41963
+  hps: 14819.2778
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-SpringrainIdolofRage-101009"
  value: {
-  dps: 94178.94808
-  tps: 623864.76711
-  dtps: 26333.29512
-  hps: 14745.23662
+  dps: 91801.95879
+  tps: 605384.12374
+  dtps: 29487.80655
+  hps: 14637.40379
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-SpringrainStoneofDestruction-101026"
  value: {
-  dps: 91169.10072
-  tps: 604010.97771
-  dtps: 27189.31668
-  hps: 15165.77416
+  dps: 89387.00742
+  tps: 589770.45792
+  dtps: 30059.29026
+  hps: 14716.08706
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-SpringrainStoneofRage-101012"
  value: {
-  dps: 93862.4013
-  tps: 622388.17964
-  dtps: 26289.76061
-  hps: 14655.13504
+  dps: 91769.75333
+  tps: 606280.49001
+  dtps: 29426.51667
+  hps: 14596.34676
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-SpringrainStoneofWisdom-101041"
  value: {
-  dps: 91131.90791
-  tps: 603681.23123
-  dtps: 27331.81463
-  hps: 15093.864
+  dps: 89411.21061
+  tps: 589745.90099
+  dtps: 30269.19338
+  hps: 14845.13555
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Static-Caster'sMedallion-93254"
  value: {
-  dps: 91153.50306
-  tps: 604212.14092
-  dtps: 26784.14581
-  hps: 15117.03312
+  dps: 89400.47823
+  tps: 590550.36608
+  dtps: 29739.81909
+  hps: 14930.79734
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-SteadfastFootman'sMedallion-92782"
  value: {
-  dps: 91317.02512
-  tps: 605121.45861
-  dtps: 27228.78736
-  hps: 14866.14505
+  dps: 89370.48586
+  tps: 589663.94978
+  dtps: 30354.77053
+  hps: 14908.68354
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-SteadfastTalismanoftheShado-PanAssault-94507"
  value: {
-  dps: 91235.27641
-  tps: 604672.41369
-  dtps: 26783.40384
-  hps: 14624.18417
+  dps: 89443.01332
+  tps: 590161.08899
+  dtps: 29606.91744
+  hps: 14669.05031
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-StreamtalkerIdolofDestruction-101222"
  value: {
-  dps: 91137.51147
-  tps: 603774.85512
-  dtps: 26914.72431
-  hps: 14691.01999
+  dps: 89303.45234
+  tps: 589142.74377
+  dtps: 29775.03536
+  hps: 14591.23803
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-StreamtalkerIdolofRage-101217"
  value: {
-  dps: 94204.06907
-  tps: 624573.38853
-  dtps: 26199.12823
-  hps: 14503.90849
+  dps: 91859.4717
+  tps: 606197.92133
+  dtps: 29257.13368
+  hps: 14768.9111
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-StreamtalkerStoneofDestruction-101225"
  value: {
-  dps: 91270.23924
-  tps: 604642.10425
-  dtps: 27027.82461
-  hps: 14992.71444
+  dps: 89380.05336
+  tps: 589721.71098
+  dtps: 29958.88686
+  hps: 14737.37253
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-StreamtalkerStoneofRage-101220"
  value: {
-  dps: 93701.02348
-  tps: 621258.12375
-  dtps: 26318.17291
-  hps: 14657.03809
+  dps: 91735.37113
+  tps: 606039.73825
+  dtps: 29431.06953
+  hps: 14617.39948
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-StreamtalkerStoneofWisdom-101250"
  value: {
-  dps: 91258.23189
-  tps: 604418.19808
-  dtps: 27391.973
-  hps: 15169.54672
+  dps: 89472.76119
+  tps: 590190.02836
+  dtps: 30278.00489
+  hps: 14910.55848
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-StuffofNightmares-87160"
  value: {
-  dps: 91298.63341
-  tps: 605006.6613
-  dtps: 26163.65312
-  hps: 14508.34474
+  dps: 89369.39997
+  tps: 589779.62671
+  dtps: 29144.66652
+  hps: 14652.65895
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-SunsoulDefenderIdol-101160"
  value: {
-  dps: 91321.54168
-  tps: 605249.35526
-  dtps: 26697.35734
-  hps: 15000.38659
+  dps: 89510.55747
+  tps: 591053.87586
+  dtps: 29507.66671
+  hps: 14775.06761
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-SunsoulDefenderStone-101163"
  value: {
-  dps: 91330.47371
-  tps: 605311.75262
-  dtps: 26914.90909
-  hps: 14915.30036
+  dps: 89582.67014
+  tps: 591342.02822
+  dtps: 29910.12729
+  hps: 15045.55427
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-SunsoulIdolofBattle-101152"
  value: {
-  dps: 95004.2894
-  tps: 628284.525
-  dtps: 26696.74815
-  hps: 14887.59369
+  dps: 92806.87879
+  tps: 611643.03257
+  dtps: 29915.22921
+  hps: 15100.26378
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-SunsoulStoneofBattle-101151"
  value: {
-  dps: 92123.54997
-  tps: 610453.77219
-  dtps: 27082.59568
-  hps: 14911.52976
+  dps: 90070.94989
+  tps: 594251.80862
+  dtps: 30113.44869
+  hps: 14862.61163
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-SunsoulStoneofWisdom-101138"
  value: {
-  dps: 91170.63805
-  tps: 604021.74227
-  dtps: 27451.20552
-  hps: 15178.40094
+  dps: 89394.92198
+  tps: 589825.44324
+  dtps: 30276.1761
+  hps: 14843.90432
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-SwordguardEmbroidery(Rank3)-4894"
  value: {
-  dps: 92141.17697
-  tps: 610518.34187
-  dtps: 26892.8423
-  hps: 14816.45356
+  dps: 90221.62308
+  tps: 595189.38089
+  dtps: 29936.89963
+  hps: 14787.9843
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-SymboloftheCatacombs-83735"
  value: {
-  dps: 93235.38335
-  tps: 616170.08641
-  dtps: 26872.63546
-  hps: 14834.69341
+  dps: 90998.60057
+  tps: 599050.32969
+  dtps: 29891.18942
+  hps: 14838.16951
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-SynapseSprings(MarkII)-4898"
  value: {
-  dps: 92476.32183
-  tps: 612716.41284
-  dtps: 26905.01593
-  hps: 14990.49425
+  dps: 90096.56931
+  tps: 594218.48519
+  dtps: 29908.93031
+  hps: 14869.23989
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TalismanofBloodlust-96864"
  value: {
-  dps: 97315.56494
-  tps: 644890.07318
-  dtps: 25705.12853
-  hps: 14891.27204
+  dps: 94823.19073
+  tps: 626251.35715
+  dtps: 28278.4328
+  hps: 14899.24607
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TerrorintheMists-87167"
  value: {
-  dps: 97870.38554
-  tps: 645601.62982
-  dtps: 26027.06847
-  hps: 14861.33346
+  dps: 95098.31848
+  tps: 624557.10077
+  dtps: 29464.36978
+  hps: 15390.18644
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TheGloamingBlade-88149"
  value: {
-  dps: 91368.7205
-  tps: 605544.30441
-  dtps: 26836.27007
-  hps: 14794.33237
+  dps: 89590.41678
+  tps: 591312.62685
+  dtps: 29908.45774
+  hps: 14827.42116
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Thousand-YearPickledEgg-87573"
  value: {
-  dps: 91030.99616
-  tps: 602933.53314
-  dtps: 26947.53917
-  hps: 14737.22043
+  dps: 89702.9224
+  tps: 591633.58089
+  dtps: 30117.80417
+  hps: 15323.71634
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TrailseekerIdolofRage-101054"
  value: {
-  dps: 94377.54225
-  tps: 625182.18287
-  dtps: 26106.35706
-  hps: 14505.02064
+  dps: 91875.24521
+  tps: 605750.84623
+  dtps: 29359.82088
+  hps: 14763.62374
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TrailseekerStoneofRage-101057"
  value: {
-  dps: 93701.02348
-  tps: 621258.12375
-  dtps: 26291.05507
-  hps: 14657.03809
+  dps: 91763.53492
+  tps: 606313.85185
+  dtps: 29348.18109
+  hps: 14594.72808
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TyrannicalGladiator'sBadgeofConquest-100043"
  value: {
-  dps: 94188.04269
-  tps: 623553.90469
-  dtps: 26479.56298
-  hps: 14727.31153
+  dps: 91867.0056
+  tps: 605690.83877
+  dtps: 29628.04122
+  hps: 14728.23035
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TyrannicalGladiator'sBadgeofConquest-91099"
  value: {
-  dps: 94188.04269
-  tps: 623553.90469
-  dtps: 26479.56298
-  hps: 14727.31153
+  dps: 91867.0056
+  tps: 605690.83877
+  dtps: 29628.04122
+  hps: 14728.23035
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TyrannicalGladiator'sBadgeofConquest-94373"
  value: {
-  dps: 94188.04269
-  tps: 623553.90469
-  dtps: 26479.56298
-  hps: 14727.31153
+  dps: 91867.0056
+  tps: 605690.83877
+  dtps: 29628.04122
+  hps: 14728.23035
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TyrannicalGladiator'sBadgeofConquest-99772"
  value: {
-  dps: 94188.04269
-  tps: 623553.90469
-  dtps: 26479.56298
-  hps: 14727.31153
+  dps: 91867.0056
+  tps: 605690.83877
+  dtps: 29628.04122
+  hps: 14728.23035
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TyrannicalGladiator'sBadgeofDominance-100016"
  value: {
-  dps: 91382.89041
-  tps: 605448.64734
-  dtps: 27337.51329
-  hps: 15074.28608
+  dps: 89416.43392
+  tps: 589918.72861
+  dtps: 30108.92705
+  hps: 14777.79674
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TyrannicalGladiator'sBadgeofDominance-91400"
  value: {
-  dps: 91382.89041
-  tps: 605448.64734
-  dtps: 27337.51329
-  hps: 15074.28608
+  dps: 89416.43392
+  tps: 589918.72861
+  dtps: 30108.92705
+  hps: 14777.79674
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TyrannicalGladiator'sBadgeofDominance-94346"
  value: {
-  dps: 91382.89041
-  tps: 605448.64734
-  dtps: 27337.51329
-  hps: 15074.28608
+  dps: 89416.43392
+  tps: 589918.72861
+  dtps: 30108.92705
+  hps: 14777.79674
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TyrannicalGladiator'sBadgeofDominance-99937"
  value: {
-  dps: 91382.89041
-  tps: 605448.64734
-  dtps: 27337.51329
-  hps: 15074.28608
+  dps: 89416.43392
+  tps: 589918.72861
+  dtps: 30108.92705
+  hps: 14777.79674
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TyrannicalGladiator'sBadgeofVictory-100019"
  value: {
-  dps: 92125.68709
-  tps: 610307.93058
-  dtps: 27199.7632
-  hps: 14833.45665
+  dps: 90037.52253
+  tps: 593853.95825
+  dtps: 30347.71864
+  hps: 14934.3344
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TyrannicalGladiator'sBadgeofVictory-91410"
  value: {
-  dps: 92125.68709
-  tps: 610307.93058
-  dtps: 27199.7632
-  hps: 14833.45665
+  dps: 90037.52253
+  tps: 593853.95825
+  dtps: 30347.71864
+  hps: 14934.3344
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TyrannicalGladiator'sBadgeofVictory-94349"
  value: {
-  dps: 92125.68709
-  tps: 610307.93058
-  dtps: 27199.7632
-  hps: 14833.45665
+  dps: 90037.52253
+  tps: 593853.95825
+  dtps: 30347.71864
+  hps: 14934.3344
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TyrannicalGladiator'sBadgeofVictory-99943"
  value: {
-  dps: 92125.68709
-  tps: 610307.93058
-  dtps: 27199.7632
-  hps: 14833.45665
+  dps: 90037.52253
+  tps: 593853.95825
+  dtps: 30347.71864
+  hps: 14934.3344
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TyrannicalGladiator'sEmblemofCruelty-100066"
  value: {
-  dps: 93975.62384
-  tps: 622061.20633
-  dtps: 26936.65424
-  hps: 15056.02368
+  dps: 91927.87619
+  tps: 606322.6043
+  dtps: 30132.20114
+  hps: 15225.0815
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TyrannicalGladiator'sEmblemofCruelty-91209"
  value: {
-  dps: 93975.62384
-  tps: 622061.20633
-  dtps: 26936.65424
-  hps: 15056.02368
+  dps: 91927.87619
+  tps: 606322.6043
+  dtps: 30132.20114
+  hps: 15225.0815
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TyrannicalGladiator'sEmblemofCruelty-94396"
  value: {
-  dps: 93975.62384
-  tps: 622061.20633
-  dtps: 26936.65424
-  hps: 15056.02368
+  dps: 91927.87619
+  tps: 606322.6043
+  dtps: 30132.20114
+  hps: 15225.0815
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TyrannicalGladiator'sEmblemofCruelty-99838"
  value: {
-  dps: 93975.62384
-  tps: 622061.20633
-  dtps: 26936.65424
-  hps: 15056.02368
+  dps: 91927.87619
+  tps: 606322.6043
+  dtps: 30132.20114
+  hps: 15225.0815
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TyrannicalGladiator'sEmblemofMeditation-91211"
  value: {
-  dps: 91442.73865
-  tps: 606005.43212
-  dtps: 27298.33991
-  hps: 14874.6692
+  dps: 89253.28565
+  tps: 588832.90127
+  dtps: 30430.10597
+  hps: 15042.15258
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TyrannicalGladiator'sEmblemofMeditation-94329"
  value: {
-  dps: 91442.73865
-  tps: 606005.43212
-  dtps: 27298.33991
-  hps: 14874.6692
+  dps: 89253.28565
+  tps: 588832.90127
+  dtps: 30430.10597
+  hps: 15042.15258
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TyrannicalGladiator'sEmblemofMeditation-99840"
  value: {
-  dps: 91442.73865
-  tps: 606005.43212
-  dtps: 27298.33991
-  hps: 14874.6692
+  dps: 89253.28565
+  tps: 588832.90127
+  dtps: 30430.10597
+  hps: 15042.15258
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TyrannicalGladiator'sEmblemofMeditation-99990"
  value: {
-  dps: 91442.73865
-  tps: 606005.43212
-  dtps: 27298.33991
-  hps: 14874.6692
+  dps: 89253.28565
+  tps: 588832.90127
+  dtps: 30430.10597
+  hps: 15042.15258
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TyrannicalGladiator'sEmblemofTenacity-100092"
  value: {
-  dps: 91407.69524
-  tps: 605852.18544
-  dtps: 27249.25239
-  hps: 15214.94972
+  dps: 89475.41297
+  tps: 590408.07399
+  dtps: 30198.50195
+  hps: 14947.73688
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TyrannicalGladiator'sEmblemofTenacity-91210"
  value: {
-  dps: 91407.69524
-  tps: 605852.18544
-  dtps: 27249.25239
-  hps: 15214.94972
+  dps: 89475.41297
+  tps: 590408.07399
+  dtps: 30198.50195
+  hps: 14947.73688
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TyrannicalGladiator'sEmblemofTenacity-94422"
  value: {
-  dps: 91407.69524
-  tps: 605852.18544
-  dtps: 27249.25239
-  hps: 15214.94972
+  dps: 89475.41297
+  tps: 590408.07399
+  dtps: 30198.50195
+  hps: 14947.73688
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TyrannicalGladiator'sEmblemofTenacity-99839"
  value: {
-  dps: 91407.69524
-  tps: 605852.18544
-  dtps: 27249.25239
-  hps: 15214.94972
+  dps: 89475.41297
+  tps: 590408.07399
+  dtps: 30198.50195
+  hps: 14947.73688
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TyrannicalGladiator'sInsigniaofConquest-100026"
  value: {
-  dps: 94801.1313
-  tps: 627377.60511
-  dtps: 26674.53322
-  hps: 14845.66411
+  dps: 92649.94506
+  tps: 610527.64111
+  dtps: 29652.08695
+  hps: 14878.69376
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TyrannicalGladiator'sInsigniaofDominance-100152"
  value: {
-  dps: 91383.53898
-  tps: 605357.12679
-  dtps: 27186.69597
-  hps: 14887.80255
+  dps: 89401.07492
+  tps: 589472.38166
+  dtps: 30348.11171
+  hps: 15031.2761
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TyrannicalGladiator'sInsigniaofVictory-100085"
  value: {
-  dps: 92481.50153
-  tps: 612598.22385
-  dtps: 27196.62145
-  hps: 14897.11905
+  dps: 90439.83018
+  tps: 596462.11511
+  dtps: 30291.5701
+  hps: 14872.86286
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TyrannicalPrimalDiamond"
  value: {
-  dps: 91113.94148
-  tps: 603822.66909
-  dtps: 27656.3116
-  hps: 15360.79547
+  dps: 89277.27352
+  tps: 589152.51601
+  dtps: 30385.75124
+  hps: 15032.09687
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-UnerringVisionofLeiShen-96930"
  value: {
-  dps: 94753.01535
-  tps: 627139.80851
-  dtps: 26874.80127
-  hps: 15021.02676
+  dps: 92544.8725
+  tps: 610467.91393
+  dtps: 29993.46469
+  hps: 15031.80391
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-VaporshieldMedallion-93262"
  value: {
-  dps: 91722.24488
-  tps: 607976.37827
-  dtps: 26208.30745
-  hps: 14349.31703
+  dps: 89405.52663
+  tps: 590249.38022
+  dtps: 29334.49273
+  hps: 14358.31779
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-VialofDragon'sBlood-87063"
  value: {
-  dps: 91329.02508
-  tps: 605100.72305
-  dtps: 26041.56673
-  hps: 14249.37987
+  dps: 89405.21934
+  tps: 589895.88604
+  dtps: 29159.14054
+  hps: 14671.49104
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-VialofIchorousBlood-100963"
  value: {
-  dps: 91244.30727
-  tps: 604585.9428
-  dtps: 27307.48079
-  hps: 15092.12138
+  dps: 89324.10895
+  tps: 589379.58599
+  dtps: 30268.34223
+  hps: 14769.32419
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-VialofIchorousBlood-81264"
  value: {
-  dps: 91244.30727
-  tps: 604585.9428
-  dtps: 27320.78941
-  hps: 15104.29857
+  dps: 89340.28045
+  tps: 589492.7772
+  dtps: 30255.9439
+  hps: 14746.89165
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ViciousTalismanoftheShado-PanAssault-94511"
  value: {
-  dps: 95846.80905
-  tps: 632823.354
-  dtps: 26620.42969
-  hps: 14977.62121
+  dps: 93697.39543
+  tps: 616312.24268
+  dtps: 29792.4225
+  hps: 15302.91778
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-VisionofthePredator-81192"
  value: {
-  dps: 92362.41178
-  tps: 611505.55457
-  dtps: 27160.11292
-  hps: 15084.29874
+  dps: 90178.29402
+  tps: 594617.17785
+  dtps: 30123.16346
+  hps: 14871.47141
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-VolatileTalismanoftheShado-PanAssault-94510"
  value: {
-  dps: 91281.19098
-  tps: 604222.92985
-  dtps: 27109.99264
-  hps: 15291.22997
+  dps: 89888.52619
+  tps: 593480.16303
+  dtps: 29987.46039
+  hps: 15030.03992
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-WindsweptPages-81125"
  value: {
-  dps: 93699.247
-  tps: 621850.75101
-  dtps: 26277.77782
-  hps: 14970.20258
+  dps: 91940.91157
+  tps: 607895.60284
+  dtps: 29474.88327
+  hps: 14758.63629
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-WoundripperMedallion-93253"
  value: {
-  dps: 96539.59353
-  tps: 638475.59144
-  dtps: 26459.73075
-  hps: 15078.05335
+  dps: 94209.10555
+  tps: 620948.6329
+  dtps: 29637.86542
+  hps: 14823.02732
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Wushoolay'sFinalChoice-96785"
  value: {
-  dps: 91369.24653
-  tps: 605257.24451
-  dtps: 27256.34244
-  hps: 15047.96179
+  dps: 89454.92553
+  tps: 590087.14825
+  dtps: 30229.59583
+  hps: 14915.34875
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Xing-Ho,BreathofYu'lon-102246"
  value: {
-  dps: 90478.12047
-  tps: 599542.20839
-  dtps: 26165.17425
-  hps: 15140.90111
+  dps: 89223.24314
+  tps: 589419.68487
+  dtps: 29210.3654
+  hps: 15132.90906
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-YaungolFireCarrier-86518"
  value: {
-  dps: 92437.73194
-  tps: 612867.84311
-  dtps: 26857.69239
-  hps: 15033.82837
+  dps: 90151.78929
+  tps: 595168.02475
+  dtps: 29977.30277
+  hps: 15194.26454
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Yu'lon'sBite-103987"
  value: {
-  dps: 94092.31555
-  tps: 621929.37603
-  dtps: 26938.20972
-  hps: 14944.21271
+  dps: 91541.28705
+  tps: 602701.28828
+  dtps: 29998.65436
+  hps: 14930.73703
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ZenAlchemistStone-75274"
  value: {
-  dps: 94749.5093
-  tps: 627525.48252
-  dtps: 26045.0167
-  hps: 14539.71755
+  dps: 92195.78187
+  tps: 607673.38208
+  dtps: 29493.77818
+  hps: 14768.18692
  }
 }
 dps_results: {
  key: "TestGuardian-Average-Default"
  value: {
-  dps: 93751.86608
-  tps: 619159.73309
-  dtps: 26672.12232
-  hps: 15130.33479
+  dps: 92112.51995
+  tps: 606271.50271
+  dtps: 29858.53638
+  hps: 15368.22726
  }
 }
 dps_results: {
@@ -3192,9 +3192,9 @@ dps_results: {
 dps_results: {
  key: "TestGuardian-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 94091.59988
-  tps: 623344.25309
-  dtps: 26692.00759
-  hps: 14753.80451
+  dps: 90098.51766
+  tps: 594341.09599
+  dtps: 29954.95799
+  hps: 14938.21946
  }
 }

--- a/sim/encounters/msv/garajal_ai.go
+++ b/sim/encounters/msv/garajal_ai.go
@@ -185,7 +185,7 @@ func (ai *GarajalAI) registerTankSwapAuras() {
 	}
 
 	const voodooDollsDuration = time.Second * 71
-	const banishmentDuration = time.Second * 30
+	const banishmentDuration = time.Second * 15
 
 	ai.BanishmentAura = ai.TankUnit.RegisterAura(core.Aura{
 		Label:    "Banishment",
@@ -326,8 +326,8 @@ func (ai *GarajalAI) registerShadowBolt() {
 
 		Cast: core.CastConfig{
 			DefaultCast: core.Cast{
-				GCD:      core.BossGCD * 5,
-				CastTime: time.Second * 3,
+				GCD:      time.Millisecond * 2101,
+				CastTime: time.Millisecond * 2100,
 			},
 		},
 

--- a/sim/encounters/msv/garajal_ai.go
+++ b/sim/encounters/msv/garajal_ai.go
@@ -49,33 +49,28 @@ func createGarajalHeroicPreset(raidPrefix string, raidSize int32, bossHealth flo
 
 	targetPathNames := []string{raidPrefix + "/" + bossName}
 
-	for addIdx := int32(1); addIdx <= 3; addIdx++ {
-		currentAddName := addName + fmt.Sprintf(" - %d", addIdx)
+	core.AddPresetTarget(&core.PresetTarget{
+		PathPrefix: raidPrefix,
 
-		core.AddPresetTarget(&core.PresetTarget{
-			PathPrefix: raidPrefix,
+		Config: &proto.Target{
+			Id:      garajalAddID,
+			Name:    addName,
+			Level:   92,
+			MobType: proto.MobType_MobTypeDemon,
 
-			Config: &proto.Target{
-				Id:      garajalAddID*100 + addIdx, // hack to guarantee distinct IDs for each add
-				Name:    currentAddName,
-				Level:   92,
-				MobType: proto.MobType_MobTypeDemon,
+			Stats: stats.Stats{
+				stats.Health: addHealth,
+				stats.Armor:  24835, // TODO: verify add armor
+			}.ToProtoArray(),
 
-				Stats: stats.Stats{
-					stats.Health: addHealth,
-					stats.Armor:  24835, // TODO: verify add armor
-				}.ToProtoArray(),
+			TargetInputs:    []*proto.TargetInput{},
+			DisabledAtStart: true,
+		},
 
-				TargetInputs:    []*proto.TargetInput{},
-				DisabledAtStart: true,
-			},
+		AI: makeGarajalAI(raidSize, false),
+	})
 
-			AI: makeGarajalAI(raidSize, false),
-		})
-
-		targetPathNames = append(targetPathNames, raidPrefix+"/"+currentAddName)
-	}
-
+	targetPathNames = append(targetPathNames, raidPrefix + "/" + addName)
 	core.AddPresetEncounter(bossName, targetPathNames)
 }
 

--- a/sim/encounters/msv/garajal_ai.go
+++ b/sim/encounters/msv/garajal_ai.go
@@ -212,7 +212,7 @@ func (ai *GarajalAI) registerTankSwapAuras() {
 			ai.TankUnit.CurrentTarget = ai.AddUnits[0]
 		},
 
-		OnExpire: func(_ *core.Aura, sim *core.Simulation) {
+		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
 			sim.EnableTargetUnit(ai.BossUnit)
 
 			for _, addUnit := range ai.AddUnits {
@@ -220,6 +220,7 @@ func (ai *GarajalAI) registerTankSwapAuras() {
 			}
 
 			ai.BossUnit.AutoAttacks.CancelAutoSwing(sim)
+			aura.Unit.PseudoStats.InFrontOfTarget = false
 		},
 	})
 
@@ -234,6 +235,7 @@ func (ai *GarajalAI) registerTankSwapAuras() {
 			sim.EnableTargetUnit(ai.BossUnit)
 			ai.SharedShadowyAttackTimer.Set(sim.CurrentTime + core.DurationFromSeconds(8.0*sim.RandomFloat("Shadowy Attack Timing")))
 			ai.syncBossGCDToSwing(sim)
+			aura.Unit.PseudoStats.InFrontOfTarget = true
 
 			if sim.CurrentTime+voodooDollsDuration > ai.enableFrenzyAt {
 				core.StartPeriodicAction(sim, core.PeriodicActionOptions{

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -33,449 +33,449 @@ character_stats_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AgilePrimalDiamond"
  value: {
-  dps: 141836.11116
-  tps: 897365.35877
-  dtps: 26807.42661
+  dps: 143352.23285
+  tps: 903503.59228
+  dtps: 27593.16813
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AssuranceofConsequence-105472"
  value: {
-  dps: 140706.5913
-  tps: 890123.03922
-  dtps: 26744.3219
+  dps: 142063.59857
+  tps: 894474.78569
+  dtps: 27123.27012
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AusterePrimalDiamond"
  value: {
-  dps: 140105.43432
-  tps: 882462.50806
-  dtps: 26549.15713
+  dps: 140994.19167
+  tps: 892733.62565
+  dtps: 27569.60408
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BattleplateofResoundingRings"
  value: {
-  dps: 127722.86584
-  tps: 811417.07437
-  dtps: 28621.5806
+  dps: 128615.4097
+  tps: 810140.52296
+  dtps: 29820.43011
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BattleplateoftheLastMogu"
  value: {
-  dps: 145164.11523
-  tps: 905923.73259
-  dtps: 28169.97797
+  dps: 146845.6402
+  tps: 911395.52207
+  dtps: 29183.88451
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BattleplateofthePrehistoricMarauder"
  value: {
-  dps: 129630.85873
-  tps: 821207.14705
-  dtps: 27925.4239
+  dps: 132379.62837
+  tps: 828469.3771
+  dtps: 28766.47792
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BurningPrimalDiamond"
  value: {
-  dps: 141831.78674
-  tps: 897335.08789
-  dtps: 26807.42661
+  dps: 143347.90844
+  tps: 903473.3214
+  dtps: 27593.16813
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CapacitivePrimalDiamond"
  value: {
-  dps: 139518.81666
-  tps: 883995.28481
-  dtps: 26692.53071
+  dps: 141226.59275
+  tps: 885990.84669
+  dtps: 27573.59798
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CourageousPrimalDiamond"
  value: {
-  dps: 139871.19722
-  tps: 884761.65173
-  dtps: 26807.42661
+  dps: 141353.68039
+  tps: 890837.02505
+  dtps: 27593.16813
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DelicateVialoftheSanguinaire-96895"
  value: {
-  dps: 145947.04218
-  tps: 923545.3241
-  dtps: 26127.29546
+  dps: 147184.49974
+  tps: 925790.87412
+  dtps: 26489.39156
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DestructivePrimalDiamond"
  value: {
-  dps: 139539.62919
-  tps: 882983.64693
-  dtps: 26755.38041
+  dps: 141444.25889
+  tps: 886827.13915
+  dtps: 27543.47045
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EffulgentPrimalDiamond"
  value: {
-  dps: 139760.41956
-  tps: 883189.42093
-  dtps: 27070.64541
+  dps: 140877.1587
+  tps: 887211.34126
+  dtps: 27662.97531
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EmberPrimalDiamond"
  value: {
-  dps: 139871.19722
-  tps: 884761.65173
-  dtps: 26807.42661
+  dps: 141353.68039
+  tps: 890837.02505
+  dtps: 27593.16813
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnchantWeapon-BloodyDancingSteel-5125"
  value: {
-  dps: 141938.52005
-  tps: 894023.76879
-  dtps: 26748.85872
+  dps: 143742.45049
+  tps: 901475.54608
+  dtps: 27779.4685
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnchantWeapon-Colossus-4445"
  value: {
-  dps: 140445.23055
-  tps: 886757.32453
-  dtps: 26599.58815
+  dps: 141624.3809
+  tps: 889467.32378
+  dtps: 27182.22393
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnchantWeapon-JadeSpirit-4442"
  value: {
-  dps: 140522.31579
-  tps: 886714.98434
-  dtps: 27018.37864
+  dps: 142282.67465
+  tps: 888179.01936
+  dtps: 28013.79308
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnchantWeapon-River'sSong-4446"
  value: {
-  dps: 141932.24022
-  tps: 895543.71409
-  dtps: 26856.67914
+  dps: 141984.8286
+  tps: 892519.34082
+  dtps: 27592.38013
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnchantWeapon-SpiritofConquest-5124"
  value: {
-  dps: 140522.31579
-  tps: 886714.98434
-  dtps: 27018.37864
+  dps: 142282.67465
+  tps: 888179.01936
+  dtps: 28013.79308
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnchantWeapon-Windsong-4441"
  value: {
-  dps: 141267.4511
-  tps: 891091.43657
-  dtps: 26996.38373
+  dps: 142240.24799
+  tps: 896926.88076
+  dtps: 28023.91245
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnigmaticPrimalDiamond"
  value: {
-  dps: 139539.62919
-  tps: 882983.64693
-  dtps: 26755.38041
+  dps: 141444.25889
+  tps: 886827.13915
+  dtps: 27543.47045
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EternalPrimalDiamond"
  value: {
-  dps: 140054.10784
-  tps: 885085.04014
-  dtps: 26738.10115
+  dps: 140516.82152
+  tps: 883271.60165
+  dtps: 27583.68628
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EvilEyeofGalakras-105491"
  value: {
-  dps: 152679.15545
-  tps: 963532.28313
-  dtps: 26229.46187
+  dps: 154221.20888
+  tps: 971859.36558
+  dtps: 26893.14534
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FabledFeatherofJi-Kun-96842"
  value: {
-  dps: 145833.07107
-  tps: 914375.92862
-  dtps: 26150.09332
+  dps: 145941.81049
+  tps: 914606.12825
+  dtps: 26816.73333
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Fen-Yu,FuryofXuen-102248"
  value: {
-  dps: 145536.38346
-  tps: 925093.26778
-  dtps: 26944.51975
+  dps: 147247.45655
+  tps: 931738.58525
+  dtps: 27907.96095
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FleetPrimalDiamond"
  value: {
-  dps: 138954.95358
-  tps: 881477.4237
-  dtps: 26566.99819
+  dps: 141270.52884
+  tps: 888822.08261
+  dtps: 27595.67589
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForlornPrimalDiamond"
  value: {
-  dps: 139871.19722
-  tps: 884761.65173
-  dtps: 26807.42661
+  dps: 141353.68039
+  tps: 890837.02505
+  dtps: 27593.16813
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GazeoftheTwins-96915"
  value: {
-  dps: 150042.61024
-  tps: 944712.13299
-  dtps: 26109.81749
+  dps: 152031.18406
+  tps: 955960.70028
+  dtps: 26828.81884
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Gong-Lu,StrengthofXuen-102249"
  value: {
-  dps: 149925.47846
-  tps: 954971.66563
-  dtps: 26578.70608
+  dps: 152597.77028
+  tps: 959574.50974
+  dtps: 27684.05071
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Horridon'sLastGasp-96757"
  value: {
-  dps: 140614.67904
-  tps: 889560.32325
-  dtps: 26744.3219
+  dps: 141905.53148
+  tps: 894225.33456
+  dtps: 27143.8953
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpassivePrimalDiamond"
  value: {
-  dps: 139539.62919
-  tps: 882983.64693
-  dtps: 26755.38041
+  dps: 141444.25889
+  tps: 886827.13915
+  dtps: 27543.47045
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IndomitablePrimalDiamond"
  value: {
-  dps: 139760.41956
-  tps: 883189.42093
-  dtps: 27070.64541
+  dps: 140877.1587
+  tps: 887211.34126
+  dtps: 27662.97531
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InscribedBagofHydra-Spawn-96828"
  value: {
-  dps: 140614.67904
-  tps: 889560.32325
-  dtps: 26744.3219
+  dps: 141905.53148
+  tps: 894225.33456
+  dtps: 27143.8953
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Ji-Kun'sRisingWinds-96843"
  value: {
-  dps: 140614.67904
-  tps: 889560.32325
-  dtps: 26744.3219
+  dps: 141905.53148
+  tps: 894225.33456
+  dtps: 27143.8953
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PhaseFingers-4697"
  value: {
-  dps: 140960.32311
-  tps: 889438.11342
-  dtps: 27051.27003
+  dps: 142277.69404
+  tps: 891181.6449
+  dtps: 27721.72854
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PlateofResoundingRings"
  value: {
-  dps: 126905.96975
-  tps: 795211.67998
-  dtps: 27767.04086
+  dps: 127594.79561
+  tps: 795109.62353
+  dtps: 28315.05143
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PlateoftheLastMogu"
  value: {
-  dps: 136531.17988
-  tps: 852105.31267
-  dtps: 27495.09199
+  dps: 136469.27298
+  tps: 853273.28709
+  dtps: 28198.16969
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PlateofthePrehistoricMarauder"
  value: {
-  dps: 134765.72653
-  tps: 840325.69562
-  dtps: 29119.03867
+  dps: 135292.73024
+  tps: 843246.92697
+  dtps: 29302.5056
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PowerfulPrimalDiamond"
  value: {
-  dps: 139760.41956
-  tps: 883189.42093
-  dtps: 27070.64541
+  dps: 140877.1587
+  tps: 887211.34126
+  dtps: 27662.97531
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PriceofProgress-81266"
  value: {
-  dps: 140614.67904
-  tps: 889560.32325
-  dtps: 26744.3219
+  dps: 141905.53148
+  tps: 894225.33456
+  dtps: 27143.8953
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Primordius'TalismanofRage-96873"
  value: {
-  dps: 150472.45113
-  tps: 950877.50727
-  dtps: 26407.82582
+  dps: 153030.54609
+  tps: 963338.68116
+  dtps: 26789.74558
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Qian-Le,CourageofNiuzao-102245"
  value: {
-  dps: 140722.86334
-  tps: 887905.47253
-  dtps: 27088.37154
+  dps: 141701.71336
+  tps: 893837.79659
+  dtps: 28124.26011
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Qian-Ying,FortitudeofNiuzao-102250"
  value: {
-  dps: 144212.99179
-  tps: 907245.12345
-  dtps: 26647.91418
+  dps: 145384.98301
+  tps: 910120.13625
+  dtps: 27494.22453
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Renataki'sSoulCharm-96741"
  value: {
-  dps: 141133.23663
-  tps: 891234.23543
-  dtps: 26705.70697
+  dps: 142426.69046
+  tps: 897121.68269
+  dtps: 27227.12634
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ReverberatingPrimalDiamond"
  value: {
-  dps: 142852.91174
-  tps: 900670.73915
-  dtps: 26818.48379
+  dps: 143208.5297
+  tps: 902540.71446
+  dtps: 27720.59868
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RevitalizingPrimalDiamond"
  value: {
-  dps: 141831.78674
-  tps: 897335.08789
-  dtps: 26807.42661
+  dps: 143347.90844
+  tps: 903473.3214
+  dtps: 27593.16813
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SinisterPrimalDiamond"
  value: {
-  dps: 139518.81666
-  tps: 883995.28481
-  dtps: 26692.53071
+  dps: 141226.59275
+  tps: 885990.84669
+  dtps: 27573.59798
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SynapseSprings(MarkII)-4898"
  value: {
-  dps: 140960.32311
-  tps: 889438.11342
-  dtps: 27051.27003
+  dps: 142277.69404
+  tps: 891181.6449
+  dtps: 27721.72854
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TalismanofBloodlust-96864"
  value: {
-  dps: 142778.49476
-  tps: 897988.99952
-  dtps: 26830.4945
+  dps: 142858.97401
+  tps: 901605.31706
+  dtps: 27233.13334
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheGloamingBlade-88149"
  value: {
-  dps: 142852.91174
-  tps: 900670.73915
-  dtps: 26818.48379
+  dps: 143208.5297
+  tps: 902540.71446
+  dtps: 27720.59868
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TyrannicalPrimalDiamond"
  value: {
-  dps: 139871.19722
-  tps: 884761.65173
-  dtps: 26807.42661
+  dps: 141353.68039
+  tps: 890837.02505
+  dtps: 27593.16813
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-UnerringVisionofLeiShen-96930"
  value: {
-  dps: 147494.9687
-  tps: 931246.49344
-  dtps: 26550.32119
+  dps: 148731.21325
+  tps: 936447.39374
+  dtps: 27096.98004
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Wushoolay'sFinalChoice-96785"
  value: {
-  dps: 140614.67904
-  tps: 889560.32325
-  dtps: 26744.3219
+  dps: 141905.53148
+  tps: 894225.33456
+  dtps: 27143.8953
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Xing-Ho,BreathofYu'lon-102246"
  value: {
-  dps: 139881.85154
-  tps: 889571.27529
-  dtps: 26817.58239
+  dps: 141689.33007
+  tps: 892149.40597
+  dtps: 27954.98462
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-YaungolFireCarrier-86518"
  value: {
-  dps: 142852.91174
-  tps: 900670.73915
-  dtps: 26818.48379
+  dps: 143208.5297
+  tps: 902540.71446
+  dtps: 27720.59868
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ZenAlchemistStone-75274"
  value: {
-  dps: 144102.18943
-  tps: 911098.1856
-  dtps: 25505.92756
+  dps: 146152.50345
+  tps: 914938.62956
+  dtps: 26467.37458
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 141905.04353
-  tps: 894084.43791
-  dtps: 26772.03445
+  dps: 142885.02599
+  tps: 897088.86907
+  dtps: 27617.04192
  }
 }
 dps_results: {
@@ -625,8 +625,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 146318.82032
-  tps: 928744.56329
-  dtps: 26736.58645
+  dps: 146441.9487
+  tps: 921534.2768
+  dtps: 27980.3101
  }
 }

--- a/ui/druid/guardian/builds/garajal_default.build.json
+++ b/ui/druid/guardian/builds/garajal_default.build.json
@@ -149,7 +149,7 @@
     "reactionTimeMs": 100,
     "inFrontOfTarget": true,
     "healingModel": {
-      "hps": 37500,
+      "hps": 42500,
       "cadenceSeconds": 0.45,
       "cadenceVariation": 2.31,
       "absorbFrac": 0.18,
@@ -180,28 +180,18 @@
             "label": "Frenzy time",
             "tooltip": "Simulation time (in seconds) at which to disable tank swaps and enable the boss Frenzy buff",
             "numberValue": 256
+          },
+          {
+            "inputType": "Number",
+            "label": "Spiritual Grasp frequency",
+            "tooltip": "Average time (in seconds) between Spiritual Grasp hits, following an exponential distribution",
+            "numberValue": 8.25
           }
         ]
       },
       {
-        "id": 6699201,
-        "name": "Severer of Souls 25 H - 1",
-        "level": 92,
-        "mobType": "MobTypeDemon",
-        "stats": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,24835,0,758866,0,0],
-        "disabledAtStart": true
-      },
-      {
-        "id": 6699202,
-        "name": "Severer of Souls 25 H - 2",
-        "level": 92,
-        "mobType": "MobTypeDemon",
-        "stats": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,24835,0,758866,0,0],
-        "disabledAtStart": true
-      },
-      {
-        "id": 6699203,
-        "name": "Severer of Souls 25 H - 3",
+        "id": 66992,
+        "name": "Severer of Souls 25 H",
         "level": 92,
         "mobType": "MobTypeDemon",
         "stats": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,24835,0,758866,0,0],

--- a/ui/druid/guardian/builds/garajal_encounter_only.build.json
+++ b/ui/druid/guardian/builds/garajal_encounter_only.build.json
@@ -78,7 +78,7 @@
     "reactionTimeMs": 100,
     "inFrontOfTarget": true,
     "healingModel": {
-      "hps": 37500,
+      "hps": 42500,
       "cadenceSeconds": 0.45,
       "cadenceVariation": 2.31,
       "absorbFrac": 0.18,
@@ -109,28 +109,18 @@
             "label": "Frenzy time",
             "tooltip": "Simulation time (in seconds) at which to disable tank swaps and enable the boss Frenzy buff",
             "numberValue": 256
+          },
+          {
+            "inputType": "Number",
+            "label": "Spiritual Grasp frequency",
+            "tooltip": "Average time (in seconds) between Spiritual Grasp hits, following an exponential distribution",
+            "numberValue": 8.25
           }
         ]
       },
       {
-        "id": 6699201,
-        "name": "Severer of Souls 25 H - 1",
-        "level": 92,
-        "mobType": "MobTypeDemon",
-        "stats": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,24835,0,758866,0,0],
-        "disabledAtStart": true
-      },
-      {
-        "id": 6699202,
-        "name": "Severer of Souls 25 H - 2",
-        "level": 92,
-        "mobType": "MobTypeDemon",
-        "stats": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,24835,0,758866,0,0],
-        "disabledAtStart": true
-      },
-      {
-        "id": 6699203,
-        "name": "Severer of Souls 25 H - 3",
+        "id": 66992,
+        "name": "Severer of Souls 25 H",
         "level": 92,
         "mobType": "MobTypeDemon",
         "stats": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,24835,0,758866,0,0],

--- a/ui/monk/brewmaster/builds/garajal_default.build.json
+++ b/ui/monk/brewmaster/builds/garajal_default.build.json
@@ -176,7 +176,7 @@
     "inFrontOfTarget": true,
     "distanceFromTarget": 5,
     "healingModel": {
-      "hps": 37500,
+      "hps": 42500,
       "cadenceSeconds": 0.45,
       "cadenceVariation": 2.31,
       "absorbFrac": 0.18,
@@ -208,28 +208,18 @@
             "label": "Frenzy time",
             "tooltip": "Simulation time (in seconds) at which to disable tank swaps and enable the boss Frenzy buff",
             "numberValue": 256
+          },
+          {
+            "inputType": "Number",
+            "label": "Spiritual Grasp frequency",
+            "tooltip": "Average time (in seconds) between Spiritual Grasp hits, following an exponential distribution",
+            "numberValue": 8.25
           }
         ]
       },
       {
-        "id": 6699201,
-        "name": "Severer of Souls 25 H - 1",
-        "level": 92,
-        "mobType": "MobTypeDemon",
-        "stats": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,24835,0,758866,0,0],
-        "disabledAtStart": true
-      },
-      {
-        "id": 6699202,
-        "name": "Severer of Souls 25 H - 2",
-        "level": 92,
-        "mobType": "MobTypeDemon",
-        "stats": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,24835,0,758866,0,0],
-        "disabledAtStart": true
-      },
-      {
-        "id": 6699203,
-        "name": "Severer of Souls 25 H - 3",
+        "id": 66992,
+        "name": "Severer of Souls 25 H",
         "level": 92,
         "mobType": "MobTypeDemon",
         "stats": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,24835,0,758866,0,0],

--- a/ui/warrior/protection/builds/garajal_default.build.json
+++ b/ui/warrior/protection/builds/garajal_default.build.json
@@ -177,7 +177,7 @@
     "inFrontOfTarget": true,
     "distanceFromTarget": 15,
     "healingModel": {
-      "hps": 37500,
+      "hps": 42500,
       "cadenceSeconds": 0.45,
       "cadenceVariation": 2.31,
       "absorbFrac": 0.18,
@@ -209,28 +209,18 @@
             "label": "Frenzy time",
             "tooltip": "Simulation time (in seconds) at which to disable tank swaps and enable the boss Frenzy buff",
             "numberValue": 256
+          },
+          {
+            "inputType": "Number",
+            "label": "Spiritual Grasp frequency",
+            "tooltip": "Average time (in seconds) between Spiritual Grasp hits, following an exponential distribution",
+            "numberValue": 8.25
           }
         ]
       },
       {
-        "id": 6699201,
-        "name": "Severer of Souls 25 H - 1",
-        "level": 92,
-        "mobType": "MobTypeDemon",
-        "stats": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,24835,0,758866,0,0],
-        "disabledAtStart": true
-      },
-      {
-        "id": 6699202,
-        "name": "Severer of Souls 25 H - 2",
-        "level": 92,
-        "mobType": "MobTypeDemon",
-        "stats": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,24835,0,758866,0,0],
-        "disabledAtStart": true
-      },
-      {
-        "id": 6699203,
-        "name": "Severer of Souls 25 H - 3",
+        "id": 66992,
+        "name": "Severer of Souls 25 H",
         "level": 92,
         "mobType": "MobTypeDemon",
         "stats": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,24835,0,758866,0,0],


### PR DESCRIPTION
- Reduced add target count to 1 so that cleave pad damage is not counted towards sim DPS.
- Halved Banishment duration, but increased Shadowbolt cast frequency accordingly to match Vengeance decay profiles from logs.
- Added random Spiritual Grasp hits at a cadence and distribution fit to Beta logs. These also work as an incoming damage source for DPS sims.
- Fixed attack table to have the tank attack from behind when not getting hit.
- Updated tank sim preset builds accordingly (including an HPS adjustment after more log analysis).