### PR TITLE
[Pet] Fixup attack speed multiplier inheritance 

### DIFF
--- a/sim/core/pet.go
+++ b/sim/core/pet.go
@@ -271,14 +271,18 @@ func (pet *Pet) Enable(sim *Simulation, petAgent PetAgent) {
 		// make sure to reset it to refresh focus
 		pet.focusBar.reset(sim)
 		pet.focusBar.enable(sim, sim.CurrentTime)
-		pet.focusBar.focusRegenMultiplier *= pet.Owner.PseudoStats.AttackSpeedMultiplier
+		if pet.hasResourceRegenInheritance {
+			pet.focusBar.focusRegenMultiplier *= pet.Owner.PseudoStats.AttackSpeedMultiplier
+		}
 	}
 
 	if pet.HasEnergyBar() {
 		// make sure to reset it to refresh energy
 		pet.energyBar.reset(sim)
 		pet.energyBar.enable(sim, sim.CurrentTime)
-		pet.energyBar.energyRegenMultiplier *= pet.Owner.PseudoStats.AttackSpeedMultiplier
+		if pet.hasResourceRegenInheritance {
+			pet.energyBar.energyRegenMultiplier *= pet.Owner.PseudoStats.AttackSpeedMultiplier
+		}
 	}
 }
 
@@ -313,7 +317,7 @@ func (pet *Pet) enableDynamicMeleeSpeed(sim *Simulation) {
 		panic("Pet already present in dynamic melee speed pet list!")
 	}
 
-	if math.Abs(pet.inheritedMeleeSpeedMultiplier - 1) > 1e-14 {
+	if math.Abs(pet.inheritedMeleeSpeedMultiplier-1) > 1e-14 {
 		panic(fmt.Sprintf("Pet melee speed multiplier was not reset properly! Current inherited value = %.17f", pet.inheritedMeleeSpeedMultiplier))
 	}
 
@@ -338,7 +342,7 @@ func (pet *Pet) resetDynamicMeleeSpeed(sim *Simulation) {
 		panic("Pet not present in dynamic melee speed pet list!")
 	}
 
-	pet.dynamicMeleeSpeedInheritance(sim, 1 / pet.inheritedMeleeSpeedMultiplier)
+	pet.dynamicMeleeSpeedInheritance(sim, 1/pet.inheritedMeleeSpeedMultiplier)
 	pet.dynamicMeleeSpeedInheritance = nil
 }
 
@@ -347,7 +351,7 @@ func (pet *Pet) enableDynamicCastSpeed(sim *Simulation) {
 		panic("Pet already present in dynamic cast speed pet list!")
 	}
 
-	if math.Abs(pet.inheritedCastSpeedMultiplier - 1) > 1e-14 {
+	if math.Abs(pet.inheritedCastSpeedMultiplier-1) > 1e-14 {
 		panic(fmt.Sprintf("Pet cast speed multiplier was not reset properly! Current inherited value = %.17f", pet.inheritedCastSpeedMultiplier))
 	}
 
@@ -371,7 +375,7 @@ func (pet *Pet) resetDynamicCastSpeed(sim *Simulation) {
 		panic("Pet not present in dynamic cast speed pet list!")
 	}
 
-	pet.dynamicCastSpeedInheritance(sim, 1 / pet.inheritedCastSpeedMultiplier)
+	pet.dynamicCastSpeedInheritance(sim, 1/pet.inheritedCastSpeedMultiplier)
 	pet.dynamicCastSpeedInheritance = nil
 }
 

--- a/sim/death_knight/ghoul_pet.go
+++ b/sim/death_knight/ghoul_pet.go
@@ -86,7 +86,7 @@ func (dk *DeathKnight) SetupGhoul(ghoulPet *GhoulPet, scalingCoef float64) {
 		AutoSwingMelee: true,
 	})
 
-	ghoulPet.Unit.EnableFocusBar(100, 10.0, false, nil)
+	ghoulPet.Unit.EnableFocusBar(100, 10.0, false, nil, true)
 
 	dk.AddPet(ghoulPet)
 }

--- a/sim/druid/feral/feral.go
+++ b/sim/druid/feral/feral.go
@@ -39,9 +39,10 @@ func NewFeralDruid(character *core.Character, options *proto.Player) *FeralDruid
 	cat.registerTreants()
 
 	cat.EnableEnergyBar(core.EnergyBarOptions{
-		MaxComboPoints: 5,
-		MaxEnergy:      100.0,
-		UnitClass:      proto.Class_ClassDruid,
+		MaxComboPoints:        5,
+		MaxEnergy:             100.0,
+		UnitClass:             proto.Class_ClassDruid,
+		HasHasteRatingScaling: true,
 	})
 	cat.EnableRageBar(core.RageBarOptions{BaseRageMultiplier: 2.5})
 
@@ -77,7 +78,7 @@ type FeralDruid struct {
 	Shred          *druid.DruidSpell
 	TigersFury     *druid.DruidSpell
 
-	tempSnapshotAura   *core.Aura
+	tempSnapshotAura *core.Aura
 }
 
 func (cat *FeralDruid) GetDruid() *druid.Druid {
@@ -146,11 +147,11 @@ func (cat *FeralDruid) applyMastery() {
 	razorClaws := cat.AddDynamicMod(core.SpellModConfig{
 		ClassMask:  druid.DruidSpellThrashCat | druid.DruidSpellRake | druid.DruidSpellRip,
 		Kind:       core.SpellMod_DamageDone_Pct,
-		FloatValue: BaseMasteryMod + MasteryModPerPoint * cat.GetMasteryPoints(),
+		FloatValue: BaseMasteryMod + MasteryModPerPoint*cat.GetMasteryPoints(),
 	})
 
 	cat.AddOnMasteryStatChanged(func(_ *core.Simulation, _ float64, newMasteryRating float64) {
-		razorClaws.UpdateFloatValue(BaseMasteryMod + MasteryModPerPoint * core.MasteryRatingToMasteryPoints(newMasteryRating))
+		razorClaws.UpdateFloatValue(BaseMasteryMod + MasteryModPerPoint*core.MasteryRatingToMasteryPoints(newMasteryRating))
 	})
 
 	razorClaws.Activate()

--- a/sim/druid/guardian/tank.go
+++ b/sim/druid/guardian/tank.go
@@ -36,9 +36,10 @@ func NewGuardianDruid(character *core.Character, options *proto.Player) *Guardia
 	bear.registerTreants()
 
 	bear.EnableEnergyBar(core.EnergyBarOptions{
-		MaxComboPoints: 5,
-		MaxEnergy:      100,
-		UnitClass:      proto.Class_ClassDruid,
+		MaxComboPoints:        5,
+		MaxEnergy:             100,
+		UnitClass:             proto.Class_ClassDruid,
+		HasHasteRatingScaling: true,
 	})
 	bear.EnableRageBar(core.RageBarOptions{
 		BaseRageMultiplier: 2.5,

--- a/sim/hunter/hunter.go
+++ b/sim/hunter/hunter.go
@@ -60,7 +60,7 @@ func NewHunter(character *core.Character, options *proto.Player, hunterOptions *
 	focusPerSecond := 4.0
 
 	kindredSpritsBonusFocus := core.TernaryFloat64(hunter.Spec == proto.Spec_SpecBeastMasteryHunter, 20, 0)
-	hunter.EnableFocusBar(100+kindredSpritsBonusFocus, focusPerSecond, true, nil)
+	hunter.EnableFocusBar(100+kindredSpritsBonusFocus, focusPerSecond, true, nil, true)
 
 	hunter.PseudoStats.CanParry = true
 

--- a/sim/hunter/pet.go
+++ b/sim/hunter/pet.go
@@ -164,7 +164,7 @@ func (hunter *Hunter) NewHunterPet() *HunterPet {
 			WHFocusIncreaseMod.Deactivate()
 			WHDamageMod.Deactivate()
 		}
-	})
+	}, true)
 
 	hp.EnableAutoAttacks(hp, core.AutoAttackOptions{
 		MainHand: core.Weapon{

--- a/sim/monk/monk.go
+++ b/sim/monk/monk.go
@@ -259,9 +259,10 @@ func NewMonk(character *core.Character, options *proto.MonkOptions, talents stri
 	monk.XuenPet = monk.NewXuen()
 
 	monk.EnableEnergyBar(core.EnergyBarOptions{
-		MaxComboPoints: 4,
-		MaxEnergy:      100.0,
-		UnitClass:      proto.Class_ClassMonk,
+		MaxComboPoints:        4,
+		MaxEnergy:             100.0,
+		UnitClass:             proto.Class_ClassMonk,
+		HasHasteRatingScaling: true,
 	})
 
 	monk.EnableAutoAttacks(monk, core.AutoAttackOptions{

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -257,9 +257,10 @@ func NewRogue(character *core.Character, options *proto.RogueOptions, talents st
 	}
 
 	rogue.EnableEnergyBar(core.EnergyBarOptions{
-		MaxComboPoints: 5,
-		MaxEnergy:      maxEnergy,
-		UnitClass:      proto.Class_ClassRogue,
+		MaxComboPoints:        5,
+		MaxEnergy:             maxEnergy,
+		UnitClass:             proto.Class_ClassRogue,
+		HasHasteRatingScaling: true,
 	})
 
 	rogue.EnableAutoAttacks(rogue, core.AutoAttackOptions{

--- a/sim/warlock/affliction/TestAffliction.results
+++ b/sim/warlock/affliction/TestAffliction.results
@@ -33,2632 +33,2632 @@ character_stats_results: {
 dps_results: {
  key: "TestAffliction-AllItems-AgilePrimalDiamond"
  value: {
-  dps: 90707.04204
-  tps: 64579.53845
+  dps: 90538.92236
+  tps: 64765.22938
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AlacrityofXuen-103989"
  value: {
-  dps: 86149.65587
-  tps: 61192.18486
+  dps: 85895.27204
+  tps: 61256.47147
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ArcaneBadgeoftheShieldwall-93347"
  value: {
-  dps: 91949.96296
-  tps: 65163.93203
+  dps: 91573.73881
+  tps: 65283.99487
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ArrowflightMedallion-93258"
  value: {
-  dps: 88697.01965
-  tps: 63087.49817
+  dps: 88115.01034
+  tps: 63028.65974
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AssuranceofConsequence-105472"
  value: {
-  dps: 86149.65587
-  tps: 61192.18486
+  dps: 85895.27204
+  tps: 61256.47147
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AusterePrimalDiamond"
  value: {
-  dps: 90018.83431
-  tps: 63978.49729
+  dps: 89835.44926
+  tps: 64136.6624
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BadJuju-96781"
  value: {
-  dps: 89208.56133
-  tps: 63642.13377
+  dps: 88953.2951
+  tps: 63705.53797
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BadgeofKypariZar-84079"
  value: {
-  dps: 87310.71302
-  tps: 62122.10268
+  dps: 87055.99426
+  tps: 62186.05436
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BlossomofPureSnow-89081"
  value: {
-  dps: 92590.76447
-  tps: 65912.40641
+  dps: 92043.86973
+  tps: 65831.06373
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BottleofInfiniteStars-87057"
  value: {
-  dps: 88276.22371
-  tps: 62895.40276
+  dps: 88021.22643
+  tps: 62959.07592
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BraidofTenSongs-84072"
  value: {
-  dps: 87310.71302
-  tps: 62122.10268
+  dps: 87055.99426
+  tps: 62186.05436
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Brawler'sStatue-87571"
  value: {
-  dps: 86149.65587
-  tps: 61192.18486
+  dps: 85895.27204
+  tps: 61256.47147
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BreathoftheHydra-96827"
  value: {
-  dps: 104547.78221
-  tps: 74186.00814
+  dps: 103887.68009
+  tps: 74382.59209
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BroochofMunificentDeeds-87500"
  value: {
-  dps: 86266.65795
-  tps: 61278.26898
+  dps: 86145.06648
+  tps: 61539.26996
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BrutalTalismanoftheShado-PanAssault-94508"
  value: {
-  dps: 86149.65587
-  tps: 61192.18486
+  dps: 85895.27204
+  tps: 61256.47147
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BurningPrimalDiamond"
  value: {
-  dps: 91484.61296
-  tps: 65118.44835
+  dps: 91334.57737
+  tps: 65331.81621
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CapacitivePrimalDiamond"
  value: {
-  dps: 90384.56671
-  tps: 64224.39895
+  dps: 90271.61664
+  tps: 64465.09132
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CarbonicCarbuncle-81138"
  value: {
-  dps: 88205.41323
-  tps: 62663.76882
+  dps: 87983.63673
+  tps: 62894.95671
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Cha-Ye'sEssenceofBrilliance-96888"
  value: {
-  dps: 101071.57456
-  tps: 71946.10975
+  dps: 100169.3399
+  tps: 71506.05605
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CharmofTenSongs-84071"
  value: {
-  dps: 89637.8444
-  tps: 63817.57649
+  dps: 89257.57153
+  tps: 63925.67805
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CommunalIdolofDestruction-101168"
  value: {
-  dps: 92073.34792
-  tps: 65590.34189
+  dps: 91607.94855
+  tps: 65672.18067
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CommunalStoneofDestruction-101171"
  value: {
-  dps: 94701.41361
-  tps: 67639.8111
+  dps: 94081.27997
+  tps: 67356.51829
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CommunalStoneofWisdom-101183"
  value: {
-  dps: 90203.14972
-  tps: 64189.45375
+  dps: 89964.3793
+  tps: 64290.3062
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ContemplationofChi-Ji-103688"
  value: {
-  dps: 90748.01957
-  tps: 64527.44724
+  dps: 90448.99899
+  tps: 64513.988
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ContemplationofChi-Ji-103988"
  value: {
-  dps: 92718.6916
-  tps: 66033.83088
+  dps: 92261.17365
+  tps: 65970.62316
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Coren'sColdChromiumCoaster-87574"
  value: {
-  dps: 87286.29196
-  tps: 62001.68002
+  dps: 87066.63479
+  tps: 62092.64376
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CoreofDecency-87497"
  value: {
-  dps: 86195.94954
-  tps: 61304.36515
+  dps: 85956.3443
+  tps: 61399.05176
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CourageousPrimalDiamond"
  value: {
-  dps: 91249.01433
-  tps: 64863.93992
+  dps: 91057.56075
+  tps: 65010.13644
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CraftedDreadfulGladiator'sBadgeofConquest-93419"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CraftedDreadfulGladiator'sBadgeofDominance-93600"
  value: {
-  dps: 90111.39029
-  tps: 64381.36282
+  dps: 89732.79074
+  tps: 64336.51665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CraftedDreadfulGladiator'sBadgeofVictory-93606"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CraftedDreadfulGladiator'sEmblemofCruelty-93485"
  value: {
-  dps: 87137.09184
-  tps: 61956.32521
+  dps: 86942.21
+  tps: 62076.5967
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CraftedDreadfulGladiator'sEmblemofMeditation-93487"
  value: {
-  dps: 86300.73087
-  tps: 61371.85834
+  dps: 86092.12432
+  tps: 61525.15481
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CraftedDreadfulGladiator'sEmblemofTenacity-93486"
  value: {
-  dps: 86425.20983
-  tps: 61465.00786
+  dps: 86308.98093
+  tps: 61683.01566
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CraftedDreadfulGladiator'sInsigniaofConquest-93424"
  value: {
-  dps: 86149.65587
-  tps: 61192.18486
+  dps: 85895.27204
+  tps: 61256.47147
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CraftedDreadfulGladiator'sInsigniaofDominance-93601"
  value: {
-  dps: 91272.96211
-  tps: 64778.2861
+  dps: 90883.3771
+  tps: 64837.72682
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CraftedDreadfulGladiator'sInsigniaofVictory-93611"
  value: {
-  dps: 86149.65587
-  tps: 61192.18486
+  dps: 85895.27204
+  tps: 61256.47147
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CraftedMalevolentGladiator'sBadgeofConquest-98755"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CraftedMalevolentGladiator'sBadgeofDominance-98910"
  value: {
-  dps: 90548.01121
-  tps: 64566.43638
+  dps: 90250.42366
+  tps: 64631.34277
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CraftedMalevolentGladiator'sBadgeofVictory-98912"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CraftedMalevolentGladiator'sEmblemofCruelty-98811"
  value: {
-  dps: 87371.36
-  tps: 62142.55482
+  dps: 87153.93195
+  tps: 62240.2801
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CraftedMalevolentGladiator'sEmblemofMeditation-98813"
  value: {
-  dps: 86304.95304
-  tps: 61378.4961
+  dps: 86096.79074
+  tps: 61532.23682
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CraftedMalevolentGladiator'sEmblemofTenacity-98812"
  value: {
-  dps: 86551.95978
-  tps: 61573.68376
+  dps: 86340.31097
+  tps: 61734.38756
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CraftedMalevolentGladiator'sInsigniaofConquest-98760"
  value: {
-  dps: 86149.65587
-  tps: 61192.18486
+  dps: 85895.27204
+  tps: 61256.47147
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CraftedMalevolentGladiator'sInsigniaofDominance-98911"
  value: {
-  dps: 92336.55678
-  tps: 65551.94225
+  dps: 92055.83233
+  tps: 65730.75288
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CraftedMalevolentGladiator'sInsigniaofVictory-98917"
  value: {
-  dps: 86149.65587
-  tps: 61192.18486
+  dps: 85895.27204
+  tps: 61256.47147
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CurseofHubris-102307"
  value: {
-  dps: 90902.80916
-  tps: 64719.15142
+  dps: 90420.96871
+  tps: 64567.41474
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CurseofHubris-104649"
  value: {
-  dps: 91323.06484
-  tps: 64958.2156
+  dps: 90742.90089
+  tps: 64767.56886
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CurseofHubris-104898"
  value: {
-  dps: 90366.37521
-  tps: 64373.83544
+  dps: 89839.87841
+  tps: 64272.23893
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CurseofHubris-105147"
  value: {
-  dps: 89666.05553
-  tps: 63825.70243
+  dps: 89121.89312
+  tps: 63651.31088
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CurseofHubris-105396"
  value: {
-  dps: 91258.5017
-  tps: 64912.32409
+  dps: 90780.9034
+  tps: 64786.25611
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CurseofHubris-105645"
  value: {
-  dps: 91511.4714
-  tps: 65113.43818
+  dps: 91049.1831
+  tps: 65043.36591
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CutstitcherMedallion-93255"
  value: {
-  dps: 90828.5059
-  tps: 64685.72949
+  dps: 90427.31384
+  tps: 64645.48672
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Daelo'sFinalWords-87496"
  value: {
-  dps: 86261.19401
-  tps: 61310.08951
+  dps: 85992.94967
+  tps: 61336.99622
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkglowEmbroidery(Rank3)-4893"
  value: {
-  dps: 89612.89014
-  tps: 63885.08304
+  dps: 89442.23811
+  tps: 64097.07761
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmistVortex-87172"
  value: {
-  dps: 92125.80732
-  tps: 65496.70099
+  dps: 91411.24365
+  tps: 65348.79405
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DeadeyeBadgeoftheShieldwall-93346"
  value: {
-  dps: 88527.66282
-  tps: 63213.24633
+  dps: 88106.60712
+  tps: 63181.75826
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DelicateVialoftheSanguinaire-96895"
  value: {
-  dps: 86149.65587
-  tps: 61192.18486
+  dps: 85895.27204
+  tps: 61256.47147
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DestructivePrimalDiamond"
  value: {
-  dps: 90562.60256
-  tps: 64343.58002
+  dps: 90435.41348
+  tps: 64574.71261
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DisciplineofXuen-103986"
  value: {
-  dps: 93732.9121
-  tps: 66992.27728
+  dps: 93466.81436
+  tps: 67164.80419
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Dominator'sArcaneBadge-93342"
  value: {
-  dps: 91949.96296
-  tps: 65163.93203
+  dps: 91573.73881
+  tps: 65283.99487
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Dominator'sDeadeyeBadge-93341"
  value: {
-  dps: 88527.66282
-  tps: 63213.24633
+  dps: 88106.60712
+  tps: 63181.75826
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Dominator'sDurableBadge-93345"
  value: {
-  dps: 88527.66282
-  tps: 63213.24633
+  dps: 88106.60712
+  tps: 63181.75826
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Dominator'sKnightlyBadge-93344"
  value: {
-  dps: 88527.66282
-  tps: 63213.24633
+  dps: 88106.60712
+  tps: 63181.75826
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Dominator'sMendingBadge-93343"
  value: {
-  dps: 89452.14403
-  tps: 63708.21763
+  dps: 89090.71272
+  tps: 63693.12454
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DreadfulGladiator'sBadgeofConquest-84344"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DreadfulGladiator'sBadgeofDominance-84488"
  value: {
-  dps: 90111.39029
-  tps: 64381.36282
+  dps: 89732.79074
+  tps: 64336.51665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DreadfulGladiator'sBadgeofVictory-84490"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DreadfulGladiator'sEmblemofCruelty-84399"
  value: {
-  dps: 87137.09184
-  tps: 61956.32521
+  dps: 86942.21
+  tps: 62076.5967
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DreadfulGladiator'sEmblemofMeditation-84401"
  value: {
-  dps: 86300.73087
-  tps: 61371.85834
+  dps: 86092.12432
+  tps: 61525.15481
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DreadfulGladiator'sEmblemofTenacity-84400"
  value: {
-  dps: 86425.20983
-  tps: 61465.00786
+  dps: 86308.98093
+  tps: 61683.01566
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DreadfulGladiator'sInsigniaofConquest-84349"
  value: {
-  dps: 86149.65587
-  tps: 61192.18486
+  dps: 85895.27204
+  tps: 61256.47147
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DreadfulGladiator'sInsigniaofDominance-84489"
  value: {
-  dps: 91144.25003
-  tps: 64730.22273
+  dps: 90687.60568
+  tps: 64688.86636
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DreadfulGladiator'sInsigniaofVictory-84495"
  value: {
-  dps: 86149.65587
-  tps: 61192.18486
+  dps: 85895.27204
+  tps: 61256.47147
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DurableBadgeoftheShieldwall-93350"
  value: {
-  dps: 88527.66282
-  tps: 63213.24633
+  dps: 88106.60712
+  tps: 63181.75826
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EffulgentPrimalDiamond"
  value: {
-  dps: 90018.83431
-  tps: 63978.49729
+  dps: 89835.44926
+  tps: 64136.6624
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EmberPrimalDiamond"
  value: {
-  dps: 90805.53295
-  tps: 64548.6202
+  dps: 90632.80783
+  tps: 64721.00813
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EmblemofKypariZar-84077"
  value: {
-  dps: 86958.38052
-  tps: 61758.44423
+  dps: 86749.2081
+  tps: 61873.55987
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EmblemoftheCatacombs-83733"
  value: {
-  dps: 88314.9637
-  tps: 62788.92884
+  dps: 87674.23022
+  tps: 62679.46729
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EmptyFruitBarrel-81133"
  value: {
-  dps: 86195.94954
-  tps: 61304.36515
+  dps: 85956.3443
+  tps: 61399.05176
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnchantWeapon-BloodyDancingSteel-5125"
  value: {
-  dps: 88624.69461
-  tps: 63131.33421
+  dps: 88332.41464
+  tps: 63217.46723
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnchantWeapon-Colossus-4445"
  value: {
-  dps: 88624.69461
-  tps: 63131.33421
+  dps: 88332.41464
+  tps: 63217.46723
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnchantWeapon-DancingSteel-4444"
  value: {
-  dps: 88624.69461
-  tps: 63131.33421
+  dps: 88332.41464
+  tps: 63217.46723
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnchantWeapon-ElementalForce-4443"
  value: {
-  dps: 89449.32453
-  tps: 63992.67485
+  dps: 89022.02368
+  tps: 63905.30357
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnchantWeapon-River'sSong-4446"
  value: {
-  dps: 88624.69461
-  tps: 63131.33421
+  dps: 88332.41464
+  tps: 63217.46723
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnchantWeapon-SpiritofConquest-5124"
  value: {
-  dps: 88624.69461
-  tps: 63131.33421
+  dps: 88332.41464
+  tps: 63217.46723
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnchantWeapon-Windsong-4441"
  value: {
-  dps: 90077.17709
-  tps: 64002.14882
+  dps: 89770.40623
+  tps: 64036.14815
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnigmaticPrimalDiamond"
  value: {
-  dps: 90562.60256
-  tps: 64343.58002
+  dps: 90435.41348
+  tps: 64574.71261
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EssenceofTerror-87175"
  value: {
-  dps: 97416.13809
-  tps: 69080.7304
+  dps: 96571.74102
+  tps: 68998.13724
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EternalPrimalDiamond"
  value: {
-  dps: 89945.50197
-  tps: 63935.31947
+  dps: 89774.38046
+  tps: 64106.17394
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EvilEyeofGalakras-105491"
  value: {
-  dps: 86149.65587
-  tps: 61192.18486
+  dps: 85895.27204
+  tps: 61256.47147
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FabledFeatherofJi-Kun-96842"
  value: {
-  dps: 86149.65587
-  tps: 61192.18486
+  dps: 85895.27204
+  tps: 61256.47147
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FearwurmBadge-84074"
  value: {
-  dps: 86958.38052
-  tps: 61758.44423
+  dps: 86749.2081
+  tps: 61873.55987
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FearwurmRelic-84070"
  value: {
-  dps: 89493.69066
-  tps: 63554.87392
+  dps: 89371.20694
+  tps: 63935.47124
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FelsoulIdolofDestruction-101263"
  value: {
-  dps: 92351.77317
-  tps: 65649.19491
+  dps: 91880.59204
+  tps: 65721.62664
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FelsoulStoneofDestruction-101266"
  value: {
-  dps: 94777.38509
-  tps: 67985.15765
+  dps: 94437.98726
+  tps: 67908.16548
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Fen-Yu,FuryofXuen-102248"
  value: {
-  dps: 91050.75342
-  tps: 65111.38964
+  dps: 90479.00973
+  tps: 64951.4507
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FlashfrozenResinGlobule-100951"
  value: {
-  dps: 89919.11937
-  tps: 64038.3377
+  dps: 89543.56556
+  tps: 64023.54998
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FlashfrozenResinGlobule-81263"
  value: {
-  dps: 90431.20469
-  tps: 64404.42912
+  dps: 90049.6417
+  tps: 64382.24935
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FlashingSteelTalisman-81265"
  value: {
-  dps: 86261.19401
-  tps: 61310.08951
+  dps: 85992.94967
+  tps: 61336.99622
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FleetPrimalDiamond"
  value: {
-  dps: 90732.53499
-  tps: 64567.97724
+  dps: 90560.97014
+  tps: 64738.38836
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForlornPrimalDiamond"
  value: {
-  dps: 90805.53295
-  tps: 64548.6202
+  dps: 90632.80783
+  tps: 64721.00813
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FortitudeoftheZandalari-94516"
  value: {
-  dps: 88699.75632
-  tps: 63287.71187
+  dps: 88510.02988
+  tps: 63398.60426
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FortitudeoftheZandalari-95677"
  value: {
-  dps: 88265.15673
-  tps: 62939.57756
+  dps: 88075.73935
+  tps: 63050.779
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FortitudeoftheZandalari-96049"
  value: {
-  dps: 88848.11361
-  tps: 63406.5529
+  dps: 88658.28167
+  tps: 63517.33979
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FortitudeoftheZandalari-96421"
  value: {
-  dps: 89031.3785
-  tps: 63553.35652
+  dps: 88841.41623
+  tps: 63664.01309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FortitudeoftheZandalari-96793"
  value: {
-  dps: 89197.18958
-  tps: 63686.17885
+  dps: 89007.10941
+  tps: 63796.7175
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GazeoftheTwins-96915"
  value: {
-  dps: 88436.62576
-  tps: 62929.95065
+  dps: 87680.43781
+  tps: 62689.89575
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Gerp'sPerfectArrow-87495"
  value: {
-  dps: 86998.17027
-  tps: 61795.95845
+  dps: 86782.44787
+  tps: 61900.3539
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Gong-Lu,StrengthofXuen-102249"
  value: {
-  dps: 91050.75342
-  tps: 65111.38964
+  dps: 90479.00973
+  tps: 64951.4507
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GrievousGladiator'sBadgeofConquest-100195"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GrievousGladiator'sBadgeofConquest-100603"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GrievousGladiator'sBadgeofConquest-102856"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GrievousGladiator'sBadgeofConquest-103145"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GrievousGladiator'sBadgeofDominance-100490"
  value: {
-  dps: 92697.27153
-  tps: 65869.16566
+  dps: 92376.95273
+  tps: 65852.66636
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GrievousGladiator'sBadgeofDominance-100576"
  value: {
-  dps: 92697.27153
-  tps: 65869.16566
+  dps: 92376.95273
+  tps: 65852.66636
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GrievousGladiator'sBadgeofDominance-102830"
  value: {
-  dps: 92697.27153
-  tps: 65869.16566
+  dps: 92376.95273
+  tps: 65852.66636
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GrievousGladiator'sBadgeofDominance-103308"
  value: {
-  dps: 92697.27153
-  tps: 65869.16566
+  dps: 92376.95273
+  tps: 65852.66636
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GrievousGladiator'sBadgeofVictory-100500"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GrievousGladiator'sBadgeofVictory-100579"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GrievousGladiator'sBadgeofVictory-102833"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GrievousGladiator'sBadgeofVictory-103314"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GrievousGladiator'sEmblemofCruelty-100305"
  value: {
-  dps: 88196.7721
-  tps: 62711.28162
+  dps: 87987.1438
+  tps: 62828.84493
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GrievousGladiator'sEmblemofCruelty-100626"
  value: {
-  dps: 88196.7721
-  tps: 62711.28162
+  dps: 87987.1438
+  tps: 62828.84493
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GrievousGladiator'sEmblemofCruelty-102877"
  value: {
-  dps: 88196.7721
-  tps: 62711.28162
+  dps: 87987.1438
+  tps: 62828.84493
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GrievousGladiator'sEmblemofCruelty-103210"
  value: {
-  dps: 88196.7721
-  tps: 62711.28162
+  dps: 87987.1438
+  tps: 62828.84493
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GrievousGladiator'sEmblemofMeditation-100307"
  value: {
-  dps: 86271.36729
-  tps: 61364.05967
+  dps: 86052.45469
+  tps: 61508.65997
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GrievousGladiator'sEmblemofMeditation-100559"
  value: {
-  dps: 86271.36729
-  tps: 61364.05967
+  dps: 86052.45469
+  tps: 61508.65997
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GrievousGladiator'sEmblemofMeditation-102813"
  value: {
-  dps: 86271.36729
-  tps: 61364.05967
+  dps: 86052.45469
+  tps: 61508.65997
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GrievousGladiator'sEmblemofMeditation-103212"
  value: {
-  dps: 86271.36729
-  tps: 61364.05967
+  dps: 86052.45469
+  tps: 61508.65997
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GrievousGladiator'sEmblemofTenacity-100306"
  value: {
-  dps: 86790.61026
-  tps: 61899.37286
+  dps: 86533.65225
+  tps: 61969.33438
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GrievousGladiator'sEmblemofTenacity-100652"
  value: {
-  dps: 86790.61026
-  tps: 61899.37286
+  dps: 86533.65225
+  tps: 61969.33438
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GrievousGladiator'sEmblemofTenacity-102903"
  value: {
-  dps: 86790.61026
-  tps: 61899.37286
+  dps: 86533.65225
+  tps: 61969.33438
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GrievousGladiator'sEmblemofTenacity-103211"
  value: {
-  dps: 86790.61026
-  tps: 61899.37286
+  dps: 86533.65225
+  tps: 61969.33438
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GrievousGladiator'sInsigniaofConquest-103150"
  value: {
-  dps: 86149.65587
-  tps: 61192.18486
+  dps: 85895.27204
+  tps: 61256.47147
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GrievousGladiator'sInsigniaofDominance-103309"
  value: {
-  dps: 95913.66554
-  tps: 67985.07825
+  dps: 95579.46624
+  tps: 67924.34243
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GrievousGladiator'sInsigniaofVictory-103319"
  value: {
-  dps: 86149.65587
-  tps: 61192.18486
+  dps: 85895.27204
+  tps: 61256.47147
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Hawkmaster'sTalon-89082"
  value: {
-  dps: 88803.70107
-  tps: 63190.80442
+  dps: 88466.15186
+  tps: 63260.16785
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Heart-LesionDefenderIdol-100999"
  value: {
-  dps: 86580.48289
-  tps: 61623.40091
+  dps: 86286.1889
+  tps: 61788.96279
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Heart-LesionDefenderStone-101002"
  value: {
-  dps: 90410.39757
-  tps: 64460.32969
+  dps: 89877.62281
+  tps: 64301.36315
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Heart-LesionIdolofBattle-100991"
  value: {
-  dps: 87518.27546
-  tps: 62169.98237
+  dps: 87276.80267
+  tps: 62241.47726
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Heart-LesionStoneofBattle-100990"
  value: {
-  dps: 90211.80475
-  tps: 64399.84955
+  dps: 89654.14945
+  tps: 64206.34791
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofFire-81181"
  value: {
-  dps: 87628.47603
-  tps: 62376.6065
+  dps: 87373.66561
+  tps: 62440.46652
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartwarmerMedallion-93260"
  value: {
-  dps: 90828.5059
-  tps: 64685.72949
+  dps: 90427.31384
+  tps: 64645.48672
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HelmbreakerMedallion-93261"
  value: {
-  dps: 88697.01965
-  tps: 63087.49817
+  dps: 88115.01034
+  tps: 63028.65974
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Horridon'sLastGasp-96757"
  value: {
-  dps: 93249.54504
-  tps: 66461.89471
+  dps: 92810.13183
+  tps: 66427.21709
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpassivePrimalDiamond"
  value: {
-  dps: 90562.60256
-  tps: 64343.58002
+  dps: 90435.41348
+  tps: 64574.71261
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-IndomitablePrimalDiamond"
  value: {
-  dps: 90018.83431
-  tps: 63978.49729
+  dps: 89835.44926
+  tps: 64136.6624
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InscribedBagofHydra-Spawn-96828"
  value: {
-  dps: 86131.15362
-  tps: 61280.27
+  dps: 85910.94769
+  tps: 61378.85994
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsigniaofKypariZar-84078"
  value: {
-  dps: 86149.65587
-  tps: 61192.18486
+  dps: 85895.27204
+  tps: 61256.47147
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-IronBellyWok-89083"
  value: {
-  dps: 88803.70107
-  tps: 63190.80442
+  dps: 88466.15186
+  tps: 63260.16785
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-IronProtectorTalisman-85181"
  value: {
-  dps: 86441.56599
-  tps: 61468.18015
+  dps: 86206.90962
+  tps: 61660.6529
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JadeBanditFigurine-86043"
  value: {
-  dps: 88803.70107
-  tps: 63190.80442
+  dps: 88466.15186
+  tps: 63260.16785
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JadeBanditFigurine-86772"
  value: {
-  dps: 88989.70375
-  tps: 63159.62848
+  dps: 88774.27735
+  tps: 63322.56466
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JadeCharioteerFigurine-86042"
  value: {
-  dps: 88803.70107
-  tps: 63190.80442
+  dps: 88466.15186
+  tps: 63260.16785
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JadeCharioteerFigurine-86771"
  value: {
-  dps: 88989.70375
-  tps: 63159.62848
+  dps: 88774.27735
+  tps: 63322.56466
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JadeCourtesanFigurine-86045"
  value: {
-  dps: 90537.41331
-  tps: 64474.63232
+  dps: 90147.58355
+  tps: 64446.83505
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JadeCourtesanFigurine-86774"
  value: {
-  dps: 90052.71038
-  tps: 64131.35062
+  dps: 89659.77086
+  tps: 64098.59296
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JadeMagistrateFigurine-86044"
  value: {
-  dps: 92590.76447
-  tps: 65912.40641
+  dps: 92043.86973
+  tps: 65831.06373
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JadeMagistrateFigurine-86773"
  value: {
-  dps: 91700.54722
-  tps: 65203.66445
+  dps: 91204.55763
+  tps: 65204.68202
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JadeWarlordFigurine-86046"
  value: {
-  dps: 89378.85548
-  tps: 63864.03482
+  dps: 88916.14512
+  tps: 63815.64475
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JadeWarlordFigurine-86775"
  value: {
-  dps: 88942.28666
-  tps: 63566.41967
+  dps: 88432.47183
+  tps: 63472.53475
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Ji-Kun'sRisingWinds-96843"
  value: {
-  dps: 86149.65587
-  tps: 61192.18486
+  dps: 85895.27204
+  tps: 61256.47147
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KnightlyBadgeoftheShieldwall-93349"
  value: {
-  dps: 88527.66282
-  tps: 63213.24633
+  dps: 88106.60712
+  tps: 63181.75826
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KnotofTenSongs-84073"
  value: {
-  dps: 86149.65587
-  tps: 61192.18486
+  dps: 85895.27204
+  tps: 61256.47147
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Kor'kronBookofHurting-92785"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Lao-Chin'sLiquidCourage-89079"
  value: {
-  dps: 89378.85548
-  tps: 63864.03482
+  dps: 88916.14512
+  tps: 63815.64475
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LeiShen'sFinalOrders-87072"
  value: {
-  dps: 88763.37095
-  tps: 63108.16698
+  dps: 88229.14013
+  tps: 63185.71138
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LessonsoftheDarkmaster-81268"
  value: {
-  dps: 86149.65587
-  tps: 61192.18486
+  dps: 85895.27204
+  tps: 61256.47147
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LightdrinkerIdolofRage-101200"
  value: {
-  dps: 87932.27144
-  tps: 62619.92335
+  dps: 87677.37338
+  tps: 62683.69573
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LightdrinkerStoneofRage-101203"
  value: {
-  dps: 90008.90566
-  tps: 64238.83098
+  dps: 89704.88838
+  tps: 64318.20345
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LightoftheCosmos-87065"
  value: {
-  dps: 94859.85766
-  tps: 67194.94061
+  dps: 94471.55963
+  tps: 67375.62525
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LordBlastington'sScopeofDoom-4699"
  value: {
-  dps: 88624.69461
-  tps: 63131.33421
+  dps: 88332.41464
+  tps: 63217.46723
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MalevolentGladiator'sBadgeofConquest-84934"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MalevolentGladiator'sBadgeofConquest-91452"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MalevolentGladiator'sBadgeofDominance-84940"
  value: {
-  dps: 90841.3793
-  tps: 64773.63726
+  dps: 90476.49132
+  tps: 64776.50119
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MalevolentGladiator'sBadgeofDominance-91753"
  value: {
-  dps: 90548.01121
-  tps: 64566.43638
+  dps: 90250.42366
+  tps: 64631.34277
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MalevolentGladiator'sBadgeofVictory-84942"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MalevolentGladiator'sBadgeofVictory-91763"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MalevolentGladiator'sEmblemofCruelty-84936"
  value: {
-  dps: 87480.49336
-  tps: 62208.25741
+  dps: 87273.37638
+  tps: 62316.53816
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MalevolentGladiator'sEmblemofCruelty-91562"
  value: {
-  dps: 87371.36
-  tps: 62142.55482
+  dps: 87153.93195
+  tps: 62240.2801
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MalevolentGladiator'sEmblemofMeditation-84939"
  value: {
-  dps: 86304.95304
-  tps: 61378.4961
+  dps: 86096.79074
+  tps: 61532.23682
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MalevolentGladiator'sEmblemofMeditation-91564"
  value: {
-  dps: 86304.95304
-  tps: 61378.4961
+  dps: 86096.79074
+  tps: 61532.23682
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MalevolentGladiator'sEmblemofTenacity-84938"
  value: {
-  dps: 86623.35001
-  tps: 61644.42055
+  dps: 86353.72595
+  tps: 61821.26491
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MalevolentGladiator'sEmblemofTenacity-91563"
  value: {
-  dps: 86551.95978
-  tps: 61573.68376
+  dps: 86340.31097
+  tps: 61734.38756
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MalevolentGladiator'sInsigniaofConquest-91457"
  value: {
-  dps: 86149.65587
-  tps: 61192.18486
+  dps: 85895.27204
+  tps: 61256.47147
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MalevolentGladiator'sInsigniaofDominance-91754"
  value: {
-  dps: 92452.30528
-  tps: 65774.19548
+  dps: 92195.64125
+  tps: 65841.21777
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MalevolentGladiator'sInsigniaofVictory-91768"
  value: {
-  dps: 86149.65587
-  tps: 61192.18486
+  dps: 85895.27204
+  tps: 61256.47147
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MarkoftheCatacombs-83731"
  value: {
-  dps: 89365.88423
-  tps: 63641.03314
+  dps: 88910.03126
+  tps: 63614.05825
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MarkoftheHardenedGrunt-92783"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MedallionofMystifyingVapors-93257"
  value: {
-  dps: 89413.13645
-  tps: 63821.89443
+  dps: 88977.56845
+  tps: 63747.60306
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MedallionoftheCatacombs-83734"
  value: {
-  dps: 87226.90739
-  tps: 62054.98079
+  dps: 86972.21281
+  tps: 62118.95665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MendingBadgeoftheShieldwall-93348"
  value: {
-  dps: 89452.14403
-  tps: 63708.21763
+  dps: 89090.71272
+  tps: 63693.12454
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MirrorScope-4700"
  value: {
-  dps: 88624.69461
-  tps: 63131.33421
+  dps: 88332.41464
+  tps: 63217.46723
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MistdancerDefenderIdol-101089"
  value: {
-  dps: 86580.48289
-  tps: 61623.40091
+  dps: 86286.1889
+  tps: 61788.96279
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MistdancerDefenderStone-101087"
  value: {
-  dps: 90370.74272
-  tps: 64478.01375
+  dps: 90073.76016
+  tps: 64370.00781
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MistdancerIdolofRage-101113"
  value: {
-  dps: 87932.27144
-  tps: 62619.92335
+  dps: 87677.37338
+  tps: 62683.69573
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MistdancerStoneofRage-101117"
  value: {
-  dps: 90345.33573
-  tps: 64465.37619
+  dps: 90178.41393
+  tps: 64675.45534
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MistdancerStoneofWisdom-101107"
  value: {
-  dps: 90203.14972
-  tps: 64189.45375
+  dps: 89964.3793
+  tps: 64290.3062
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MithrilWristwatch-87572"
  value: {
-  dps: 89087.68324
-  tps: 63324.3255
+  dps: 88690.55022
+  tps: 63408.43065
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MountainsageIdolofDestruction-101069"
  value: {
-  dps: 92355.21826
-  tps: 65607.96641
+  dps: 91754.12206
+  tps: 65615.67715
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MountainsageStoneofDestruction-101072"
  value: {
-  dps: 93931.21997
-  tps: 66925.76616
+  dps: 93735.89363
+  tps: 67103.15123
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-NitroBoosts-4223"
  value: {
-  dps: 91484.61296
-  tps: 65118.44835
+  dps: 91334.57737
+  tps: 65331.81621
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-OathswornDefenderIdol-101303"
  value: {
-  dps: 86580.48289
-  tps: 61623.40091
+  dps: 86286.1889
+  tps: 61788.96279
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-OathswornDefenderStone-101306"
  value: {
-  dps: 90553.33601
-  tps: 64563.74781
+  dps: 90053.26517
+  tps: 64440.6049
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-OathswornIdolofBattle-101295"
  value: {
-  dps: 87518.27546
-  tps: 62169.98237
+  dps: 87276.80267
+  tps: 62241.47726
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-OathswornStoneofBattle-101294"
  value: {
-  dps: 90056.22973
-  tps: 64155.10292
+  dps: 89842.52527
+  tps: 64392.38989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PhaseFingers-4697"
  value: {
-  dps: 91231.30608
-  tps: 64871.25193
+  dps: 90948.80217
+  tps: 64962.2416
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PouchofWhiteAsh-103639"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PowerfulPrimalDiamond"
  value: {
-  dps: 90018.83431
-  tps: 63978.49729
+  dps: 89835.44926
+  tps: 64136.6624
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PriceofProgress-81266"
  value: {
-  dps: 89503.94956
-  tps: 63699.40272
+  dps: 89288.16207
+  tps: 63815.76602
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PridefulGladiator'sBadgeofConquest-102659"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PridefulGladiator'sBadgeofConquest-103342"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PridefulGladiator'sBadgeofDominance-102633"
  value: {
-  dps: 95140.12182
-  tps: 67567.99741
+  dps: 94668.6582
+  tps: 67524.53172
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PridefulGladiator'sBadgeofDominance-103505"
  value: {
-  dps: 95140.12182
-  tps: 67567.99741
+  dps: 94668.6582
+  tps: 67524.53172
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PridefulGladiator'sBadgeofVictory-102636"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PridefulGladiator'sBadgeofVictory-103511"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PridefulGladiator'sEmblemofCruelty-102680"
  value: {
-  dps: 88716.12922
-  tps: 63096.48661
+  dps: 88546.84516
+  tps: 63251.63876
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PridefulGladiator'sEmblemofCruelty-103407"
  value: {
-  dps: 88716.12922
-  tps: 63096.48661
+  dps: 88546.84516
+  tps: 63251.63876
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PridefulGladiator'sEmblemofMeditation-102616"
  value: {
-  dps: 86352.52748
-  tps: 61427.87737
+  dps: 86101.91442
+  tps: 61541.04311
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PridefulGladiator'sEmblemofMeditation-103409"
  value: {
-  dps: 86352.52748
-  tps: 61427.87737
+  dps: 86101.91442
+  tps: 61541.04311
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PridefulGladiator'sEmblemofTenacity-102706"
  value: {
-  dps: 86734.50993
-  tps: 61799.99068
+  dps: 86499.83873
+  tps: 61903.97867
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PridefulGladiator'sEmblemofTenacity-103408"
  value: {
-  dps: 86734.50993
-  tps: 61799.99068
+  dps: 86499.83873
+  tps: 61903.97867
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PridefulGladiator'sInsigniaofConquest-103347"
  value: {
-  dps: 86149.65587
-  tps: 61192.18486
+  dps: 85895.27204
+  tps: 61256.47147
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PridefulGladiator'sInsigniaofDominance-103506"
  value: {
-  dps: 99597.81138
-  tps: 70722.01432
+  dps: 99127.75917
+  tps: 70527.91856
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PridefulGladiator'sInsigniaofVictory-103516"
  value: {
-  dps: 86149.65587
-  tps: 61192.18486
+  dps: 85895.27204
+  tps: 61256.47147
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Primordius'TalismanofRage-96873"
  value: {
-  dps: 88581.61231
-  tps: 62931.26177
+  dps: 88359.66014
+  tps: 63008.86278
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Qian-Le,CourageofNiuzao-102245"
  value: {
-  dps: 89772.89099
-  tps: 64221.95042
+  dps: 89536.46609
+  tps: 64268.56545
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Qian-Ying,FortitudeofNiuzao-102250"
  value: {
-  dps: 88425.77004
-  tps: 63267.33764
+  dps: 88225.32909
+  tps: 63360.88235
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Qin-xi'sPolarizingSeal-87075"
  value: {
-  dps: 86195.94954
-  tps: 61304.36515
+  dps: 85956.3443
+  tps: 61399.05176
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RegaliaoftheHornedNightmare"
  value: {
-  dps: 102337.3011
-  tps: 73633.34739
+  dps: 102342.94597
+  tps: 74247.32644
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RegaliaoftheThousandfoldHells"
  value: {
-  dps: 102658.52459
-  tps: 73278.85136
+  dps: 102174.88946
+  tps: 73233.9262
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RelicofChi-Ji-79330"
  value: {
-  dps: 90736.66342
-  tps: 64567.93543
+  dps: 90485.19012
+  tps: 64658.04573
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RelicofKypariZar-84075"
  value: {
-  dps: 89527.01982
-  tps: 63696.40392
+  dps: 89218.54722
+  tps: 63727.53331
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RelicofNiuzao-79329"
  value: {
-  dps: 86710.51437
-  tps: 61834.2012
+  dps: 86332.587
+  tps: 61888.8689
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RelicofXuen-79327"
  value: {
-  dps: 86149.65587
-  tps: 61192.18486
+  dps: 85895.27204
+  tps: 61256.47147
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RelicofXuen-79328"
  value: {
-  dps: 86149.65587
-  tps: 61192.18486
+  dps: 85895.27204
+  tps: 61256.47147
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Renataki'sSoulCharm-96741"
  value: {
-  dps: 86149.65587
-  tps: 61192.18486
+  dps: 85895.27204
+  tps: 61256.47147
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ResolveofNiuzao-103690"
  value: {
-  dps: 88160.99097
-  tps: 62803.11017
+  dps: 87906.02693
+  tps: 62866.81657
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ResolveofNiuzao-103990"
  value: {
-  dps: 89042.69602
-  tps: 63509.28836
+  dps: 88787.47764
+  tps: 63572.74042
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ReverberatingPrimalDiamond"
  value: {
-  dps: 90707.04204
-  tps: 64579.53845
+  dps: 90538.92236
+  tps: 64765.22938
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RevitalizingPrimalDiamond"
  value: {
-  dps: 90707.04204
-  tps: 64579.53845
+  dps: 90538.92236
+  tps: 64765.22938
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SI:7Operative'sManual-92784"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ScrollofReveredAncestors-89080"
  value: {
-  dps: 90537.41331
-  tps: 64474.63232
+  dps: 90147.58355
+  tps: 64446.83505
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SearingWords-81267"
  value: {
-  dps: 87217.97421
-  tps: 61959.22224
+  dps: 86999.6173
+  tps: 62051.48623
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Sha-SkinRegalia"
  value: {
-  dps: 97562.15897
-  tps: 70272.32847
+  dps: 97529.50661
+  tps: 70423.44579
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ShadowflameRegalia"
  value: {
-  dps: 66632.83517
-  tps: 46973.9955
+  dps: 66244.16579
+  tps: 46771.02898
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Shock-ChargerMedallion-93259"
  value: {
-  dps: 94996.44566
-  tps: 67229.03926
+  dps: 94261.32688
+  tps: 67133.54347
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SigilofCompassion-83736"
  value: {
-  dps: 87226.90739
-  tps: 62054.98079
+  dps: 86972.21281
+  tps: 62118.95665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SigilofDevotion-83740"
  value: {
-  dps: 86890.2082
-  tps: 61725.24697
+  dps: 86685.60887
+  tps: 61836.64725
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SigilofFidelity-83737"
  value: {
-  dps: 89604.01884
-  tps: 63811.24363
+  dps: 89224.39648
+  tps: 63837.03685
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SigilofGrace-83738"
  value: {
-  dps: 87226.90739
-  tps: 62054.98079
+  dps: 86972.21281
+  tps: 62118.95665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SigilofKypariZar-84076"
  value: {
-  dps: 88964.0297
-  tps: 63422.74436
+  dps: 88506.04919
+  tps: 63280.94632
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SigilofPatience-83739"
  value: {
-  dps: 86149.65587
-  tps: 61192.18486
+  dps: 85895.27204
+  tps: 61256.47147
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SigiloftheCatacombs-83732"
  value: {
-  dps: 89697.03096
-  tps: 63742.11213
+  dps: 89245.94633
+  tps: 63833.69707
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SinisterPrimalDiamond"
  value: {
-  dps: 90384.56671
-  tps: 64224.39895
+  dps: 90271.61664
+  tps: 64465.09132
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SkullrenderMedallion-93256"
  value: {
-  dps: 88697.01965
-  tps: 63087.49817
+  dps: 88115.01034
+  tps: 63028.65974
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SpiritsoftheSun-87163"
  value: {
-  dps: 91420.95783
-  tps: 65138.36074
+  dps: 91021.95887
+  tps: 65156.33542
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SpringrainIdolofDestruction-101023"
  value: {
-  dps: 92279.0275
-  tps: 65592.04457
+  dps: 91582.12121
+  tps: 65473.4858
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SpringrainIdolofRage-101009"
  value: {
-  dps: 87932.27144
-  tps: 62619.92335
+  dps: 87677.37338
+  tps: 62683.69573
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SpringrainStoneofDestruction-101026"
  value: {
-  dps: 94580.02843
-  tps: 67481.47537
+  dps: 94231.70405
+  tps: 67475.24614
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SpringrainStoneofRage-101012"
  value: {
-  dps: 89955.86561
-  tps: 64232.85348
+  dps: 89689.04883
+  tps: 64245.70062
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SpringrainStoneofWisdom-101041"
  value: {
-  dps: 90203.14972
-  tps: 64189.45375
+  dps: 89964.3793
+  tps: 64290.3062
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Static-Caster'sMedallion-93254"
  value: {
-  dps: 94996.44566
-  tps: 67229.03926
+  dps: 94261.32688
+  tps: 67133.54347
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SteadfastFootman'sMedallion-92782"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SteadfastTalismanoftheShado-PanAssault-94507"
  value: {
-  dps: 88710.96541
-  tps: 63243.59756
+  dps: 88455.84272
+  tps: 63307.1453
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StreamtalkerIdolofDestruction-101222"
  value: {
-  dps: 92507.77165
-  tps: 65849.2527
+  dps: 91815.21334
+  tps: 65675.9891
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StreamtalkerIdolofRage-101217"
  value: {
-  dps: 87932.27144
-  tps: 62619.92335
+  dps: 87677.37338
+  tps: 62683.69573
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StreamtalkerStoneofDestruction-101225"
  value: {
-  dps: 94382.69713
-  tps: 67335.17136
+  dps: 94144.42694
+  tps: 67568.26048
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StreamtalkerStoneofRage-101220"
  value: {
-  dps: 90004.61672
-  tps: 64205.91518
+  dps: 89769.46579
+  tps: 64305.38889
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StreamtalkerStoneofWisdom-101250"
  value: {
-  dps: 90203.14972
-  tps: 64189.45375
+  dps: 89964.3793
+  tps: 64290.3062
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StuffofNightmares-87160"
  value: {
-  dps: 88419.39166
-  tps: 63010.06932
+  dps: 88164.35308
+  tps: 63073.70118
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SunsoulDefenderIdol-101160"
  value: {
-  dps: 86580.48289
-  tps: 61623.40091
+  dps: 86286.1889
+  tps: 61788.96279
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SunsoulDefenderStone-101163"
  value: {
-  dps: 90741.37653
-  tps: 64718.40405
+  dps: 90466.43135
+  tps: 64788.9648
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SunsoulIdolofBattle-101152"
  value: {
-  dps: 87518.27546
-  tps: 62169.98237
+  dps: 87276.80267
+  tps: 62241.47726
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SunsoulStoneofBattle-101151"
  value: {
-  dps: 90231.16495
-  tps: 64416.46086
+  dps: 90039.4582
+  tps: 64529.80698
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SunsoulStoneofWisdom-101138"
  value: {
-  dps: 90203.14972
-  tps: 64189.45375
+  dps: 89964.3793
+  tps: 64290.3062
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SwordguardEmbroidery(Rank3)-4894"
  value: {
-  dps: 89612.89014
-  tps: 63885.08304
+  dps: 89442.23811
+  tps: 64097.07761
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SymboloftheCatacombs-83735"
  value: {
-  dps: 87226.90739
-  tps: 62054.98079
+  dps: 86972.21281
+  tps: 62118.95665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SynapseSprings(MarkII)-4898"
  value: {
-  dps: 92613.37827
-  tps: 65745.77146
+  dps: 92274.42665
+  tps: 65756.66833
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TalismanofBloodlust-96864"
  value: {
-  dps: 90699.00047
-  tps: 64507.99479
+  dps: 90060.55223
+  tps: 64418.36308
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TerrorintheMists-87167"
  value: {
-  dps: 90028.08654
-  tps: 64085.20606
+  dps: 89576.24757
+  tps: 64017.67932
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Thousand-YearPickledEgg-87573"
  value: {
-  dps: 89741.20755
-  tps: 63868.37313
+  dps: 89508.98919
+  tps: 63967.40652
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TrailseekerIdolofRage-101054"
  value: {
-  dps: 87932.27144
-  tps: 62619.92335
+  dps: 87677.37338
+  tps: 62683.69573
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TrailseekerStoneofRage-101057"
  value: {
-  dps: 90026.99258
-  tps: 64257.33425
+  dps: 89866.44858
+  tps: 64389.62922
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TyrannicalGladiator'sBadgeofConquest-100043"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TyrannicalGladiator'sBadgeofConquest-91099"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TyrannicalGladiator'sBadgeofConquest-94373"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TyrannicalGladiator'sBadgeofConquest-99772"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TyrannicalGladiator'sBadgeofDominance-100016"
  value: {
-  dps: 91432.61688
-  tps: 65210.68104
+  dps: 90980.47618
+  tps: 64991.43939
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TyrannicalGladiator'sBadgeofDominance-91400"
  value: {
-  dps: 91432.61688
-  tps: 65210.68104
+  dps: 90980.47618
+  tps: 64991.43939
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TyrannicalGladiator'sBadgeofDominance-94346"
  value: {
-  dps: 91432.61688
-  tps: 65210.68104
+  dps: 90980.47618
+  tps: 64991.43939
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TyrannicalGladiator'sBadgeofDominance-99937"
  value: {
-  dps: 91432.61688
-  tps: 65210.68104
+  dps: 90980.47618
+  tps: 64991.43939
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TyrannicalGladiator'sBadgeofVictory-100019"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TyrannicalGladiator'sBadgeofVictory-91410"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TyrannicalGladiator'sBadgeofVictory-94349"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TyrannicalGladiator'sBadgeofVictory-99943"
  value: {
-  dps: 86182.1048
-  tps: 61230.96806
+  dps: 85829.89982
+  tps: 61194.3305
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TyrannicalGladiator'sEmblemofCruelty-100066"
  value: {
-  dps: 87692.98987
-  tps: 62364.76159
+  dps: 87497.98336
+  tps: 62479.32639
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TyrannicalGladiator'sEmblemofCruelty-91209"
  value: {
-  dps: 87692.98987
-  tps: 62364.76159
+  dps: 87497.98336
+  tps: 62479.32639
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TyrannicalGladiator'sEmblemofCruelty-94396"
  value: {
-  dps: 87692.98987
-  tps: 62364.76159
+  dps: 87497.98336
+  tps: 62479.32639
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TyrannicalGladiator'sEmblemofCruelty-99838"
  value: {
-  dps: 87692.98987
-  tps: 62364.76159
+  dps: 87497.98336
+  tps: 62479.32639
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TyrannicalGladiator'sEmblemofMeditation-91211"
  value: {
-  dps: 86304.95304
-  tps: 61378.4961
+  dps: 86096.79074
+  tps: 61532.23682
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TyrannicalGladiator'sEmblemofMeditation-94329"
  value: {
-  dps: 86304.95304
-  tps: 61378.4961
+  dps: 86096.79074
+  tps: 61532.23682
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TyrannicalGladiator'sEmblemofMeditation-99840"
  value: {
-  dps: 86304.95304
-  tps: 61378.4961
+  dps: 86096.79074
+  tps: 61532.23682
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TyrannicalGladiator'sEmblemofMeditation-99990"
  value: {
-  dps: 86304.95304
-  tps: 61378.4961
+  dps: 86096.79074
+  tps: 61532.23682
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TyrannicalGladiator'sEmblemofTenacity-100092"
  value: {
-  dps: 86554.64667
-  tps: 61683.36568
+  dps: 86249.19368
+  tps: 61709.22876
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TyrannicalGladiator'sEmblemofTenacity-91210"
  value: {
-  dps: 86554.64667
-  tps: 61683.36568
+  dps: 86249.19368
+  tps: 61709.22876
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TyrannicalGladiator'sEmblemofTenacity-94422"
  value: {
-  dps: 86554.64667
-  tps: 61683.36568
+  dps: 86249.19368
+  tps: 61709.22876
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TyrannicalGladiator'sEmblemofTenacity-99839"
  value: {
-  dps: 86554.64667
-  tps: 61683.36568
+  dps: 86249.19368
+  tps: 61709.22876
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TyrannicalGladiator'sInsigniaofConquest-100026"
  value: {
-  dps: 86149.65587
-  tps: 61192.18486
+  dps: 85895.27204
+  tps: 61256.47147
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TyrannicalGladiator'sInsigniaofDominance-100152"
  value: {
-  dps: 94046.98319
-  tps: 66843.61391
+  dps: 93699.95449
+  tps: 66886.92361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TyrannicalGladiator'sInsigniaofVictory-100085"
  value: {
-  dps: 86149.65587
-  tps: 61192.18486
+  dps: 85895.27204
+  tps: 61256.47147
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TyrannicalPrimalDiamond"
  value: {
-  dps: 89945.50197
-  tps: 63935.31947
+  dps: 89774.38046
+  tps: 64106.17394
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnerringVisionofLeiShen-96930"
  value: {
-  dps: 101173.02876
-  tps: 71348.13498
+  dps: 100981.00312
+  tps: 71579.06173
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VaporshieldMedallion-93262"
  value: {
-  dps: 89413.13645
-  tps: 63821.89443
+  dps: 88977.56845
+  tps: 63747.60306
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VialofDragon'sBlood-87063"
  value: {
-  dps: 88276.22371
-  tps: 62895.40276
+  dps: 88021.22643
+  tps: 62959.07592
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VialofIchorousBlood-100963"
  value: {
-  dps: 89113.41053
-  tps: 63410.99885
+  dps: 88899.28943
+  tps: 63527.66197
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VialofIchorousBlood-81264"
  value: {
-  dps: 89503.94956
-  tps: 63699.40272
+  dps: 89288.16207
+  tps: 63815.76602
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousTalismanoftheShado-PanAssault-94511"
  value: {
-  dps: 86149.65587
-  tps: 61192.18486
+  dps: 85895.27204
+  tps: 61256.47147
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VolatileTalismanoftheShado-PanAssault-94510"
  value: {
-  dps: 98677.05699
-  tps: 70015.4095
+  dps: 98001.66613
+  tps: 69823.91414
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WindsweptPages-81125"
  value: {
-  dps: 88576.25231
-  tps: 63019.31204
+  dps: 88180.33667
+  tps: 63100.35829
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WoundripperMedallion-93253"
  value: {
-  dps: 88697.01965
-  tps: 63087.49817
+  dps: 88115.01034
+  tps: 63028.65974
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Wushoolay'sFinalChoice-96785"
  value: {
-  dps: 104239.09416
-  tps: 73941.90067
+  dps: 103766.55828
+  tps: 73835.08862
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Xing-Ho,BreathofYu'lon-102246"
  value: {
-  dps: 117330.02518
-  tps: 89430.39959
+  dps: 116348.47374
+  tps: 89151.45609
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Yu'lon'sBite-103987"
  value: {
-  dps: 97612.33729
-  tps: 69123.58522
+  dps: 97004.75177
+  tps: 68997.83391
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ZenAlchemistStone-75274"
  value: {
-  dps: 94645.70934
-  tps: 67480.75131
+  dps: 94164.23721
+  tps: 67292.30946
  }
 }
 dps_results: {
  key: "TestAffliction-Average-Default"
  value: {
-  dps: 92640.19692
-  tps: 65604.48365
+  dps: 92232.26265
+  tps: 65606.44127
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 148398.31609
-  tps: 123683.33839
+  dps: 146947.46617
+  tps: 123786.21329
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 148398.31609
-  tps: 107690.25278
+  dps: 146947.46617
+  tps: 107793.12768
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p1-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 243309.93689
-  tps: 164110.63481
+  dps: 234564.56642
+  tps: 164230.44893
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p1-Affliction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 93394.02576
-  tps: 83924.731
+  dps: 92143.43658
+  tps: 83858.48392
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p1-Affliction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 93394.02576
-  tps: 68592.22013
+  dps: 92143.43658
+  tps: 68525.97306
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p1-Affliction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 122909.20972
-  tps: 84678.84101
+  dps: 119669.94892
+  tps: 84566.78857
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-preraid-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 91881.59277
-  tps: 78740.72446
+  dps: 91622.87283
+  tps: 78942.86382
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-preraid-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 91881.59277
-  tps: 65498.05209
+  dps: 91622.87283
+  tps: 65700.19145
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-preraid-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 152436.65707
-  tps: 98329.99639
+  dps: 148252.40948
+  tps: 98657.61095
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-preraid-Affliction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 56238.96617
-  tps: 53610.25171
+  dps: 55943.74769
+  tps: 53570.95245
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-preraid-Affliction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 56238.96617
-  tps: 40737.67507
+  dps: 55943.74769
+  tps: 40698.37581
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-preraid-Affliction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 73435.1619
-  tps: 48666.32997
+  dps: 72942.09531
+  tps: 48740.06175
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 146720.08926
-  tps: 122303.06165
+  dps: 145122.53077
+  tps: 122426.78952
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 146720.08926
-  tps: 106567.92903
+  dps: 145122.53077
+  tps: 106691.65691
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p1-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 241909.44071
-  tps: 163783.94266
+  dps: 234527.78974
+  tps: 165123.72382
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p1-Affliction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 92127.05332
-  tps: 82831.94029
+  dps: 91008.6265
+  tps: 82778.09808
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p1-Affliction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 92127.05332
-  tps: 67740.88629
+  dps: 91008.6265
+  tps: 67687.04408
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p1-Affliction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 121772.77581
-  tps: 83756.06756
+  dps: 118716.42156
+  tps: 83835.40373
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-preraid-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 90637.01076
-  tps: 78092.12695
+  dps: 90257.53293
+  tps: 78051.38448
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-preraid-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 90637.01076
-  tps: 64637.57182
+  dps: 90257.53293
+  tps: 64596.82935
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-preraid-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 150489.25144
-  tps: 97233.43742
+  dps: 146782.01358
+  tps: 97696.35771
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-preraid-Affliction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 55466.22205
-  tps: 52216.74875
+  dps: 55176.4
+  tps: 52254.63047
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-preraid-Affliction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 55466.22205
-  tps: 40042.68403
+  dps: 55176.4
+  tps: 40080.56575
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-preraid-Affliction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 71402.1588
-  tps: 46925.82239
+  dps: 70888.52516
+  tps: 46944.23328
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 150444.87509
-  tps: 124746.13809
+  dps: 148872.43073
+  tps: 124888.46153
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 150444.87509
-  tps: 109010.46556
+  dps: 148872.43073
+  tps: 109152.789
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p1-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 250520.21279
-  tps: 169126.29652
+  dps: 242794.85148
+  tps: 170487.88923
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p1-Affliction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 94532.59377
-  tps: 84505.2548
+  dps: 93299.82133
+  tps: 84380.33588
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p1-Affliction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 94532.59377
-  tps: 69292.96544
+  dps: 93299.82133
+  tps: 69168.04651
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p1-Affliction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 126390.07616
-  tps: 86714.96887
+  dps: 123179.77152
+  tps: 86797.67322
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-preraid-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 92934.68408
-  tps: 79457.3829
+  dps: 92595.38418
+  tps: 79467.93149
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-preraid-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 92934.68408
-  tps: 66002.26572
+  dps: 92595.38418
+  tps: 66012.81431
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-preraid-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 156932.27878
-  tps: 101103.64496
+  dps: 153194.11165
+  tps: 101791.59019
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-preraid-Affliction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 57090.65317
-  tps: 53348.80329
+  dps: 56677.7167
+  tps: 53271.90677
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-preraid-Affliction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 57090.65317
-  tps: 41074.45629
+  dps: 56677.7167
+  tps: 40997.55977
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-preraid-Affliction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 74413.22041
-  tps: 48752.17749
+  dps: 73886.28172
+  tps: 48781.06467
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 153913.81949
-  tps: 127851.21886
+  dps: 152153.51806
+  tps: 127627.28206
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 153913.81949
-  tps: 111084.27427
+  dps: 152153.51806
+  tps: 110860.33748
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p1-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 260644.44302
-  tps: 175269.33801
+  dps: 251313.05543
+  tps: 175018.0457
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p1-Affliction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 95842.47267
-  tps: 86095.03075
+  dps: 94726.92557
+  tps: 86104.10931
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p1-Affliction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 95842.47267
-  tps: 70279.60616
+  dps: 94726.92557
+  tps: 70288.68471
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p1-Affliction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 130154.39847
-  tps: 89769.17135
+  dps: 127183.93275
+  tps: 90211.57077
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-preraid-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 94892.52032
-  tps: 81322.04798
+  dps: 94351.9097
+  tps: 81131.28786
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-preraid-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 94892.52032
-  tps: 67231.84458
+  dps: 94351.9097
+  tps: 67041.08446
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-preraid-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 164154.53679
-  tps: 106996.77504
+  dps: 159406.57411
+  tps: 106138.32966
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-preraid-Affliction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 57183.57459
-  tps: 53661.00328
+  dps: 56857.96615
+  tps: 53617.56444
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-preraid-Affliction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 57183.57459
-  tps: 41187.57632
+  dps: 56857.96615
+  tps: 41144.13747
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-preraid-Affliction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 77582.67451
-  tps: 51803.38153
+  dps: 76935.96772
+  tps: 51812.64065
  }
 }
 dps_results: {
  key: "TestAffliction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 92193.23026
-  tps: 66010.96133
+  dps: 91749.86882
+  tps: 65968.52232
  }
 }

--- a/sim/warlock/demonology/TestDemonology.results
+++ b/sim/warlock/demonology/TestDemonology.results
@@ -33,2464 +33,2464 @@ character_stats_results: {
 dps_results: {
  key: "TestDemonology-AllItems-AgilePrimalDiamond"
  value: {
-  dps: 86370.38139
-  tps: 55176.61531
+  dps: 84612.46135
+  tps: 54822.69122
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-AlacrityofXuen-103989"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ArcaneBadgeoftheShieldwall-93347"
  value: {
-  dps: 86430.47123
-  tps: 55715.99692
+  dps: 84520.59455
+  tps: 55115.07974
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ArrowflightMedallion-93258"
  value: {
-  dps: 84334.41418
-  tps: 53906.68653
+  dps: 83412.58061
+  tps: 53933.2362
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-AssuranceofConsequence-105472"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-AusterePrimalDiamond"
  value: {
-  dps: 85457.0812
-  tps: 54380.74723
+  dps: 83838.03371
+  tps: 54072.81731
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BadJuju-96781"
  value: {
-  dps: 84618.25418
-  tps: 54713.51296
+  dps: 83408.03406
+  tps: 54360.716
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BadgeofKypariZar-84079"
  value: {
-  dps: 83106.70449
-  tps: 53619.8519
+  dps: 81917.94052
+  tps: 53278.78205
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BlossomofPureSnow-89081"
  value: {
-  dps: 88434.27169
-  tps: 56565.57582
+  dps: 87278.17348
+  tps: 56413.81656
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BottleofInfiniteStars-87057"
  value: {
-  dps: 83875.68975
-  tps: 54176.24065
+  dps: 82676.01019
+  tps: 53829.20475
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BraidofTenSongs-84072"
  value: {
-  dps: 83106.70449
-  tps: 53619.8519
+  dps: 81917.94052
+  tps: 53278.78205
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Brawler'sStatue-87571"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BreathoftheHydra-96827"
  value: {
-  dps: 94286.62267
-  tps: 60249.65728
+  dps: 91805.43993
+  tps: 59646.53048
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BroochofMunificentDeeds-87500"
  value: {
-  dps: 81329.02127
-  tps: 52309.79851
+  dps: 80714.60475
+  tps: 52576.4262
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BrutalTalismanoftheShado-PanAssault-94508"
  value: {
-  dps: 83472.40981
-  tps: 53597.04389
+  dps: 82210.68656
+  tps: 53341.41342
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BurningPrimalDiamond"
  value: {
-  dps: 87192.32752
-  tps: 55712.89406
+  dps: 85376.51611
+  tps: 55314.38908
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CapacitivePrimalDiamond"
  value: {
-  dps: 86141.65556
-  tps: 54765.63372
+  dps: 84265.42129
+  tps: 54359.60573
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CarbonicCarbuncle-81138"
  value: {
-  dps: 83533.23805
-  tps: 53714.88089
+  dps: 82575.44599
+  tps: 53476.68062
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Cha-Ye'sEssenceofBrilliance-96888"
  value: {
-  dps: 92470.28186
-  tps: 59116.76049
+  dps: 91202.50813
+  tps: 58884.46456
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CharmofTenSongs-84071"
  value: {
-  dps: 84626.74117
-  tps: 54162.21845
+  dps: 82508.53249
+  tps: 53667.36881
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CommunalIdolofDestruction-101168"
  value: {
-  dps: 85744.94269
-  tps: 55258.64928
+  dps: 84360.18775
+  tps: 54942.48165
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CommunalStoneofDestruction-101171"
  value: {
-  dps: 87980.83692
-  tps: 56817.27638
+  dps: 86584.42421
+  tps: 56350.4285
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CommunalStoneofWisdom-101183"
  value: {
-  dps: 85907.71891
-  tps: 55331.00745
+  dps: 84687.98277
+  tps: 54997.62001
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ContemplationofChi-Ji-103688"
  value: {
-  dps: 86388.73688
-  tps: 55632.46811
+  dps: 85173.88804
+  tps: 55317.04243
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ContemplationofChi-Ji-103988"
  value: {
-  dps: 88224.56987
-  tps: 56842.30794
+  dps: 87194.42736
+  tps: 56560.30359
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Coren'sColdChromiumCoaster-87574"
  value: {
-  dps: 83299.41776
-  tps: 53561.31101
+  dps: 82040.11615
+  tps: 53162.19111
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CoreofDecency-87497"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CourageousPrimalDiamond"
  value: {
-  dps: 86851.76254
-  tps: 55228.89368
+  dps: 85050.67061
+  tps: 54855.46405
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CraftedDreadfulGladiator'sBadgeofConquest-93419"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CraftedDreadfulGladiator'sBadgeofDominance-93600"
  value: {
-  dps: 85568.09052
-  tps: 55209.03975
+  dps: 84691.97185
+  tps: 55044.55252
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CraftedDreadfulGladiator'sBadgeofVictory-93606"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CraftedDreadfulGladiator'sEmblemofCruelty-93485"
  value: {
-  dps: 83196.48173
-  tps: 53502.35486
+  dps: 81937.42585
+  tps: 53132.55217
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CraftedDreadfulGladiator'sEmblemofMeditation-93487"
  value: {
-  dps: 82190.90765
-  tps: 52959.01676
+  dps: 81013.35486
+  tps: 52624.48948
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CraftedDreadfulGladiator'sEmblemofTenacity-93486"
  value: {
-  dps: 81340.8604
-  tps: 52364.21876
+  dps: 80771.0546
+  tps: 52600.21077
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CraftedDreadfulGladiator'sInsigniaofConquest-93424"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CraftedDreadfulGladiator'sInsigniaofDominance-93601"
  value: {
-  dps: 87206.45491
-  tps: 56208.66082
+  dps: 86088.53897
+  tps: 56000.82201
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CraftedDreadfulGladiator'sInsigniaofVictory-93611"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CraftedMalevolentGladiator'sBadgeofConquest-98755"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CraftedMalevolentGladiator'sBadgeofDominance-98910"
  value: {
-  dps: 86204.91873
-  tps: 55636.79586
+  dps: 85322.59554
+  tps: 55467.39644
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CraftedMalevolentGladiator'sBadgeofVictory-98912"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CraftedMalevolentGladiator'sEmblemofCruelty-98811"
  value: {
-  dps: 83497.90769
-  tps: 53693.65699
+  dps: 82315.06268
+  tps: 53322.17531
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CraftedMalevolentGladiator'sEmblemofMeditation-98813"
  value: {
-  dps: 82190.90765
-  tps: 52959.01676
+  dps: 81013.35486
+  tps: 52624.48948
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CraftedMalevolentGladiator'sEmblemofTenacity-98812"
  value: {
-  dps: 81261.94103
-  tps: 52254.2357
+  dps: 80625.52942
+  tps: 52453.8956
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CraftedMalevolentGladiator'sInsigniaofConquest-98760"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CraftedMalevolentGladiator'sInsigniaofDominance-98911"
  value: {
-  dps: 88007.0246
-  tps: 56686.9613
+  dps: 86899.33363
+  tps: 56528.5246
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CraftedMalevolentGladiator'sInsigniaofVictory-98917"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CurseofHubris-102307"
  value: {
-  dps: 85741.55659
-  tps: 54739.77108
+  dps: 84987.08984
+  tps: 54813.06056
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CurseofHubris-104649"
  value: {
-  dps: 86203.94968
-  tps: 54999.81693
+  dps: 85625.08973
+  tps: 55187.6039
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CurseofHubris-104898"
  value: {
-  dps: 85702.16532
-  tps: 54923.42954
+  dps: 84365.6864
+  tps: 54486.52894
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CurseofHubris-105147"
  value: {
-  dps: 85220.12966
-  tps: 54593.96777
+  dps: 83956.32658
+  tps: 54278.53592
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CurseofHubris-105396"
  value: {
-  dps: 85667.04361
-  tps: 54783.37351
+  dps: 84991.64965
+  tps: 54865.63773
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CurseofHubris-105645"
  value: {
-  dps: 86158.73134
-  tps: 55053.01131
+  dps: 85604.81355
+  tps: 55158.8181
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CutstitcherMedallion-93255"
  value: {
-  dps: 86388.73688
-  tps: 55632.46811
+  dps: 85173.88804
+  tps: 55317.04243
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Daelo'sFinalWords-87496"
  value: {
-  dps: 83472.40981
-  tps: 53597.04389
+  dps: 82210.68656
+  tps: 53341.41342
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkglowEmbroidery(Rank3)-4893"
  value: {
-  dps: 84236.76781
-  tps: 53777.64969
+  dps: 82266.43563
+  tps: 53277.69805
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmistVortex-87172"
  value: {
-  dps: 84647.89455
-  tps: 54368.68048
+  dps: 84247.32108
+  tps: 54821.49276
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DeadeyeBadgeoftheShieldwall-93346"
  value: {
-  dps: 83824.90764
-  tps: 54215.24611
+  dps: 82668.80028
+  tps: 53907.66123
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DelicateVialoftheSanguinaire-96895"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DestructivePrimalDiamond"
  value: {
-  dps: 86236.82654
-  tps: 54825.78965
+  dps: 84366.5605
+  tps: 54423.8493
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DisciplineofXuen-103986"
  value: {
-  dps: 85552.5739
-  tps: 55314.85848
+  dps: 84313.82566
+  tps: 54870.16349
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Dominator'sArcaneBadge-93342"
  value: {
-  dps: 86430.47123
-  tps: 55715.99692
+  dps: 84520.59455
+  tps: 55115.07974
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Dominator'sDeadeyeBadge-93341"
  value: {
-  dps: 83824.90764
-  tps: 54215.24611
+  dps: 82668.80028
+  tps: 53907.66123
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Dominator'sDurableBadge-93345"
  value: {
-  dps: 83824.90764
-  tps: 54215.24611
+  dps: 82668.80028
+  tps: 53907.66123
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Dominator'sKnightlyBadge-93344"
  value: {
-  dps: 83824.90764
-  tps: 54215.24611
+  dps: 82668.80028
+  tps: 53907.66123
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Dominator'sMendingBadge-93343"
  value: {
-  dps: 85148.14215
-  tps: 54845.72795
+  dps: 83935.25432
+  tps: 54514.67201
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DreadfulGladiator'sBadgeofConquest-84344"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DreadfulGladiator'sBadgeofDominance-84488"
  value: {
-  dps: 85568.09052
-  tps: 55209.03975
+  dps: 84691.97185
+  tps: 55044.55252
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DreadfulGladiator'sBadgeofVictory-84490"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DreadfulGladiator'sEmblemofCruelty-84399"
  value: {
-  dps: 83196.48173
-  tps: 53502.35486
+  dps: 81937.42585
+  tps: 53132.55217
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DreadfulGladiator'sEmblemofMeditation-84401"
  value: {
-  dps: 82190.90765
-  tps: 52959.01676
+  dps: 81013.35486
+  tps: 52624.48948
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DreadfulGladiator'sEmblemofTenacity-84400"
  value: {
-  dps: 81340.8604
-  tps: 52364.21876
+  dps: 80771.0546
+  tps: 52600.21077
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DreadfulGladiator'sInsigniaofConquest-84349"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DreadfulGladiator'sInsigniaofDominance-84489"
  value: {
-  dps: 87062.63812
-  tps: 56103.54688
+  dps: 85775.63185
+  tps: 55770.47609
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DreadfulGladiator'sInsigniaofVictory-84495"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DurableBadgeoftheShieldwall-93350"
  value: {
-  dps: 83824.90764
-  tps: 54215.24611
+  dps: 82668.80028
+  tps: 53907.66123
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EffulgentPrimalDiamond"
  value: {
-  dps: 85457.0812
-  tps: 54380.74723
+  dps: 83838.03371
+  tps: 54072.81731
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EmberPrimalDiamond"
  value: {
-  dps: 86458.89288
-  tps: 54983.73555
+  dps: 84658.35503
+  tps: 54603.19335
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EmblemofKypariZar-84077"
  value: {
-  dps: 82882.47382
-  tps: 53340.29891
+  dps: 81843.35442
+  tps: 53084.11181
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EmblemoftheCatacombs-83733"
  value: {
-  dps: 82120.63472
-  tps: 52778.30264
+  dps: 81485.91978
+  tps: 53291.94513
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EmptyFruitBarrel-81133"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnchantWeapon-BloodyDancingSteel-5125"
  value: {
-  dps: 84174.02203
-  tps: 53840.62742
+  dps: 82560.31864
+  tps: 53580.74514
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnchantWeapon-Colossus-4445"
  value: {
-  dps: 84174.02203
-  tps: 53840.62742
+  dps: 82560.31864
+  tps: 53580.74514
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnchantWeapon-DancingSteel-4444"
  value: {
-  dps: 84174.02203
-  tps: 53840.62742
+  dps: 82560.31864
+  tps: 53580.74514
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnchantWeapon-ElementalForce-4443"
  value: {
-  dps: 85311.50846
-  tps: 55015.27001
+  dps: 83665.03675
+  tps: 54707.44727
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnchantWeapon-River'sSong-4446"
  value: {
-  dps: 84174.02203
-  tps: 53840.62742
+  dps: 82560.31864
+  tps: 53580.74514
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnchantWeapon-SpiritofConquest-5124"
  value: {
-  dps: 84174.02203
-  tps: 53840.62742
+  dps: 82560.31864
+  tps: 53580.74514
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnchantWeapon-Windsong-4441"
  value: {
-  dps: 85646.50264
-  tps: 54710.40032
+  dps: 83864.90602
+  tps: 54228.28405
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnigmaticPrimalDiamond"
  value: {
-  dps: 86236.82654
-  tps: 54825.78965
+  dps: 84366.5605
+  tps: 54423.8493
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EssenceofTerror-87175"
  value: {
-  dps: 90008.43918
-  tps: 57621.93024
+  dps: 88906.52906
+  tps: 57657.71587
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EternalPrimalDiamond"
  value: {
-  dps: 85646.30674
-  tps: 54456.79067
+  dps: 83901.21797
+  tps: 54118.37065
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EvilEyeofGalakras-105491"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FabledFeatherofJi-Kun-96842"
  value: {
-  dps: 83472.40981
-  tps: 53597.04389
+  dps: 82210.68656
+  tps: 53341.41342
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FearwurmBadge-84074"
  value: {
-  dps: 82882.47382
-  tps: 53340.29891
+  dps: 81843.35442
+  tps: 53084.11181
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FearwurmRelic-84070"
  value: {
-  dps: 84613.45641
-  tps: 54288.89434
+  dps: 82910.09327
+  tps: 53749.32865
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FelsoulIdolofDestruction-101263"
  value: {
-  dps: 85499.02113
-  tps: 55095.83524
+  dps: 83825.75365
+  tps: 54845.54338
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FelsoulStoneofDestruction-101266"
  value: {
-  dps: 88150.662
-  tps: 56927.27647
+  dps: 86979.55013
+  tps: 56584.92372
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Fen-Yu,FuryofXuen-102248"
  value: {
-  dps: 85403.84807
-  tps: 54286.01297
+  dps: 84162.59809
+  tps: 54255.63791
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FlashfrozenResinGlobule-100951"
  value: {
-  dps: 86438.363
-  tps: 55298.74945
+  dps: 85245.30895
+  tps: 55085.31162
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FlashingSteelTalisman-81265"
  value: {
-  dps: 83472.40981
-  tps: 53597.04389
+  dps: 82210.68656
+  tps: 53341.41342
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FleetPrimalDiamond"
  value: {
-  dps: 86267.4846
-  tps: 54901.2702
+  dps: 84510.87032
+  tps: 54558.34879
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForlornPrimalDiamond"
  value: {
-  dps: 86458.89288
-  tps: 54983.73555
+  dps: 84658.35503
+  tps: 54603.19335
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FortitudeoftheZandalari-94516"
  value: {
-  dps: 84231.05639
-  tps: 54435.15045
+  dps: 83024.50757
+  tps: 54084.79566
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FortitudeoftheZandalari-95677"
  value: {
-  dps: 83884.77347
-  tps: 54184.60015
+  dps: 82683.14627
+  tps: 53836.93183
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FortitudeoftheZandalari-96049"
  value: {
-  dps: 84349.26541
-  tps: 54520.67966
+  dps: 83141.03653
+  tps: 54169.40781
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FortitudeoftheZandalari-96421"
  value: {
-  dps: 84495.28833
-  tps: 54626.3334
+  dps: 83284.98407
+  tps: 54273.92871
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FortitudeoftheZandalari-96793"
  value: {
-  dps: 84627.4043
-  tps: 54721.92488
+  dps: 83415.22231
+  tps: 54368.49523
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GazeoftheTwins-96915"
  value: {
-  dps: 83859.25803
-  tps: 53912.70989
+  dps: 82833.24794
+  tps: 53667.31601
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Gerp'sPerfectArrow-87495"
  value: {
-  dps: 82922.25523
-  tps: 53370.47154
+  dps: 81868.744
+  tps: 53091.08677
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Gong-Lu,StrengthofXuen-102249"
  value: {
-  dps: 85403.84807
-  tps: 54286.01297
+  dps: 84162.59809
+  tps: 54255.63791
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GrievousGladiator'sBadgeofConquest-100195"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GrievousGladiator'sBadgeofConquest-100603"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GrievousGladiator'sBadgeofConquest-102856"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GrievousGladiator'sBadgeofConquest-103145"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GrievousGladiator'sBadgeofDominance-100490"
  value: {
-  dps: 88790.73295
-  tps: 57280.81713
+  dps: 87754.96852
+  tps: 57078.13857
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GrievousGladiator'sBadgeofDominance-100576"
  value: {
-  dps: 88790.73295
-  tps: 57280.81713
+  dps: 87754.96852
+  tps: 57078.13857
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GrievousGladiator'sBadgeofDominance-102830"
  value: {
-  dps: 88790.73295
-  tps: 57280.81713
+  dps: 87754.96852
+  tps: 57078.13857
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GrievousGladiator'sBadgeofDominance-103308"
  value: {
-  dps: 88790.73295
-  tps: 57280.81713
+  dps: 87754.96852
+  tps: 57078.13857
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GrievousGladiator'sBadgeofVictory-100500"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GrievousGladiator'sBadgeofVictory-100579"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GrievousGladiator'sBadgeofVictory-102833"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GrievousGladiator'sBadgeofVictory-103314"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GrievousGladiator'sEmblemofCruelty-100305"
  value: {
-  dps: 84035.10278
-  tps: 54033.43845
+  dps: 82971.62676
+  tps: 53624.89735
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GrievousGladiator'sEmblemofCruelty-100626"
  value: {
-  dps: 84035.10278
-  tps: 54033.43845
+  dps: 82971.62676
+  tps: 53624.89735
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GrievousGladiator'sEmblemofCruelty-102877"
  value: {
-  dps: 84035.10278
-  tps: 54033.43845
+  dps: 82971.62676
+  tps: 53624.89735
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GrievousGladiator'sEmblemofCruelty-103210"
  value: {
-  dps: 84035.10278
-  tps: 54033.43845
+  dps: 82971.62676
+  tps: 53624.89735
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GrievousGladiator'sEmblemofMeditation-100307"
  value: {
-  dps: 82190.90765
-  tps: 52959.01676
+  dps: 81013.35486
+  tps: 52624.48948
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GrievousGladiator'sEmblemofMeditation-100559"
  value: {
-  dps: 82190.90765
-  tps: 52959.01676
+  dps: 81013.35486
+  tps: 52624.48948
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GrievousGladiator'sEmblemofMeditation-102813"
  value: {
-  dps: 82190.90765
-  tps: 52959.01676
+  dps: 81013.35486
+  tps: 52624.48948
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GrievousGladiator'sEmblemofMeditation-103212"
  value: {
-  dps: 82190.90765
-  tps: 52959.01676
+  dps: 81013.35486
+  tps: 52624.48948
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GrievousGladiator'sEmblemofTenacity-100306"
  value: {
-  dps: 81418.23442
-  tps: 52383.88492
+  dps: 80588.36652
+  tps: 52331.64869
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GrievousGladiator'sEmblemofTenacity-100652"
  value: {
-  dps: 81418.23442
-  tps: 52383.88492
+  dps: 80588.36652
+  tps: 52331.64869
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GrievousGladiator'sEmblemofTenacity-102903"
  value: {
-  dps: 81418.23442
-  tps: 52383.88492
+  dps: 80588.36652
+  tps: 52331.64869
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GrievousGladiator'sEmblemofTenacity-103211"
  value: {
-  dps: 81418.23442
-  tps: 52383.88492
+  dps: 80588.36652
+  tps: 52331.64869
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GrievousGladiator'sInsigniaofConquest-103150"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GrievousGladiator'sInsigniaofDominance-103309"
  value: {
-  dps: 91206.03856
-  tps: 58896.02875
+  dps: 90049.35042
+  tps: 58611.97871
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GrievousGladiator'sInsigniaofVictory-103319"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Hawkmaster'sTalon-89082"
  value: {
-  dps: 84963.2151
-  tps: 54827.73935
+  dps: 83660.16758
+  tps: 54804.87749
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Heart-LesionDefenderIdol-100999"
  value: {
-  dps: 81445.09972
-  tps: 52436.03675
+  dps: 80487.68892
+  tps: 52151.05141
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Heart-LesionDefenderStone-101002"
  value: {
-  dps: 83454.15607
-  tps: 53872.67269
+  dps: 82518.73449
+  tps: 53569.99417
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Heart-LesionIdolofBattle-100991"
  value: {
-  dps: 83534.13136
-  tps: 53704.13236
+  dps: 82357.4458
+  tps: 53351.12528
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Heart-LesionStoneofBattle-100990"
  value: {
-  dps: 84237.50434
-  tps: 54434.87044
+  dps: 83065.03984
+  tps: 54129.23096
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofFire-81181"
  value: {
-  dps: 83359.78825
-  tps: 53802.96719
+  dps: 82167.4318
+  tps: 53459.93383
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartwarmerMedallion-93260"
  value: {
-  dps: 86388.73688
-  tps: 55632.46811
+  dps: 85173.88804
+  tps: 55317.04243
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HelmbreakerMedallion-93261"
  value: {
-  dps: 84334.41418
-  tps: 53906.68653
+  dps: 83412.58061
+  tps: 53933.2362
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Horridon'sLastGasp-96757"
  value: {
-  dps: 88583.58671
-  tps: 57068.2306
+  dps: 87540.76517
+  tps: 56784.43496
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpassivePrimalDiamond"
  value: {
-  dps: 86236.82654
-  tps: 54825.78965
+  dps: 84366.5605
+  tps: 54423.8493
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-IndomitablePrimalDiamond"
  value: {
-  dps: 85457.0812
-  tps: 54380.74723
+  dps: 83838.03371
+  tps: 54072.81731
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InscribedBagofHydra-Spawn-96828"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InsigniaofKypariZar-84078"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-IronBellyWok-89083"
  value: {
-  dps: 84963.2151
-  tps: 54827.73935
+  dps: 83660.16758
+  tps: 54804.87749
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-IronProtectorTalisman-85181"
  value: {
-  dps: 81177.32386
-  tps: 52255.71752
+  dps: 80594.95048
+  tps: 52419.018
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-JadeBanditFigurine-86043"
  value: {
-  dps: 84963.2151
-  tps: 54827.73935
+  dps: 83660.16758
+  tps: 54804.87749
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-JadeBanditFigurine-86772"
  value: {
-  dps: 83884.90494
-  tps: 54203.82854
+  dps: 83352.35807
+  tps: 54501.19884
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-JadeCharioteerFigurine-86042"
  value: {
-  dps: 84963.2151
-  tps: 54827.73935
+  dps: 83660.16758
+  tps: 54804.87749
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-JadeCharioteerFigurine-86771"
  value: {
-  dps: 83884.90494
-  tps: 54203.82854
+  dps: 83352.35807
+  tps: 54501.19884
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-JadeCourtesanFigurine-86045"
  value: {
-  dps: 86120.08925
-  tps: 55464.1401
+  dps: 84892.8099
+  tps: 55128.35214
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-JadeCourtesanFigurine-86774"
  value: {
-  dps: 85674.14383
-  tps: 55180.28896
+  dps: 84453.87878
+  tps: 54846.10528
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-JadeMagistrateFigurine-86044"
  value: {
-  dps: 88434.27169
-  tps: 56565.57582
+  dps: 87278.17348
+  tps: 56413.81656
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-JadeMagistrateFigurine-86773"
  value: {
-  dps: 87726.83431
-  tps: 56188.91127
+  dps: 86718.75792
+  tps: 56112.56904
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-JadeWarlordFigurine-86046"
  value: {
-  dps: 83540.95153
-  tps: 54079.61553
+  dps: 82688.73132
+  tps: 53868.84992
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-JadeWarlordFigurine-86775"
  value: {
-  dps: 83311.45305
-  tps: 53880.58251
+  dps: 82461.82439
+  tps: 53681.13607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Ji-Kun'sRisingWinds-96843"
  value: {
-  dps: 83472.40981
-  tps: 53597.04389
+  dps: 82210.68656
+  tps: 53341.41342
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-KnightlyBadgeoftheShieldwall-93349"
  value: {
-  dps: 83824.90764
-  tps: 54215.24611
+  dps: 82668.80028
+  tps: 53907.66123
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-KnotofTenSongs-84073"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Kor'kronBookofHurting-92785"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Lao-Chin'sLiquidCourage-89079"
  value: {
-  dps: 83540.95153
-  tps: 54079.61553
+  dps: 82688.73132
+  tps: 53868.84992
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LeiShen'sFinalOrders-87072"
  value: {
-  dps: 84143.45489
-  tps: 53907.75607
+  dps: 82692.83623
+  tps: 53703.6602
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LessonsoftheDarkmaster-81268"
  value: {
-  dps: 83472.40981
-  tps: 53597.04389
+  dps: 82210.68656
+  tps: 53341.41342
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LightdrinkerIdolofRage-101200"
  value: {
-  dps: 83601.74744
-  tps: 53978.03344
+  dps: 82405.95644
+  tps: 53633.12289
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LightdrinkerStoneofRage-101203"
  value: {
-  dps: 84245.43189
-  tps: 54410.40689
+  dps: 83039.38345
+  tps: 54052.58758
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LightoftheCosmos-87065"
  value: {
-  dps: 90046.20516
-  tps: 57653.07085
+  dps: 88108.91983
+  tps: 57132.16581
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LordBlastington'sScopeofDoom-4699"
  value: {
-  dps: 84174.02203
-  tps: 53840.62742
+  dps: 82560.31864
+  tps: 53580.74514
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MalevolentGladiator'sBadgeofConquest-84934"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MalevolentGladiator'sBadgeofConquest-91452"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MalevolentGladiator'sBadgeofDominance-84940"
  value: {
-  dps: 86542.32535
-  tps: 55822.16425
+  dps: 85607.08594
+  tps: 55659.33911
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MalevolentGladiator'sBadgeofDominance-91753"
  value: {
-  dps: 86204.91873
-  tps: 55636.79586
+  dps: 85322.59554
+  tps: 55467.39644
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MalevolentGladiator'sBadgeofVictory-84942"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MalevolentGladiator'sBadgeofVictory-91763"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MalevolentGladiator'sEmblemofCruelty-84936"
  value: {
-  dps: 83543.222
-  tps: 53712.23357
+  dps: 82364.62074
+  tps: 53358.89126
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MalevolentGladiator'sEmblemofCruelty-91562"
  value: {
-  dps: 83497.90769
-  tps: 53693.65699
+  dps: 82315.06268
+  tps: 53322.17531
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MalevolentGladiator'sEmblemofMeditation-84939"
  value: {
-  dps: 82190.90765
-  tps: 52959.01676
+  dps: 81013.35486
+  tps: 52624.48948
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MalevolentGladiator'sEmblemofMeditation-91564"
  value: {
-  dps: 82190.90765
-  tps: 52959.01676
+  dps: 81013.35486
+  tps: 52624.48948
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MalevolentGladiator'sEmblemofTenacity-84938"
  value: {
-  dps: 81150.56447
-  tps: 52229.24678
+  dps: 80728.99087
+  tps: 52497.75541
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MalevolentGladiator'sEmblemofTenacity-91563"
  value: {
-  dps: 81261.94103
-  tps: 52254.2357
+  dps: 80625.52942
+  tps: 52453.8956
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MalevolentGladiator'sInsigniaofConquest-91457"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MalevolentGladiator'sInsigniaofDominance-91754"
  value: {
-  dps: 88082.15174
-  tps: 56768.03349
+  dps: 86898.73569
+  tps: 56520.70313
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MalevolentGladiator'sInsigniaofVictory-91768"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MarkoftheCatacombs-83731"
  value: {
-  dps: 84011.73866
-  tps: 54216.98372
+  dps: 83044.07106
+  tps: 53982.73273
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MarkoftheHardenedGrunt-92783"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MedallionofMystifyingVapors-93257"
  value: {
-  dps: 84535.84365
-  tps: 54765.90865
+  dps: 83375.64008
+  tps: 54456.47035
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MedallionoftheCatacombs-83734"
  value: {
-  dps: 83039.95713
-  tps: 53571.55776
+  dps: 81852.14062
+  tps: 53231.00576
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MendingBadgeoftheShieldwall-93348"
  value: {
-  dps: 85148.14215
-  tps: 54845.72795
+  dps: 83935.25432
+  tps: 54514.67201
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MirrorScope-4700"
  value: {
-  dps: 84174.02203
-  tps: 53840.62742
+  dps: 82560.31864
+  tps: 53580.74514
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MistdancerDefenderIdol-101089"
  value: {
-  dps: 81445.09972
-  tps: 52436.03675
+  dps: 80487.68892
+  tps: 52151.05141
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MistdancerDefenderStone-101087"
  value: {
-  dps: 83645.522
-  tps: 54009.46349
+  dps: 82487.24969
+  tps: 53559.36735
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MistdancerIdolofRage-101113"
  value: {
-  dps: 83601.74744
-  tps: 53978.03344
+  dps: 82405.95644
+  tps: 53633.12289
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MistdancerStoneofRage-101117"
  value: {
-  dps: 84247.05502
-  tps: 54428.58174
+  dps: 83124.83552
+  tps: 54089.16569
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MistdancerStoneofWisdom-101107"
  value: {
-  dps: 85907.71891
-  tps: 55331.00745
+  dps: 84687.98277
+  tps: 54997.62001
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MithrilWristwatch-87572"
  value: {
-  dps: 84173.65888
-  tps: 54107.85751
+  dps: 83016.77705
+  tps: 53789.87011
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MountainsageIdolofDestruction-101069"
  value: {
-  dps: 84979.95055
-  tps: 54639.67659
+  dps: 83439.86796
+  tps: 54217.9619
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MountainsageStoneofDestruction-101072"
  value: {
-  dps: 88146.31271
-  tps: 56958.23107
+  dps: 86988.26233
+  tps: 56615.40132
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-NitroBoosts-4223"
  value: {
-  dps: 87192.32752
-  tps: 55712.89406
+  dps: 85376.51611
+  tps: 55314.38908
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-OathswornDefenderIdol-101303"
  value: {
-  dps: 81445.09972
-  tps: 52436.03675
+  dps: 80487.68892
+  tps: 52151.05141
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-OathswornDefenderStone-101306"
  value: {
-  dps: 83456.64291
-  tps: 53894.31208
+  dps: 82445.24779
+  tps: 53547.29754
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-OathswornIdolofBattle-101295"
  value: {
-  dps: 83534.13136
-  tps: 53704.13236
+  dps: 82357.4458
+  tps: 53351.12528
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-OathswornStoneofBattle-101294"
  value: {
-  dps: 84316.97265
-  tps: 54448.885
+  dps: 83183.19187
+  tps: 54188.62636
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PhaseFingers-4697"
  value: {
-  dps: 86943.11485
-  tps: 55533.84979
+  dps: 85132.09621
+  tps: 55137.3548
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PouchofWhiteAsh-103639"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PowerfulPrimalDiamond"
  value: {
-  dps: 85457.0812
-  tps: 54380.74723
+  dps: 83838.03371
+  tps: 54072.81731
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PriceofProgress-81266"
  value: {
-  dps: 85282.70916
-  tps: 54931.86254
+  dps: 84067.15073
+  tps: 54599.44535
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PridefulGladiator'sBadgeofConquest-102659"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PridefulGladiator'sBadgeofConquest-103342"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PridefulGladiator'sBadgeofDominance-102633"
  value: {
-  dps: 90738.2552
-  tps: 58598.8485
+  dps: 89750.25962
+  tps: 58436.07247
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PridefulGladiator'sBadgeofDominance-103505"
  value: {
-  dps: 90738.2552
-  tps: 58598.8485
+  dps: 89750.25962
+  tps: 58436.07247
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PridefulGladiator'sBadgeofVictory-102636"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PridefulGladiator'sBadgeofVictory-103511"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PridefulGladiator'sEmblemofCruelty-102680"
  value: {
-  dps: 84584.41363
-  tps: 54300.9012
+  dps: 83546.44252
+  tps: 53910.70227
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PridefulGladiator'sEmblemofCruelty-103407"
  value: {
-  dps: 84584.41363
-  tps: 54300.9012
+  dps: 83546.44252
+  tps: 53910.70227
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PridefulGladiator'sEmblemofMeditation-102616"
  value: {
-  dps: 82190.90765
-  tps: 52959.01676
+  dps: 81013.35486
+  tps: 52624.48948
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PridefulGladiator'sEmblemofMeditation-103409"
  value: {
-  dps: 82190.90765
-  tps: 52959.01676
+  dps: 81013.35486
+  tps: 52624.48948
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PridefulGladiator'sEmblemofTenacity-102706"
  value: {
-  dps: 81598.01696
-  tps: 52548.54054
+  dps: 80912.1945
+  tps: 52461.03352
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PridefulGladiator'sEmblemofTenacity-103408"
  value: {
-  dps: 81598.01696
-  tps: 52548.54054
+  dps: 80912.1945
+  tps: 52461.03352
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PridefulGladiator'sInsigniaofConquest-103347"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PridefulGladiator'sInsigniaofDominance-103506"
  value: {
-  dps: 94058.05592
-  tps: 60665.58056
+  dps: 93380.59482
+  tps: 60766.62761
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PridefulGladiator'sInsigniaofVictory-103516"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Primordius'TalismanofRage-96873"
  value: {
-  dps: 84444.83819
-  tps: 54228.01462
+  dps: 83334.09154
+  tps: 53807.16599
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Qian-Le,CourageofNiuzao-102245"
  value: {
-  dps: 84538.08034
-  tps: 54202.53675
+  dps: 83047.69702
+  tps: 53794.2644
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Qian-Ying,FortitudeofNiuzao-102250"
  value: {
-  dps: 83362.40932
-  tps: 53495.9628
+  dps: 81852.12307
+  tps: 53018.3986
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Qin-xi'sPolarizingSeal-87075"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RegaliaoftheHornedNightmare"
  value: {
-  dps: 99883.73598
-  tps: 64116.85598
+  dps: 97066.56285
+  tps: 63018.79484
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RegaliaoftheThousandfoldHells"
  value: {
-  dps: 96666.31415
-  tps: 61081.54694
+  dps: 95384.40271
+  tps: 61190.94784
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RelicofChi-Ji-79330"
  value: {
-  dps: 86406.35988
-  tps: 55643.71495
+  dps: 85191.26019
+  tps: 55328.21182
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RelicofKypariZar-84075"
  value: {
-  dps: 84076.43227
-  tps: 53933.00552
+  dps: 82777.62055
+  tps: 53964.42884
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RelicofNiuzao-79329"
  value: {
-  dps: 81364.83347
-  tps: 52385.52859
+  dps: 80503.77599
+  tps: 52165.59068
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RelicofXuen-79327"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RelicofXuen-79328"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Renataki'sSoulCharm-96741"
  value: {
-  dps: 83472.40981
-  tps: 53597.04389
+  dps: 82210.68656
+  tps: 53341.41342
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ResolveofNiuzao-103690"
  value: {
-  dps: 83783.91213
-  tps: 54109.8362
+  dps: 82585.53532
+  tps: 53763.51235
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ResolveofNiuzao-103990"
  value: {
-  dps: 84486.15002
-  tps: 54617.93081
+  dps: 83277.80509
+  tps: 54266.15876
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ReverberatingPrimalDiamond"
  value: {
-  dps: 86370.38139
-  tps: 55176.61531
+  dps: 84612.46135
+  tps: 54822.69122
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RevitalizingPrimalDiamond"
  value: {
-  dps: 86370.38139
-  tps: 55176.61531
+  dps: 84612.46135
+  tps: 54822.69122
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SI:7Operative'sManual-92784"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ScrollofReveredAncestors-89080"
  value: {
-  dps: 86120.08925
-  tps: 55464.1401
+  dps: 84892.8099
+  tps: 55128.35214
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SearingWords-81267"
  value: {
-  dps: 83238.27741
-  tps: 53533.50273
+  dps: 81981.37487
+  tps: 53144.83307
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Sha-SkinRegalia"
  value: {
-  dps: 91528.8492
-  tps: 59482.687
+  dps: 90267.88797
+  tps: 59576.40752
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ShadowflameRegalia"
  value: {
-  dps: 64494.42124
-  tps: 40649.67666
+  dps: 63969.20863
+  tps: 40772.29398
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Shock-ChargerMedallion-93259"
  value: {
-  dps: 89832.30302
-  tps: 57638.61174
+  dps: 88615.03694
+  tps: 57556.83905
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SigilofCompassion-83736"
  value: {
-  dps: 83039.95713
-  tps: 53571.55776
+  dps: 81852.14062
+  tps: 53231.00576
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SigilofDevotion-83740"
  value: {
-  dps: 82784.99651
-  tps: 53302.70187
+  dps: 81808.84466
+  tps: 53061.88225
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SigilofFidelity-83737"
  value: {
-  dps: 83650.8462
-  tps: 53584.31068
+  dps: 82877.53907
+  tps: 54135.43768
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SigilofGrace-83738"
  value: {
-  dps: 83039.95713
-  tps: 53571.55776
+  dps: 81852.14062
+  tps: 53231.00576
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SigilofKypariZar-84076"
  value: {
-  dps: 84124.95347
-  tps: 54259.42535
+  dps: 83086.05276
+  tps: 53997.38051
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SigilofPatience-83739"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SigiloftheCatacombs-83732"
  value: {
-  dps: 84757.8798
-  tps: 54286.50179
+  dps: 82460.56686
+  tps: 53486.42572
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SinisterPrimalDiamond"
  value: {
-  dps: 86141.65556
-  tps: 54765.63372
+  dps: 84265.42129
+  tps: 54359.60573
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SkullrenderMedallion-93256"
  value: {
-  dps: 84334.41418
-  tps: 53906.68653
+  dps: 83412.58061
+  tps: 53933.2362
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SpiritsoftheSun-87163"
  value: {
-  dps: 86864.01613
-  tps: 55961.74767
+  dps: 85767.36976
+  tps: 55664.21309
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SpringrainIdolofDestruction-101023"
  value: {
-  dps: 86154.848
-  tps: 55370.59691
+  dps: 84274.96315
+  tps: 55066.69216
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SpringrainIdolofRage-101009"
  value: {
-  dps: 83601.74744
-  tps: 53978.03344
+  dps: 82405.95644
+  tps: 53633.12289
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SpringrainStoneofDestruction-101026"
  value: {
-  dps: 88202.99049
-  tps: 56985.70057
+  dps: 86957.20292
+  tps: 56653.5347
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SpringrainStoneofRage-101012"
  value: {
-  dps: 84437.95883
-  tps: 54579.62615
+  dps: 83225.34715
+  tps: 54159.23016
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SpringrainStoneofWisdom-101041"
  value: {
-  dps: 85907.71891
-  tps: 55331.00745
+  dps: 84687.98277
+  tps: 54997.62001
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Static-Caster'sMedallion-93254"
  value: {
-  dps: 89832.30302
-  tps: 57638.61174
+  dps: 88615.03694
+  tps: 57556.83905
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SteadfastFootman'sMedallion-92782"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SteadfastTalismanoftheShado-PanAssault-94507"
  value: {
-  dps: 84221.9417
-  tps: 54426.7665
+  dps: 83017.34716
+  tps: 54077.04427
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-StreamtalkerIdolofDestruction-101222"
  value: {
-  dps: 85780.29548
-  tps: 55138.55188
+  dps: 84019.36309
+  tps: 54869.50948
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-StreamtalkerIdolofRage-101217"
  value: {
-  dps: 83601.74744
-  tps: 53978.03344
+  dps: 82405.95644
+  tps: 53633.12289
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-StreamtalkerStoneofDestruction-101225"
  value: {
-  dps: 87913.72737
-  tps: 56760.55469
+  dps: 86717.48402
+  tps: 56405.28782
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-StreamtalkerStoneofRage-101220"
  value: {
-  dps: 83975.78712
-  tps: 54281.31254
+  dps: 83084.24219
+  tps: 54117.49429
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-StreamtalkerStoneofWisdom-101250"
  value: {
-  dps: 85907.71891
-  tps: 55331.00745
+  dps: 84687.98277
+  tps: 54997.62001
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-StuffofNightmares-87160"
  value: {
-  dps: 83989.7165
-  tps: 54258.74314
+  dps: 82788.41835
+  tps: 53910.82258
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SunsoulDefenderIdol-101160"
  value: {
-  dps: 81445.09972
-  tps: 52436.03675
+  dps: 80487.68892
+  tps: 52151.05141
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SunsoulDefenderStone-101163"
  value: {
-  dps: 83501.58377
-  tps: 53892.98516
+  dps: 82585.37753
+  tps: 53632.89983
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SunsoulIdolofBattle-101152"
  value: {
-  dps: 83534.13136
-  tps: 53704.13236
+  dps: 82357.4458
+  tps: 53351.12528
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SunsoulStoneofBattle-101151"
  value: {
-  dps: 84349.89163
-  tps: 54509.18249
+  dps: 83161.37838
+  tps: 54168.97907
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SunsoulStoneofWisdom-101138"
  value: {
-  dps: 85907.71891
-  tps: 55331.00745
+  dps: 84687.98277
+  tps: 54997.62001
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SwordguardEmbroidery(Rank3)-4894"
  value: {
-  dps: 84236.76781
-  tps: 53777.64969
+  dps: 82266.43563
+  tps: 53277.69805
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SymboloftheCatacombs-83735"
  value: {
-  dps: 83039.95713
-  tps: 53571.55776
+  dps: 81852.14062
+  tps: 53231.00576
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SynapseSprings(MarkII)-4898"
  value: {
-  dps: 87782.44459
-  tps: 55998.11292
+  dps: 86085.59158
+  tps: 55623.26148
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TalismanofBloodlust-96864"
  value: {
-  dps: 85417.18452
-  tps: 54794.62067
+  dps: 83480.70497
+  tps: 54419.49795
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TerrorintheMists-87167"
  value: {
-  dps: 84665.01558
-  tps: 54289.65564
+  dps: 83886.5281
+  tps: 54434.81148
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Thousand-YearPickledEgg-87573"
  value: {
-  dps: 85486.89785
-  tps: 55063.4026
+  dps: 84269.89653
+  tps: 54726.61772
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TrailseekerIdolofRage-101054"
  value: {
-  dps: 83601.74744
-  tps: 53978.03344
+  dps: 82405.95644
+  tps: 53633.12289
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TrailseekerStoneofRage-101057"
  value: {
-  dps: 84386.75765
-  tps: 54560.45888
+  dps: 83174.83724
+  tps: 54199.81581
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TyrannicalGladiator'sBadgeofConquest-100043"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TyrannicalGladiator'sBadgeofConquest-91099"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TyrannicalGladiator'sBadgeofConquest-94373"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TyrannicalGladiator'sBadgeofConquest-99772"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TyrannicalGladiator'sBadgeofDominance-100016"
  value: {
-  dps: 87290.62707
-  tps: 56285.3242
+  dps: 86163.73533
+  tps: 56024.15828
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TyrannicalGladiator'sBadgeofDominance-91400"
  value: {
-  dps: 87290.62707
-  tps: 56285.3242
+  dps: 86163.73533
+  tps: 56024.15828
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TyrannicalGladiator'sBadgeofDominance-94346"
  value: {
-  dps: 87290.62707
-  tps: 56285.3242
+  dps: 86163.73533
+  tps: 56024.15828
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TyrannicalGladiator'sBadgeofDominance-99937"
  value: {
-  dps: 87290.62707
-  tps: 56285.3242
+  dps: 86163.73533
+  tps: 56024.15828
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TyrannicalGladiator'sBadgeofVictory-100019"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TyrannicalGladiator'sBadgeofVictory-91410"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TyrannicalGladiator'sBadgeofVictory-94349"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TyrannicalGladiator'sBadgeofVictory-99943"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TyrannicalGladiator'sEmblemofCruelty-100066"
  value: {
-  dps: 83717.64817
-  tps: 53838.26721
+  dps: 82545.81683
+  tps: 53479.44104
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TyrannicalGladiator'sEmblemofCruelty-91209"
  value: {
-  dps: 83717.64817
-  tps: 53838.26721
+  dps: 82545.81683
+  tps: 53479.44104
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TyrannicalGladiator'sEmblemofCruelty-94396"
  value: {
-  dps: 83717.64817
-  tps: 53838.26721
+  dps: 82545.81683
+  tps: 53479.44104
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TyrannicalGladiator'sEmblemofCruelty-99838"
  value: {
-  dps: 83717.64817
-  tps: 53838.26721
+  dps: 82545.81683
+  tps: 53479.44104
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TyrannicalGladiator'sEmblemofMeditation-91211"
  value: {
-  dps: 82190.90765
-  tps: 52959.01676
+  dps: 81013.35486
+  tps: 52624.48948
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TyrannicalGladiator'sEmblemofMeditation-94329"
  value: {
-  dps: 82190.90765
-  tps: 52959.01676
+  dps: 81013.35486
+  tps: 52624.48948
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TyrannicalGladiator'sEmblemofMeditation-99840"
  value: {
-  dps: 82190.90765
-  tps: 52959.01676
+  dps: 81013.35486
+  tps: 52624.48948
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TyrannicalGladiator'sEmblemofMeditation-99990"
  value: {
-  dps: 82190.90765
-  tps: 52959.01676
+  dps: 81013.35486
+  tps: 52624.48948
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TyrannicalGladiator'sEmblemofTenacity-100092"
  value: {
-  dps: 81385.07789
-  tps: 52421.82233
+  dps: 80624.92119
+  tps: 52367.76621
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TyrannicalGladiator'sEmblemofTenacity-91210"
  value: {
-  dps: 81385.07789
-  tps: 52421.82233
+  dps: 80624.92119
+  tps: 52367.76621
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TyrannicalGladiator'sEmblemofTenacity-94422"
  value: {
-  dps: 81385.07789
-  tps: 52421.82233
+  dps: 80624.92119
+  tps: 52367.76621
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TyrannicalGladiator'sEmblemofTenacity-99839"
  value: {
-  dps: 81385.07789
-  tps: 52421.82233
+  dps: 80624.92119
+  tps: 52367.76621
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TyrannicalGladiator'sInsigniaofConquest-100026"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TyrannicalGladiator'sInsigniaofDominance-100152"
  value: {
-  dps: 89372.02111
-  tps: 57685.47995
+  dps: 88443.81158
+  tps: 57511.9773
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TyrannicalGladiator'sInsigniaofVictory-100085"
  value: {
-  dps: 82181.97539
-  tps: 52950.77683
+  dps: 81006.33776
+  tps: 52616.88134
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TyrannicalPrimalDiamond"
  value: {
-  dps: 85646.30674
-  tps: 54456.79067
+  dps: 83901.21797
+  tps: 54118.37065
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-UnerringVisionofLeiShen-96930"
  value: {
-  dps: 93343.39061
-  tps: 59539.09955
+  dps: 92513.35347
+  tps: 59089.32071
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VaporshieldMedallion-93262"
  value: {
-  dps: 84535.84365
-  tps: 54765.90865
+  dps: 83375.64008
+  tps: 54456.47035
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VialofDragon'sBlood-87063"
  value: {
-  dps: 83875.68975
-  tps: 54176.24065
+  dps: 82676.01019
+  tps: 53829.20475
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VialofIchorousBlood-100963"
  value: {
-  dps: 84942.10181
-  tps: 54715.40704
+  dps: 83733.06412
+  tps: 54384.40649
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VialofIchorousBlood-81264"
  value: {
-  dps: 85282.70916
-  tps: 54931.86254
+  dps: 84067.15073
+  tps: 54599.44535
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousTalismanoftheShado-PanAssault-94511"
  value: {
-  dps: 83472.40981
-  tps: 53597.04389
+  dps: 82210.68656
+  tps: 53341.41342
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VisionofthePredator-81192"
  value: {
-  dps: 87618.8399
-  tps: 56072.57973
+  dps: 86405.37685
+  tps: 55873.82474
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VolatileTalismanoftheShado-PanAssault-94510"
  value: {
-  dps: 90925.87397
-  tps: 58604.18952
+  dps: 88446.75069
+  tps: 57772.08071
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-WindsweptPages-81125"
  value: {
-  dps: 83486.85353
-  tps: 53743.08597
+  dps: 82329.07996
+  tps: 53820.03731
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-WoundripperMedallion-93253"
  value: {
-  dps: 84334.41418
-  tps: 53906.68653
+  dps: 83412.58061
+  tps: 53933.2362
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Wushoolay'sFinalChoice-96785"
  value: {
-  dps: 93383.56878
-  tps: 59895.7822
+  dps: 92811.79672
+  tps: 60282.73436
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Xing-Ho,BreathofYu'lon-102246"
  value: {
-  dps: 121707.50271
-  tps: 88478.44947
+  dps: 121508.72589
+  tps: 89033.75966
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Yu'lon'sBite-103987"
  value: {
-  dps: 93637.87928
-  tps: 59520.01679
+  dps: 93893.31536
+  tps: 60307.9777
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ZenAlchemistStone-75274"
  value: {
-  dps: 88511.44065
-  tps: 57090.90338
+  dps: 87239.1213
+  tps: 56702.83542
  }
 }
 dps_results: {
  key: "TestDemonology-Average-Default"
  value: {
-  dps: 88663.23713
-  tps: 56562.02285
+  dps: 87349.29049
+  tps: 56491.92269
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-preraid-Demonology Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 271391.97274
-  tps: 216836.14363
+  dps: 259925.99812
+  tps: 208547.73478
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-preraid-Demonology Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 85793.72454
-  tps: 55085.58827
+  dps: 84663.71244
+  tps: 55242.0029
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-preraid-Demonology Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 140521.40573
-  tps: 74632.5156
+  dps: 134906.87093
+  tps: 74547.41979
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-preraid-Demonology Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 148663.91288
-  tps: 122884.93183
+  dps: 148931.2306
+  tps: 123508.05975
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-preraid-Demonology Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 51406.20897
-  tps: 34176.20081
+  dps: 50887.7513
+  tps: 33985.10722
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-preraid-Demonology Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 66776.66164
-  tps: 36273.29337
+  dps: 65415.05054
+  tps: 36053.3806
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-preraid-Demonology Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 273629.80407
-  tps: 218284.18504
+  dps: 263187.39816
+  tps: 212224.92771
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-preraid-Demonology Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 85236.52279
-  tps: 54725.00947
+  dps: 83596.31768
+  tps: 54362.09422
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-preraid-Demonology Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 139047.88554
-  tps: 74303.60395
+  dps: 133090.18538
+  tps: 73641.5911
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-preraid-Demonology Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 148299.93826
-  tps: 122655.64715
+  dps: 148202.45291
+  tps: 122895.2122
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-preraid-Demonology Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 50535.53104
-  tps: 33493.89059
+  dps: 50180.73265
+  tps: 33461.21224
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-preraid-Demonology Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 67106.59086
-  tps: 36479.97549
+  dps: 65434.81062
+  tps: 36138.77115
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-preraid-Demonology Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 280998.30141
-  tps: 222996.45175
+  dps: 269584.22303
+  tps: 216118.14985
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-preraid-Demonology Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 88034.17322
-  tps: 56178.86526
+  dps: 86332.82285
+  tps: 55802.08904
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-preraid-Demonology Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 144374.92815
-  tps: 76574.9245
+  dps: 138155.67343
+  tps: 75861.9707
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-preraid-Demonology Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 151442.80758
-  tps: 124140.90864
+  dps: 151348.12914
+  tps: 124569.92378
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-preraid-Demonology Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 52172.24307
-  tps: 34335.51555
+  dps: 51900.97226
+  tps: 34370.52337
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-preraid-Demonology Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 69595.47688
-  tps: 37432.88511
+  dps: 67936.2164
+  tps: 37129.11038
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-preraid-Demonology Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 278193.51465
-  tps: 221971.38483
+  dps: 280546.69236
+  tps: 224623.52124
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-preraid-Demonology Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 89169.94959
-  tps: 57043.63691
+  dps: 86279.18532
+  tps: 56578.40774
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-preraid-Demonology Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 150439.35775
-  tps: 80216.50271
+  dps: 140203.76777
+  tps: 79184.76419
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-preraid-Demonology Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 174159.88287
-  tps: 141645.99195
+  dps: 174417.19436
+  tps: 142995.87685
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-preraid-Demonology Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 52983.82984
-  tps: 35257.02154
+  dps: 52352.25431
+  tps: 35064.5467
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-preraid-Demonology Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 74678.99506
-  tps: 40900.13873
+  dps: 72074.12186
+  tps: 40702.69309
  }
 }
 dps_results: {
  key: "TestDemonology-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 86279.96496
-  tps: 56002.6387
+  dps: 84794.98143
+  tps: 55874.30577
  }
 }

--- a/sim/warlock/destruction/TestDestruction.results
+++ b/sim/warlock/destruction/TestDestruction.results
@@ -33,2464 +33,2464 @@ character_stats_results: {
 dps_results: {
  key: "TestDestruction-AllItems-AgilePrimalDiamond"
  value: {
-  dps: 94731.47008
-  tps: 70550.34226
+  dps: 94099.49698
+  tps: 70408.64733
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AlacrityofXuen-103989"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ArcaneBadgeoftheShieldwall-93347"
  value: {
-  dps: 95415.26206
-  tps: 71200.06653
+  dps: 94229.37529
+  tps: 70528.77136
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ArrowflightMedallion-93258"
  value: {
-  dps: 92058.78957
-  tps: 68673.3324
+  dps: 91242.08515
+  tps: 68185.42771
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AssuranceofConsequence-105472"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AusterePrimalDiamond"
  value: {
-  dps: 93292.87008
-  tps: 69253.27458
+  dps: 92672.65337
+  tps: 69121.75129
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BadJuju-96781"
  value: {
-  dps: 93128.27869
-  tps: 69938.38345
+  dps: 92171.72697
+  tps: 69233.64381
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BadgeofKypariZar-84079"
  value: {
-  dps: 91517.56592
-  tps: 68458.43535
+  dps: 90572.96135
+  tps: 67765.2065
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BlossomofPureSnow-89081"
  value: {
-  dps: 96612.38813
-  tps: 72093.01303
+  dps: 95749.24514
+  tps: 71540.67227
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BottleofInfiniteStars-87057"
  value: {
-  dps: 92336.99937
-  tps: 69211.34363
+  dps: 91386.31681
+  tps: 68512.25879
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BraidofTenSongs-84072"
  value: {
-  dps: 91517.56592
-  tps: 68458.43535
+  dps: 90572.96135
+  tps: 67765.2065
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Brawler'sStatue-87571"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BreathoftheHydra-96827"
  value: {
-  dps: 103132.08506
-  tps: 76990.95796
+  dps: 101346.72972
+  tps: 76387.71928
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BroochofMunificentDeeds-87500"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BrutalTalismanoftheShado-PanAssault-94508"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BurningPrimalDiamond"
  value: {
-  dps: 95546.69946
-  tps: 71187.9521
+  dps: 95078.89606
+  tps: 71111.91959
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CapacitivePrimalDiamond"
  value: {
-  dps: 93676.79917
-  tps: 69636.7951
+  dps: 93164.82671
+  tps: 69568.81125
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CarbonicCarbuncle-81138"
  value: {
-  dps: 91824.92775
-  tps: 68561.44186
+  dps: 91054.7619
+  tps: 68072.48816
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Cha-Ye'sEssenceofBrilliance-96888"
  value: {
-  dps: 103442.05353
-  tps: 77390.41482
+  dps: 102285.55646
+  tps: 76749.98201
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CharmofTenSongs-84071"
  value: {
-  dps: 92810.53798
-  tps: 68979.9506
+  dps: 91751.00448
+  tps: 68679.87789
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CommunalIdolofDestruction-101168"
  value: {
-  dps: 94198.74944
-  tps: 70429.94878
+  dps: 92939.52785
+  tps: 69944.9895
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CommunalStoneofDestruction-101171"
  value: {
-  dps: 97106.65905
-  tps: 72926.11355
+  dps: 96340.29741
+  tps: 72315.23996
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CommunalStoneofWisdom-101183"
  value: {
-  dps: 94797.58037
-  tps: 70798.74625
+  dps: 93894.96658
+  tps: 70047.3522
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ContemplationofChi-Ji-103688"
  value: {
-  dps: 95270.9256
-  tps: 71116.51279
+  dps: 94353.30872
+  tps: 70423.45604
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ContemplationofChi-Ji-103988"
  value: {
-  dps: 97472.43703
-  tps: 72718.54775
+  dps: 96616.85484
+  tps: 72190.24501
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Coren'sColdChromiumCoaster-87574"
  value: {
-  dps: 91525.66924
-  tps: 68264.22865
+  dps: 90884.79079
+  tps: 67952.27865
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CoreofDecency-87497"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CourageousPrimalDiamond"
  value: {
-  dps: 94602.17382
-  tps: 70265.87334
+  dps: 94026.4362
+  tps: 70103.40521
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedDreadfulGladiator'sBadgeofConquest-93419"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedDreadfulGladiator'sBadgeofDominance-93600"
  value: {
-  dps: 94091.96727
-  tps: 70323.03294
+  dps: 92859.72415
+  tps: 69313.29261
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedDreadfulGladiator'sBadgeofVictory-93606"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedDreadfulGladiator'sEmblemofCruelty-93485"
  value: {
-  dps: 91454.42912
-  tps: 68213.12777
+  dps: 90730.53319
+  tps: 67802.88208
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedDreadfulGladiator'sEmblemofMeditation-93487"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedDreadfulGladiator'sEmblemofTenacity-93486"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedDreadfulGladiator'sInsigniaofConquest-93424"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedDreadfulGladiator'sInsigniaofDominance-93601"
  value: {
-  dps: 95484.39892
-  tps: 71398.81307
+  dps: 94408.01672
+  tps: 70439.56142
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedDreadfulGladiator'sInsigniaofVictory-93611"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedMalevolentGladiator'sBadgeofConquest-98755"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedMalevolentGladiator'sBadgeofDominance-98910"
  value: {
-  dps: 94708.03072
-  tps: 70780.96161
+  dps: 93533.99451
+  tps: 69824.14411
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedMalevolentGladiator'sBadgeofVictory-98912"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedMalevolentGladiator'sEmblemofCruelty-98811"
  value: {
-  dps: 91609.02542
-  tps: 68345.63776
+  dps: 91050.8291
+  tps: 68031.20811
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedMalevolentGladiator'sEmblemofMeditation-98813"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedMalevolentGladiator'sEmblemofTenacity-98812"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedMalevolentGladiator'sInsigniaofConquest-98760"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedMalevolentGladiator'sInsigniaofDominance-98911"
  value: {
-  dps: 96595.63629
-  tps: 72273.587
+  dps: 95443.57028
+  tps: 71319.58536
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedMalevolentGladiator'sInsigniaofVictory-98917"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CurseofHubris-102307"
  value: {
-  dps: 93582.12791
-  tps: 69853.35629
+  dps: 92838.19759
+  tps: 69568.72728
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CurseofHubris-104649"
  value: {
-  dps: 94380.98896
-  tps: 70507.10871
+  dps: 93561.4417
+  tps: 70189.0149
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CurseofHubris-104898"
  value: {
-  dps: 92915.39502
-  tps: 69247.22601
+  dps: 92563.57732
+  tps: 69368.89544
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CurseofHubris-105147"
  value: {
-  dps: 92567.28078
-  tps: 68966.1099
+  dps: 92153.95028
+  tps: 68967.94076
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CurseofHubris-105396"
  value: {
-  dps: 93765.89373
-  tps: 69982.74073
+  dps: 93206.10645
+  tps: 69813.96038
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CurseofHubris-105645"
  value: {
-  dps: 94456.65001
-  tps: 70564.24872
+  dps: 93920.40852
+  tps: 70515.45501
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CutstitcherMedallion-93255"
  value: {
-  dps: 95270.9256
-  tps: 71116.51279
+  dps: 94353.30872
+  tps: 70423.45604
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Daelo'sFinalWords-87496"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkglowEmbroidery(Rank3)-4893"
  value: {
-  dps: 92678.82656
-  tps: 69133.22352
+  dps: 92241.90304
+  tps: 68915.78365
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmistVortex-87172"
  value: {
-  dps: 93223.18629
-  tps: 69035.48213
+  dps: 92021.65931
+  tps: 69144.65306
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DeadeyeBadgeoftheShieldwall-93346"
  value: {
-  dps: 92130.80722
-  tps: 69043.34175
+  dps: 91170.89912
+  tps: 68338.34336
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DelicateVialoftheSanguinaire-96895"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DestructivePrimalDiamond"
  value: {
-  dps: 93862.01032
-  tps: 69707.38225
+  dps: 93309.09127
+  tps: 69680.96058
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DisciplineofXuen-103986"
  value: {
-  dps: 94336.64808
-  tps: 71058.81777
+  dps: 93348.75509
+  tps: 70314.18715
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Dominator'sArcaneBadge-93342"
  value: {
-  dps: 95415.26206
-  tps: 71200.06653
+  dps: 94229.37529
+  tps: 70528.77136
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Dominator'sDeadeyeBadge-93341"
  value: {
-  dps: 92130.80722
-  tps: 69043.34175
+  dps: 91170.89912
+  tps: 68338.34336
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Dominator'sDurableBadge-93345"
  value: {
-  dps: 92130.80722
-  tps: 69043.34175
+  dps: 91170.89912
+  tps: 68338.34336
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Dominator'sKnightlyBadge-93344"
  value: {
-  dps: 92130.80722
-  tps: 69043.34175
+  dps: 91170.89912
+  tps: 68338.34336
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Dominator'sMendingBadge-93343"
  value: {
-  dps: 93976.88149
-  tps: 70179.80773
+  dps: 93094.2752
+  tps: 69483.31969
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DreadfulGladiator'sBadgeofConquest-84344"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DreadfulGladiator'sBadgeofDominance-84488"
  value: {
-  dps: 94091.96727
-  tps: 70323.03294
+  dps: 92859.72415
+  tps: 69313.29261
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DreadfulGladiator'sBadgeofVictory-84490"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DreadfulGladiator'sEmblemofCruelty-84399"
  value: {
-  dps: 91454.42912
-  tps: 68213.12777
+  dps: 90730.53319
+  tps: 67802.88208
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DreadfulGladiator'sEmblemofMeditation-84401"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DreadfulGladiator'sEmblemofTenacity-84400"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DreadfulGladiator'sInsigniaofConquest-84349"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DreadfulGladiator'sInsigniaofDominance-84489"
  value: {
-  dps: 95432.38546
-  tps: 71397.96815
+  dps: 94357.18894
+  tps: 70437.80346
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DreadfulGladiator'sInsigniaofVictory-84495"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DurableBadgeoftheShieldwall-93350"
  value: {
-  dps: 92130.80722
-  tps: 69043.34175
+  dps: 91170.89912
+  tps: 68338.34336
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EffulgentPrimalDiamond"
  value: {
-  dps: 93292.87008
-  tps: 69253.27458
+  dps: 92672.65337
+  tps: 69121.75129
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EmberPrimalDiamond"
  value: {
-  dps: 94094.18677
-  tps: 69877.83157
+  dps: 93636.75619
+  tps: 69811.22935
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EmblemofKypariZar-84077"
  value: {
-  dps: 91517.14302
-  tps: 68293.19124
+  dps: 90536.39318
+  tps: 67673.83831
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EmblemoftheCatacombs-83733"
  value: {
-  dps: 91319.13198
-  tps: 67917.83475
+  dps: 90346.90099
+  tps: 67430.87919
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EmptyFruitBarrel-81133"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnchantWeapon-BloodyDancingSteel-5125"
  value: {
-  dps: 92503.85254
-  tps: 69003.43991
+  dps: 91559.59052
+  tps: 68520.21303
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnchantWeapon-Colossus-4445"
  value: {
-  dps: 92503.85254
-  tps: 69003.43991
+  dps: 91559.59052
+  tps: 68520.21303
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnchantWeapon-DancingSteel-4444"
  value: {
-  dps: 92503.85254
-  tps: 69003.43991
+  dps: 91559.59052
+  tps: 68520.21303
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnchantWeapon-ElementalForce-4443"
  value: {
-  dps: 92446.48151
-  tps: 68825.24747
+  dps: 91920.67858
+  tps: 68790.98146
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnchantWeapon-River'sSong-4446"
  value: {
-  dps: 92503.85254
-  tps: 69003.43991
+  dps: 91559.59052
+  tps: 68520.21303
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnchantWeapon-SpiritofConquest-5124"
  value: {
-  dps: 92503.85254
-  tps: 69003.43991
+  dps: 91559.59052
+  tps: 68520.21303
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnchantWeapon-Windsong-4441"
  value: {
-  dps: 93788.05292
-  tps: 69917.20443
+  dps: 92960.70766
+  tps: 69622.38005
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnigmaticPrimalDiamond"
  value: {
-  dps: 93862.01032
-  tps: 69707.38225
+  dps: 93309.09127
+  tps: 69680.96058
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EssenceofTerror-87175"
  value: {
-  dps: 99179.85532
-  tps: 73726.67672
+  dps: 97636.59657
+  tps: 73169.12334
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EternalPrimalDiamond"
  value: {
-  dps: 93292.87008
-  tps: 69253.27458
+  dps: 92672.65337
+  tps: 69121.75129
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EvilEyeofGalakras-105491"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FabledFeatherofJi-Kun-96842"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FearwurmBadge-84074"
  value: {
-  dps: 91517.14302
-  tps: 68293.19124
+  dps: 90536.39318
+  tps: 67673.83831
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FearwurmRelic-84070"
  value: {
-  dps: 92935.83561
-  tps: 69396.62542
+  dps: 92142.85785
+  tps: 69151.1268
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FelsoulIdolofDestruction-101263"
  value: {
-  dps: 94177.00727
-  tps: 70222.99603
+  dps: 93037.79876
+  tps: 69988.80881
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FelsoulStoneofDestruction-101266"
  value: {
-  dps: 97265.16
-  tps: 73071.60326
+  dps: 96444.68758
+  tps: 72410.17059
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Fen-Yu,FuryofXuen-102248"
  value: {
-  dps: 94190.17202
-  tps: 70273.56323
+  dps: 93166.54446
+  tps: 69969.01206
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FlashfrozenResinGlobule-100951"
  value: {
-  dps: 93746.23639
-  tps: 69973.85352
+  dps: 92509.06954
+  tps: 68949.44048
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FlashfrozenResinGlobule-81263"
  value: {
-  dps: 94134.01139
-  tps: 70255.03239
+  dps: 92898.62042
+  tps: 69229.07787
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FlashingSteelTalisman-81265"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FleetPrimalDiamond"
  value: {
-  dps: 93949.68816
-  tps: 69856.64072
+  dps: 93327.79248
+  tps: 69723.70883
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ForlornPrimalDiamond"
  value: {
-  dps: 94094.18677
-  tps: 69877.83157
+  dps: 93636.75619
+  tps: 69811.22935
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FortitudeoftheZandalari-94516"
  value: {
-  dps: 92705.96669
-  tps: 69550.35658
+  dps: 91752.54739
+  tps: 68848.63495
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FortitudeoftheZandalari-95677"
  value: {
-  dps: 92336.99937
-  tps: 69211.34363
+  dps: 91386.31681
+  tps: 68512.25879
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FortitudeoftheZandalari-96049"
  value: {
-  dps: 92831.91939
-  tps: 69666.08389
+  dps: 91877.56586
+  tps: 68963.46216
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FortitudeoftheZandalari-96421"
  value: {
-  dps: 92987.50802
-  tps: 69809.04116
+  dps: 92032.00044
+  tps: 69105.30753
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FortitudeoftheZandalari-96793"
  value: {
-  dps: 93128.27869
-  tps: 69938.38345
+  dps: 92171.72697
+  tps: 69233.64381
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GazeoftheTwins-96915"
  value: {
-  dps: 92396.30436
-  tps: 69112.02388
+  dps: 91764.10614
+  tps: 68570.77184
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Gerp'sPerfectArrow-87495"
  value: {
-  dps: 91484.96175
-  tps: 68239.70903
+  dps: 90616.30266
+  tps: 67756.50368
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Gong-Lu,StrengthofXuen-102249"
  value: {
-  dps: 94190.17202
-  tps: 70273.56323
+  dps: 93166.54446
+  tps: 69969.01206
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sBadgeofConquest-100195"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sBadgeofConquest-100603"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sBadgeofConquest-102856"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sBadgeofConquest-103145"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sBadgeofDominance-100490"
  value: {
-  dps: 96744.88398
-  tps: 72305.35224
+  dps: 95535.03688
+  tps: 71332.86545
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sBadgeofDominance-100576"
  value: {
-  dps: 96744.88398
-  tps: 72305.35224
+  dps: 95535.03688
+  tps: 71332.86545
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sBadgeofDominance-102830"
  value: {
-  dps: 96744.88398
-  tps: 72305.35224
+  dps: 95535.03688
+  tps: 71332.86545
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sBadgeofDominance-103308"
  value: {
-  dps: 96744.88398
-  tps: 72305.35224
+  dps: 95535.03688
+  tps: 71332.86545
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sBadgeofVictory-100500"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sBadgeofVictory-100579"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sBadgeofVictory-102833"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sBadgeofVictory-103314"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sEmblemofCruelty-100305"
  value: {
-  dps: 92130.16749
-  tps: 68809.54938
+  dps: 91706.61841
+  tps: 68546.23985
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sEmblemofCruelty-100626"
  value: {
-  dps: 92130.16749
-  tps: 68809.54938
+  dps: 91706.61841
+  tps: 68546.23985
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sEmblemofCruelty-102877"
  value: {
-  dps: 92130.16749
-  tps: 68809.54938
+  dps: 91706.61841
+  tps: 68546.23985
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sEmblemofCruelty-103210"
  value: {
-  dps: 92130.16749
-  tps: 68809.54938
+  dps: 91706.61841
+  tps: 68546.23985
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sEmblemofMeditation-100307"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sEmblemofMeditation-100559"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sEmblemofMeditation-102813"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sEmblemofMeditation-103212"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sEmblemofTenacity-100306"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sEmblemofTenacity-100652"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sEmblemofTenacity-102903"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sEmblemofTenacity-103211"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sInsigniaofConquest-103150"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sInsigniaofDominance-103309"
  value: {
-  dps: 99548.38144
-  tps: 74421.79685
+  dps: 98987.94795
+  tps: 73973.33478
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sInsigniaofVictory-103319"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Hawkmaster'sTalon-89082"
  value: {
-  dps: 91909.10671
-  tps: 68398.09196
+  dps: 90809.82943
+  tps: 67978.31107
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Heart-LesionDefenderIdol-100999"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Heart-LesionDefenderStone-101002"
  value: {
-  dps: 92655.6167
-  tps: 69507.89049
+  dps: 91791.15371
+  tps: 68903.67489
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Heart-LesionIdolofBattle-100991"
  value: {
-  dps: 91674.71137
-  tps: 68354.29298
+  dps: 91355.09277
+  tps: 68359.39557
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Heart-LesionStoneofBattle-100990"
  value: {
-  dps: 92694.1537
-  tps: 69545.71073
+  dps: 91712.77561
+  tps: 68815.3133
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofFire-81181"
  value: {
-  dps: 91787.25288
-  tps: 68706.22795
+  dps: 90840.64796
+  tps: 68011.07181
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartwarmerMedallion-93260"
  value: {
-  dps: 95270.9256
-  tps: 71116.51279
+  dps: 94353.30872
+  tps: 70423.45604
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HelmbreakerMedallion-93261"
  value: {
-  dps: 92058.78957
-  tps: 68673.3324
+  dps: 91242.08515
+  tps: 68185.42771
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Horridon'sLastGasp-96757"
  value: {
-  dps: 97867.27778
-  tps: 73001.80267
+  dps: 97053.66198
+  tps: 72527.72412
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpassivePrimalDiamond"
  value: {
-  dps: 93862.01032
-  tps: 69707.38225
+  dps: 93309.09127
+  tps: 69680.96058
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-IndomitablePrimalDiamond"
  value: {
-  dps: 93292.87008
-  tps: 69253.27458
+  dps: 92672.65337
+  tps: 69121.75129
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InscribedBagofHydra-Spawn-96828"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InsigniaofKypariZar-84078"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-IronBellyWok-89083"
  value: {
-  dps: 91909.10671
-  tps: 68398.09196
+  dps: 90809.82943
+  tps: 67978.31107
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-IronProtectorTalisman-85181"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JadeBanditFigurine-86043"
  value: {
-  dps: 91909.10671
-  tps: 68398.09196
+  dps: 90809.82943
+  tps: 67978.31107
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JadeBanditFigurine-86772"
  value: {
-  dps: 91970.83612
-  tps: 68453.60268
+  dps: 90870.12913
+  tps: 67995.00154
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JadeCharioteerFigurine-86042"
  value: {
-  dps: 91909.10671
-  tps: 68398.09196
+  dps: 90809.82943
+  tps: 67978.31107
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JadeCharioteerFigurine-86771"
  value: {
-  dps: 91970.83612
-  tps: 68453.60268
+  dps: 90870.12913
+  tps: 67995.00154
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JadeCourtesanFigurine-86045"
  value: {
-  dps: 95013.45874
-  tps: 70932.57408
+  dps: 94142.31824
+  tps: 70231.71771
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JadeCourtesanFigurine-86774"
  value: {
-  dps: 94529.98827
-  tps: 70602.07937
+  dps: 93629.72314
+  tps: 69852.65756
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JadeMagistrateFigurine-86044"
  value: {
-  dps: 96612.38813
-  tps: 72093.01303
+  dps: 95749.24514
+  tps: 71540.67227
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JadeMagistrateFigurine-86773"
  value: {
-  dps: 95983.66254
-  tps: 71699.39347
+  dps: 94923.5073
+  tps: 70782.20058
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JadeWarlordFigurine-86046"
  value: {
-  dps: 92666.25825
-  tps: 69542.50728
+  dps: 91698.77627
+  tps: 68831.2081
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JadeWarlordFigurine-86775"
  value: {
-  dps: 92422.27779
-  tps: 69315.06046
+  dps: 91458.24688
+  tps: 68606.63226
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Ji-Kun'sRisingWinds-96843"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-KnightlyBadgeoftheShieldwall-93349"
  value: {
-  dps: 92130.80722
-  tps: 69043.34175
+  dps: 91170.89912
+  tps: 68338.34336
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-KnotofTenSongs-84073"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Kor'kronBookofHurting-92785"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Lao-Chin'sLiquidCourage-89079"
  value: {
-  dps: 92666.25825
-  tps: 69542.50728
+  dps: 91698.77627
+  tps: 68831.2081
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LeiShen'sFinalOrders-87072"
  value: {
-  dps: 92491.70596
-  tps: 69094.11084
+  dps: 91619.20174
+  tps: 68833.30234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LessonsoftheDarkmaster-81268"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LightdrinkerIdolofRage-101200"
  value: {
-  dps: 92045.08547
-  tps: 68943.12856
+  dps: 91096.56812
+  tps: 68246.12985
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LightdrinkerStoneofRage-101203"
  value: {
-  dps: 92767.35649
-  tps: 69618.30455
+  dps: 91787.46676
+  tps: 68879.7067
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LightoftheCosmos-87065"
  value: {
-  dps: 98782.93396
-  tps: 73659.11231
+  dps: 97945.21688
+  tps: 73798.60367
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LordBlastington'sScopeofDoom-4699"
  value: {
-  dps: 92503.85254
-  tps: 69003.43991
+  dps: 91559.59052
+  tps: 68520.21303
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MalevolentGladiator'sBadgeofConquest-84934"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MalevolentGladiator'sBadgeofConquest-91452"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MalevolentGladiator'sBadgeofDominance-84940"
  value: {
-  dps: 94972.46717
-  tps: 70982.75614
+  dps: 93793.73988
+  tps: 70021.98457
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MalevolentGladiator'sBadgeofDominance-91753"
  value: {
-  dps: 94708.03072
-  tps: 70780.96161
+  dps: 93533.99451
+  tps: 69824.14411
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MalevolentGladiator'sBadgeofVictory-84942"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MalevolentGladiator'sBadgeofVictory-91763"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MalevolentGladiator'sEmblemofCruelty-84936"
  value: {
-  dps: 91674.71137
-  tps: 68354.29298
+  dps: 91355.09277
+  tps: 68359.39557
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MalevolentGladiator'sEmblemofCruelty-91562"
  value: {
-  dps: 91609.02542
-  tps: 68345.63776
+  dps: 91050.8291
+  tps: 68031.20811
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MalevolentGladiator'sEmblemofMeditation-84939"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MalevolentGladiator'sEmblemofMeditation-91564"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MalevolentGladiator'sEmblemofTenacity-84938"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MalevolentGladiator'sEmblemofTenacity-91563"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MalevolentGladiator'sInsigniaofConquest-91457"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MalevolentGladiator'sInsigniaofDominance-91754"
  value: {
-  dps: 96607.33019
-  tps: 72306.39418
+  dps: 95610.90767
+  tps: 71481.9751
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MalevolentGladiator'sInsigniaofVictory-91768"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MarkoftheCatacombs-83731"
  value: {
-  dps: 92681.1267
-  tps: 69410.4455
+  dps: 91749.83404
+  tps: 68809.70831
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MarkoftheHardenedGrunt-92783"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MedallionofMystifyingVapors-93257"
  value: {
-  dps: 92810.50947
-  tps: 69676.98314
+  dps: 91840.98708
+  tps: 68963.98652
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MedallionoftheCatacombs-83734"
  value: {
-  dps: 91446.43969
-  tps: 68393.08345
+  dps: 90502.36268
+  tps: 67700.3629
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MendingBadgeoftheShieldwall-93348"
  value: {
-  dps: 93976.88149
-  tps: 70179.80773
+  dps: 93094.2752
+  tps: 69483.31969
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MirrorScope-4700"
  value: {
-  dps: 92503.85254
-  tps: 69003.43991
+  dps: 91559.59052
+  tps: 68520.21303
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MistdancerDefenderIdol-101089"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MistdancerDefenderStone-101087"
  value: {
-  dps: 92819.43664
-  tps: 69659.77304
+  dps: 91922.1942
+  tps: 69016.48754
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MistdancerIdolofRage-101113"
  value: {
-  dps: 92045.08547
-  tps: 68943.12856
+  dps: 91096.56812
+  tps: 68246.12985
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MistdancerStoneofRage-101117"
  value: {
-  dps: 92659.14237
-  tps: 69501.88153
+  dps: 91778.39719
+  tps: 68868.64111
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MistdancerStoneofWisdom-101107"
  value: {
-  dps: 94797.58037
-  tps: 70798.74625
+  dps: 93894.96658
+  tps: 70047.3522
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MithrilWristwatch-87572"
  value: {
-  dps: 92648.3499
-  tps: 69103.74009
+  dps: 92023.12362
+  tps: 68802.52017
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MountainsageIdolofDestruction-101069"
  value: {
-  dps: 93889.79401
-  tps: 70060.37108
+  dps: 93198.33188
+  tps: 70302.18377
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MountainsageStoneofDestruction-101072"
  value: {
-  dps: 97180.73598
-  tps: 73006.07869
+  dps: 96248.25386
+  tps: 72222.8697
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-NitroBoosts-4223"
  value: {
-  dps: 95546.69946
-  tps: 71187.9521
+  dps: 95078.89606
+  tps: 71111.91959
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-OathswornDefenderIdol-101303"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-OathswornDefenderStone-101306"
  value: {
-  dps: 92575.2208
-  tps: 69431.03333
+  dps: 91634.1762
+  tps: 68736.45701
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-OathswornIdolofBattle-101295"
  value: {
-  dps: 91674.71137
-  tps: 68354.29298
+  dps: 91355.09277
+  tps: 68359.39557
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-OathswornStoneofBattle-101294"
  value: {
-  dps: 92670.1055
-  tps: 69517.07157
+  dps: 91809.55023
+  tps: 68918.72241
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PhaseFingers-4697"
  value: {
-  dps: 95280.21
-  tps: 70942.97402
+  dps: 94812.87055
+  tps: 70867.34414
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PouchofWhiteAsh-103639"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PowerfulPrimalDiamond"
  value: {
-  dps: 93292.87008
-  tps: 69253.27458
+  dps: 92672.65337
+  tps: 69121.75129
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PriceofProgress-81266"
  value: {
-  dps: 94129.88605
-  tps: 70294.78294
+  dps: 93245.88266
+  tps: 69597.17557
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PridefulGladiator'sBadgeofConquest-102659"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PridefulGladiator'sBadgeofConquest-103342"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PridefulGladiator'sBadgeofDominance-102633"
  value: {
-  dps: 98844.50995
-  tps: 73902.48113
+  dps: 97734.82694
+  tps: 73083.18692
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PridefulGladiator'sBadgeofDominance-103505"
  value: {
-  dps: 98844.50995
-  tps: 73902.48113
+  dps: 97734.82694
+  tps: 73083.18692
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PridefulGladiator'sBadgeofVictory-102636"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PridefulGladiator'sBadgeofVictory-103511"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PridefulGladiator'sEmblemofCruelty-102680"
  value: {
-  dps: 92995.25166
-  tps: 69491.36981
+  dps: 92516.98432
+  tps: 69228.4346
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PridefulGladiator'sEmblemofCruelty-103407"
  value: {
-  dps: 92995.25166
-  tps: 69491.36981
+  dps: 92516.98432
+  tps: 69228.4346
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PridefulGladiator'sEmblemofMeditation-102616"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PridefulGladiator'sEmblemofMeditation-103409"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PridefulGladiator'sEmblemofTenacity-102706"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PridefulGladiator'sEmblemofTenacity-103408"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PridefulGladiator'sInsigniaofConquest-103347"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PridefulGladiator'sInsigniaofDominance-103506"
  value: {
-  dps: 102518.77836
-  tps: 76725.21357
+  dps: 101901.81315
+  tps: 76214.61842
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PridefulGladiator'sInsigniaofVictory-103516"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Primordius'TalismanofRage-96873"
  value: {
-  dps: 92605.65623
-  tps: 69145.60144
+  dps: 92070.3988
+  tps: 68838.92237
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Qian-Le,CourageofNiuzao-102245"
  value: {
-  dps: 92509.11372
-  tps: 69112.72698
+  dps: 92307.28961
+  tps: 69162.865
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Qian-Ying,FortitudeofNiuzao-102250"
  value: {
-  dps: 91209.77655
-  tps: 68216.38026
+  dps: 90546.86874
+  tps: 67661.7349
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Qin-xi'sPolarizingSeal-87075"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RegaliaoftheHornedNightmare"
  value: {
-  dps: 105740.15115
-  tps: 78738.04164
+  dps: 104701.95521
+  tps: 78480.24681
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RegaliaoftheThousandfoldHells"
  value: {
-  dps: 107707.11386
-  tps: 80622.56236
+  dps: 106994.29202
+  tps: 80695.51989
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RelicofChi-Ji-79330"
  value: {
-  dps: 95291.05934
-  tps: 71131.63303
+  dps: 94373.25645
+  tps: 70438.43764
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RelicofKypariZar-84075"
  value: {
-  dps: 92689.50232
-  tps: 69055.99085
+  dps: 91964.29743
+  tps: 68923.58781
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RelicofNiuzao-79329"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RelicofXuen-79327"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RelicofXuen-79328"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Renataki'sSoulCharm-96741"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.16247
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ResolveofNiuzao-103690"
  value: {
-  dps: 92239.2008
-  tps: 69121.48478
+  dps: 91289.24365
+  tps: 68423.09884
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ResolveofNiuzao-103990"
  value: {
-  dps: 92987.50802
-  tps: 69809.04116
+  dps: 92032.00044
+  tps: 69105.30753
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ReverberatingPrimalDiamond"
  value: {
-  dps: 94731.47008
-  tps: 70550.34226
+  dps: 94099.49698
+  tps: 70408.64733
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RevitalizingPrimalDiamond"
  value: {
-  dps: 94731.47008
-  tps: 70550.34226
+  dps: 94099.49698
+  tps: 70408.64733
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SI:7Operative'sManual-92784"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ScrollofReveredAncestors-89080"
  value: {
-  dps: 95013.45874
-  tps: 70932.57408
+  dps: 94142.31824
+  tps: 70231.71771
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SearingWords-81267"
  value: {
-  dps: 91477.26689
-  tps: 68231.12239
+  dps: 90856.87015
+  tps: 67917.7747
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Sha-SkinRegalia"
  value: {
-  dps: 101071.27493
-  tps: 75684.73289
+  dps: 100155.40845
+  tps: 75525.56647
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ShadowflameRegalia"
  value: {
-  dps: 71463.86361
-  tps: 52750.37916
+  dps: 71318.4431
+  tps: 52812.77826
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Shock-ChargerMedallion-93259"
  value: {
-  dps: 97596.63004
-  tps: 72624.39033
+  dps: 97010.32556
+  tps: 72817.80875
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SigilofCompassion-83736"
  value: {
-  dps: 91446.43969
-  tps: 68393.08345
+  dps: 90502.36268
+  tps: 67700.3629
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SigilofDevotion-83740"
  value: {
-  dps: 91448.02099
-  tps: 68271.9547
+  dps: 90541.04605
+  tps: 67690.49402
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SigilofFidelity-83737"
  value: {
-  dps: 93136.98589
-  tps: 69472.17611
+  dps: 91969.99918
+  tps: 68822.27312
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SigilofGrace-83738"
  value: {
-  dps: 91446.43969
-  tps: 68393.08345
+  dps: 90502.36268
+  tps: 67700.3629
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SigilofKypariZar-84076"
  value: {
-  dps: 92727.38845
-  tps: 69410.02552
+  dps: 91739.72987
+  tps: 68781.23516
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SigilofPatience-83739"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SigiloftheCatacombs-83732"
  value: {
-  dps: 92768.04196
-  tps: 69149.66341
+  dps: 91763.16486
+  tps: 68879.13565
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SinisterPrimalDiamond"
  value: {
-  dps: 93676.79917
-  tps: 69636.7951
+  dps: 93164.82671
+  tps: 69568.81125
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SkullrenderMedallion-93256"
  value: {
-  dps: 92058.78957
-  tps: 68673.3324
+  dps: 91242.08515
+  tps: 68185.42771
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SpiritsoftheSun-87163"
  value: {
-  dps: 95821.80761
-  tps: 71546.0545
+  dps: 94949.91419
+  tps: 70883.45294
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SpringrainIdolofDestruction-101023"
  value: {
-  dps: 93873.89318
-  tps: 69826.26294
+  dps: 93073.44952
+  tps: 70128.88145
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SpringrainIdolofRage-101009"
  value: {
-  dps: 92045.08547
-  tps: 68943.12856
+  dps: 91096.56812
+  tps: 68246.12985
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SpringrainStoneofDestruction-101026"
  value: {
-  dps: 97143.58638
-  tps: 72953.9141
+  dps: 96201.71312
+  tps: 72169.37438
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SpringrainStoneofRage-101012"
  value: {
-  dps: 92961.6406
-  tps: 69779.16758
+  dps: 92126.28321
+  tps: 69209.9323
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SpringrainStoneofWisdom-101041"
  value: {
-  dps: 94797.58037
-  tps: 70798.74625
+  dps: 93894.96658
+  tps: 70047.3522
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Static-Caster'sMedallion-93254"
  value: {
-  dps: 97596.63004
-  tps: 72624.39033
+  dps: 97010.32556
+  tps: 72817.80875
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SteadfastFootman'sMedallion-92782"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SteadfastTalismanoftheShado-PanAssault-94507"
  value: {
-  dps: 92705.96669
-  tps: 69550.35658
+  dps: 91752.54739
+  tps: 68848.63495
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StreamtalkerIdolofDestruction-101222"
  value: {
-  dps: 94278.43827
-  tps: 70310.01277
+  dps: 93322.97794
+  tps: 70281.76753
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StreamtalkerIdolofRage-101217"
  value: {
-  dps: 92045.08547
-  tps: 68943.12856
+  dps: 91096.56812
+  tps: 68246.12985
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StreamtalkerStoneofDestruction-101225"
  value: {
-  dps: 97023.03488
-  tps: 72846.45972
+  dps: 96027.67165
+  tps: 72005.3905
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StreamtalkerStoneofRage-101220"
  value: {
-  dps: 92703.35226
-  tps: 69573.10407
+  dps: 91730.10597
+  tps: 68845.00404
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StreamtalkerStoneofWisdom-101250"
  value: {
-  dps: 94797.58037
-  tps: 70798.74625
+  dps: 93894.96658
+  tps: 70047.3522
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StuffofNightmares-87160"
  value: {
-  dps: 92458.50668
-  tps: 69322.98645
+  dps: 91506.92287
+  tps: 68623.03327
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SunsoulDefenderIdol-101160"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SunsoulDefenderStone-101163"
  value: {
-  dps: 92804.23271
-  tps: 69643.36261
+  dps: 91855.24682
+  tps: 68951.52851
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SunsoulIdolofBattle-101152"
  value: {
-  dps: 91674.71137
-  tps: 68354.29298
+  dps: 91355.09277
+  tps: 68359.39557
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SunsoulStoneofBattle-101151"
  value: {
-  dps: 92689.48184
-  tps: 69537.29169
+  dps: 91882.44198
+  tps: 68965.95113
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SunsoulStoneofWisdom-101138"
  value: {
-  dps: 94797.58037
-  tps: 70798.74625
+  dps: 93894.96658
+  tps: 70047.3522
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SwordguardEmbroidery(Rank3)-4894"
  value: {
-  dps: 92678.82656
-  tps: 69133.22352
+  dps: 92241.90304
+  tps: 68915.78365
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SymboloftheCatacombs-83735"
  value: {
-  dps: 91446.43969
-  tps: 68393.08345
+  dps: 90502.36268
+  tps: 67700.3629
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SynapseSprings(MarkII)-4898"
  value: {
-  dps: 97327.50005
-  tps: 72549.28936
+  dps: 96597.89263
+  tps: 72143.1917
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TalismanofBloodlust-96864"
  value: {
-  dps: 93137.93289
-  tps: 69184.60553
+  dps: 91974.33759
+  tps: 68872.99092
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TerrorintheMists-87167"
  value: {
-  dps: 92777.48531
-  tps: 69331.21215
+  dps: 91696.17436
+  tps: 68351.34131
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Thousand-YearPickledEgg-87573"
  value: {
-  dps: 94320.64849
-  tps: 70444.7683
+  dps: 93403.73521
+  tps: 69729.59064
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TrailseekerIdolofRage-101054"
  value: {
-  dps: 92045.08547
-  tps: 68943.12856
+  dps: 91096.56812
+  tps: 68246.12985
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TrailseekerStoneofRage-101057"
  value: {
-  dps: 92826.0529
-  tps: 69672.52475
+  dps: 91906.28624
+  tps: 69004.32808
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sBadgeofConquest-100043"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sBadgeofConquest-91099"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sBadgeofConquest-94373"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sBadgeofConquest-99772"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sBadgeofDominance-100016"
  value: {
-  dps: 95449.6714
-  tps: 71337.02128
+  dps: 94211.75601
+  tps: 70329.95212
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sBadgeofDominance-91400"
  value: {
-  dps: 95449.6714
-  tps: 71337.02128
+  dps: 94211.75601
+  tps: 70329.95212
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sBadgeofDominance-94346"
  value: {
-  dps: 95449.6714
-  tps: 71337.02128
+  dps: 94211.75601
+  tps: 70329.95212
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sBadgeofDominance-99937"
  value: {
-  dps: 95449.6714
-  tps: 71337.02128
+  dps: 94211.75601
+  tps: 70329.95212
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sBadgeofVictory-100019"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sBadgeofVictory-91410"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sBadgeofVictory-94349"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sBadgeofVictory-99943"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sEmblemofCruelty-100066"
  value: {
-  dps: 91873.19919
-  tps: 68567.89809
+  dps: 91492.13918
+  tps: 68442.42926
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sEmblemofCruelty-91209"
  value: {
-  dps: 91873.19919
-  tps: 68567.89809
+  dps: 91492.13918
+  tps: 68442.42926
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sEmblemofCruelty-94396"
  value: {
-  dps: 91873.19919
-  tps: 68567.89809
+  dps: 91492.13918
+  tps: 68442.42926
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sEmblemofCruelty-99838"
  value: {
-  dps: 91873.19919
-  tps: 68567.89809
+  dps: 91492.13918
+  tps: 68442.42926
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sEmblemofMeditation-91211"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sEmblemofMeditation-94329"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sEmblemofMeditation-99840"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sEmblemofMeditation-99990"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sEmblemofTenacity-100092"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sEmblemofTenacity-91210"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sEmblemofTenacity-94422"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sEmblemofTenacity-99839"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sInsigniaofConquest-100026"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sInsigniaofDominance-100152"
  value: {
-  dps: 97649.5394
-  tps: 73034.26885
+  dps: 97035.99511
+  tps: 72623.36852
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sInsigniaofVictory-100085"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalPrimalDiamond"
  value: {
-  dps: 93292.87008
-  tps: 69253.27458
+  dps: 92672.65337
+  tps: 69121.75129
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-UnerringVisionofLeiShen-96930"
  value: {
-  dps: 100746.63112
-  tps: 75196.91367
+  dps: 101034.07229
+  tps: 75464.91586
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VaporshieldMedallion-93262"
  value: {
-  dps: 92810.50947
-  tps: 69676.98314
+  dps: 91840.98708
+  tps: 68963.98652
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VialofDragon'sBlood-87063"
  value: {
-  dps: 92336.99937
-  tps: 69211.34363
+  dps: 91386.31681
+  tps: 68512.25879
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VialofIchorousBlood-100963"
  value: {
-  dps: 93689.37063
-  tps: 69947.25274
+  dps: 92837.33232
+  tps: 69292.70121
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VialofIchorousBlood-81264"
  value: {
-  dps: 94129.88605
-  tps: 70294.78294
+  dps: 93245.88266
+  tps: 69597.17557
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousTalismanoftheShado-PanAssault-94511"
  value: {
-  dps: 90532.17127
-  tps: 67553.03931
+  dps: 89594.87566
+  tps: 66866.85249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VolatileTalismanoftheShado-PanAssault-94510"
  value: {
-  dps: 99100.45617
-  tps: 73556.15902
+  dps: 98237.484
+  tps: 73635.03957
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WindsweptPages-81125"
  value: {
-  dps: 91800.99364
-  tps: 68310.46823
+  dps: 90933.37969
+  tps: 68071.27449
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WoundripperMedallion-93253"
  value: {
-  dps: 92058.78957
-  tps: 68673.3324
+  dps: 91242.08515
+  tps: 68185.42771
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Wushoolay'sFinalChoice-96785"
  value: {
-  dps: 100695.88577
-  tps: 75182.52026
+  dps: 100196.41763
+  tps: 74874.0355
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Xing-Ho,BreathofYu'lon-102246"
  value: {
-  dps: 121001.68774
-  tps: 95371.61165
+  dps: 119735.23009
+  tps: 95014.11976
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Yu'lon'sBite-103987"
  value: {
-  dps: 101297.72298
-  tps: 75665.89454
+  dps: 101386.4294
+  tps: 76037.23514
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ZenAlchemistStone-75274"
  value: {
-  dps: 96984.36474
-  tps: 72634.97911
+  dps: 96005.38374
+  tps: 71801.02809
  }
 }
 dps_results: {
  key: "TestDestruction-Average-Default"
  value: {
-  dps: 99024.17016
-  tps: 74022.27917
+  dps: 98558.88472
+  tps: 73986.024
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p1-prebis-Destruction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 217686.85486
-  tps: 185619.29794
+  dps: 216053.08536
+  tps: 184321.38986
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p1-prebis-Destruction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 96367.4791
-  tps: 72109.0359
+  dps: 95593.54931
+  tps: 71827.57488
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p1-prebis-Destruction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 150903.2458
-  tps: 101332.95732
+  dps: 145876.62204
+  tps: 100413.69386
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p1-prebis-Destruction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 143012.60382
-  tps: 123845.01935
+  dps: 142239.76501
+  tps: 123508.29773
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p1-prebis-Destruction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 61143.21088
-  tps: 45512.69539
+  dps: 61049.72976
+  tps: 45568.69749
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p1-prebis-Destruction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 80770.4554
-  tps: 55024.84484
+  dps: 79190.1154
+  tps: 54246.75969
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p1-prebis-Destruction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 216522.39866
-  tps: 185071.87501
+  dps: 216240.23723
+  tps: 185896.14579
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p1-prebis-Destruction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 95345.48859
-  tps: 71271.6908
+  dps: 94703.73425
+  tps: 70934.17584
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p1-prebis-Destruction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 150080.88077
-  tps: 100668.3617
+  dps: 145783.17102
+  tps: 101006.36917
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p1-prebis-Destruction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 144936.82818
-  tps: 125463.69394
+  dps: 144078.83081
+  tps: 124799.92262
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p1-prebis-Destruction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 60980.22755
-  tps: 45271.04152
+  dps: 60662.52543
+  tps: 45412.38203
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p1-prebis-Destruction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 80510.72661
-  tps: 54971.50932
+  dps: 79519.1676
+  tps: 55045.00018
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p1-prebis-Destruction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 220624.41907
-  tps: 188033.26792
+  dps: 220407.35792
+  tps: 188937.55777
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p1-prebis-Destruction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 97600.94581
-  tps: 72800.90836
+  dps: 96869.11023
+  tps: 72392.62752
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p1-prebis-Destruction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 154869.66113
-  tps: 103542.80807
+  dps: 150344.15995
+  tps: 103860.95066
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p1-prebis-Destruction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 148679.04032
-  tps: 128556.14105
+  dps: 147777.71456
+  tps: 128414.02718
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p1-prebis-Destruction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 62513.797
-  tps: 46295.37083
+  dps: 62118.63498
+  tps: 46396.73926
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p1-prebis-Destruction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 83252.28674
-  tps: 56647.63379
+  dps: 82243.88449
+  tps: 56721.10207
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p1-prebis-Destruction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 219538.62477
-  tps: 186191.48122
+  dps: 220161.30038
+  tps: 187098.39983
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p1-prebis-Destruction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 96841.33335
-  tps: 71935.56994
+  dps: 96344.89271
+  tps: 72200.46647
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p1-prebis-Destruction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 154940.02029
-  tps: 100742.41237
+  dps: 148983.85098
+  tps: 101871.91772
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p1-prebis-Destruction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 141281.64825
-  tps: 120100.44836
+  dps: 141510.58362
+  tps: 120469.76665
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p1-prebis-Destruction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 61561.92746
-  tps: 45682.12217
+  dps: 61491.34393
+  tps: 45918.37935
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p1-prebis-Destruction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 81568.87942
-  tps: 54127.24847
+  dps: 80068.49381
+  tps: 54649.58341
  }
 }
 dps_results: {
  key: "TestDestruction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 97600.94581
-  tps: 72800.90836
+  dps: 96869.11023
+  tps: 72392.62752
  }
 }

--- a/sim/warlock/doomguard.go
+++ b/sim/warlock/doomguard.go
@@ -12,7 +12,7 @@ func (warlock *Warlock) registerSummonDoomguard(timer *core.Timer) {
 	summonDoomguardAura := warlock.RegisterAura(core.Aura{
 		Label:    "Summon Doomguard",
 		ActionID: core.ActionID{SpellID: 18540},
-		Duration: 60 * time.Second,
+		Duration: 62 * time.Second,
 	})
 
 	warlock.RegisterSpell(core.SpellConfig{
@@ -68,8 +68,9 @@ func (warlock *Warlock) NewDoomguardPet() *DoomguardPet {
 
 	pet.Class = proto.Class_ClassWarlock
 	pet.EnableEnergyBar(core.EnergyBarOptions{
-		MaxEnergy: 100,
-		UnitClass: proto.Class_ClassWarlock,
+		MaxEnergy:             100,
+		UnitClass:             proto.Class_ClassWarlock,
+		HasHasteRatingScaling: false,
 	})
 
 	warlock.AddPet(pet)

--- a/sim/warlock/pets.go
+++ b/sim/warlock/pets.go
@@ -107,8 +107,9 @@ func (warlock *Warlock) setPetOptions(petAgent core.PetAgent, aaOptions *core.Au
 	}
 
 	pet.EnableEnergyBar(core.EnergyBarOptions{
-		MaxEnergy: 200,
-		UnitClass: proto.Class_ClassWarlock,
+		MaxEnergy:             200,
+		UnitClass:             proto.Class_ClassWarlock,
+		HasHasteRatingScaling: false,
 	})
 
 	warlock.AddPet(petAgent)


### PR DESCRIPTION
* Pets were inherting AttackSpeedMultiplier even when the option was disabled on enable
* Pets were always modifying their energy and focus regen based on inherited haste rating, while some should not do that 
  * So this PR allows to disable this behavior

It seems Doomguard always finishes the last cast that was started before the summon times out to get to 19 casts. (Spawntime is actually longer than 60 seconds in logs). To account for this the spawn time is increased slightly to finish the last cast 