### PR TITLE
Fix wowhead gearplanner importer

### DIFF
--- a/ui/core/components/individual_sim_ui/importers/individual_60u_importer.tsx
+++ b/ui/core/components/individual_sim_ui/importers/individual_60u_importer.tsx
@@ -80,7 +80,14 @@ export class Individual60UImporter<SpecType extends Spec> extends IndividualImpo
 
 		this.simUI.sim.db.lookupEquipmentSpec(equipmentSpec);
 
-		this.finishIndividualImport(this.simUI, charClass, race, equipmentSpec, talentsStr, null, []);
+		this.finishIndividualImport(this.simUI, {
+			charClass,
+			race,
+			equipmentSpec,
+			talentsStr,
+			glyphs: null,
+			professions: [],
+		});
 
 		if (hasRemovedRandomSuffix && modifiedItemNames.length) {
 			new Toast({

--- a/ui/core/components/individual_sim_ui/importers/individual_addon_importer.tsx
+++ b/ui/core/components/individual_sim_ui/importers/individual_addon_importer.tsx
@@ -104,7 +104,14 @@ export class IndividualAddonImporter<SpecType extends Spec> extends IndividualIm
 		});
 		const equipmentSpec = EquipmentSpec.fromJson(gearJson);
 
-		this.finishIndividualImport(this.simUI, charClass, race, equipmentSpec, talentsStr, glyphs, professions);
+		this.finishIndividualImport(this.simUI, {
+			charClass,
+			race,
+			equipmentSpec,
+			talentsStr,
+			glyphs,
+			professions,
+		});
 	}
 }
 

--- a/ui/core/components/individual_sim_ui/importers/individual_importer.tsx
+++ b/ui/core/components/individual_sim_ui/importers/individual_importer.tsx
@@ -23,12 +23,25 @@ export abstract class IndividualImporter<SpecType extends Spec> extends Importer
 
 	protected async finishIndividualImport<SpecType extends Spec>(
 		simUI: IndividualSimUI<SpecType>,
-		charClass: Class,
-		race: Race,
-		equipmentSpec: EquipmentSpec,
-		talentsStr: string,
-		glyphs: Glyphs | null,
-		professions: Array<Profession>,
+		{
+			charClass,
+			race,
+			equipmentSpec,
+			talentsStr,
+			glyphs,
+			professions,
+			missingEnchants = [],
+			missingItems = [],
+		}: {
+			charClass: Class;
+			race: Race;
+			equipmentSpec: EquipmentSpec;
+			talentsStr: string;
+			glyphs: Glyphs | null;
+			professions: Profession[];
+			missingEnchants?: number[];
+			missingItems?: number[];
+		},
 	): Promise<void> {
 		if (charClass != simUI.player.getClass()) {
 			throw new Error(`Wrong Class! Expected ${simUI.player.getPlayerClass().friendlyName} but found ${classNames.get(charClass)}!`);
@@ -37,14 +50,6 @@ export abstract class IndividualImporter<SpecType extends Spec> extends Importer
 		await Database.loadLeftoversIfNecessary(equipmentSpec);
 
 		const gear = simUI.sim.db.lookupEquipmentSpec(equipmentSpec);
-
-		const expectedEnchantIds = equipmentSpec.items.map(item => item.enchant);
-		const foundEnchantIds = gear.asSpec().items.map(item => item.enchant);
-		const missingEnchants = expectedEnchantIds.filter(expectedId => expectedId != 0 && !foundEnchantIds.includes(expectedId));
-
-		const expectedItemIds = equipmentSpec.items.map(item => item.id);
-		const foundItemIds = gear.asSpec().items.map(item => item.id);
-		const missingItems = expectedItemIds.filter(expectedId => !foundItemIds.includes(expectedId));
 
 		// Now update settings using the parsed values.
 		const eventID = TypedEvent.nextEventID();

--- a/ui/core/individual_sim_ui.tsx
+++ b/ui/core/individual_sim_ui.tsx
@@ -11,7 +11,7 @@ import {
 	IndividualJsonExporter,
 	IndividualLinkExporter,
 	IndividualPawnEPExporter,
-	IndividualWowheadGearPlannerExporter,
+	// IndividualWowheadGearPlannerExporter,
 } from './components/individual_sim_ui/exporters';
 import { GearTab } from './components/individual_sim_ui/gear_tab';
 import {
@@ -364,7 +364,9 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 		// request so that this can be re-enabled.
 		//this.bt = this.addBulkTab();
 
-		this.addTopbarComponents();
+		this.sim.waitForInit().then(() => {
+			this.addTopbarComponents();
+		});
 	}
 
 	applyDefaultConfigOptions(config: IndividualSimUIConfig<SpecType>): IndividualSimUIConfig<SpecType> {
@@ -491,7 +493,7 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 
 		this.simHeader.addExportLink('Link', new IndividualLinkExporter(this.rootElem, this), false);
 		this.simHeader.addExportLink('JSON', new IndividualJsonExporter(this.rootElem, this), true);
-		this.simHeader.addExportLink('WoWHead', new IndividualWowheadGearPlannerExporter(this.rootElem, this), false, false);
+		// this.simHeader.addExportLink('WoWHead', new IndividualWowheadGearPlannerExporter(this.rootElem, this), false, false);
 		// this.simHeader.addExportLink('60U Cata EP', new Individual60UEPExporter(this.rootElem, this), false);
 		this.simHeader.addExportLink('Pawn EP', new IndividualPawnEPExporter(this.rootElem, this), false);
 		this.simHeader.addExportLink('CLI', new IndividualCLIExporter(this.rootElem, this), true);

--- a/ui/core/proto_utils/database.ts
+++ b/ui/core/proto_utils/database.ts
@@ -345,11 +345,11 @@ export class Database {
 		return new ItemSwapGear(gearMap);
 	}
 
-	enchantSpellIdToEffectId(enchantSpellId: number): number {
+	enchantSpellIdToEnchant(enchantSpellId: number): Enchant | undefined {
 		const enchant = Object.values(this.enchantsBySlot)
 			.flat()
 			.find(enchant => enchant.spellId == enchantSpellId);
-		return enchant ? enchant.effectId : 0;
+		return enchant;
 	}
 
 	glyphItemToSpellId(itemId: number): number {


### PR DESCRIPTION
- Fixes Wowhead Gearplanner Importing
- NOTE: Wowhead is using different/broken enchant SpellIDs, so a lot of them are currently failing to import.