### PR TITLE
Feature/druid/feral/t15 and t16 set bonuses

### DIFF
--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -71,6 +71,22 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestBalance-AllItems-BattlegearoftheHauntedForest"
+ value: {
+  dps: 72028.69524
+  tps: 73445.17154
+  hps: 15020.9264
+ }
+}
+dps_results: {
+ key: "TestBalance-AllItems-BattlegearoftheShatteredVale"
+ value: {
+  dps: 72379.27964
+  tps: 73856.22881
+  hps: 15505.9879
+ }
+}
+dps_results: {
  key: "TestBalance-AllItems-BurningPrimalDiamond"
  value: {
   dps: 92996.95216

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -79,14 +79,6 @@ dps_results: {
  }
 }
 dps_results: {
- key: "TestBalance-AllItems-BattlegearoftheShatteredVale"
- value: {
-  dps: 72379.27964
-  tps: 73856.22881
-  hps: 15505.9879
- }
-}
-dps_results: {
  key: "TestBalance-AllItems-BurningPrimalDiamond"
  value: {
   dps: 92996.95216

--- a/sim/druid/druid.go
+++ b/sim/druid/druid.go
@@ -68,8 +68,6 @@ type Druid struct {
 	BerserkCatAura           *core.Aura
 	CatFormAura              *core.Aura
 	FaerieFireAuras          core.AuraArray
-	FeralFuryAura            *core.Aura
-	FeralRageAura            *core.Aura
 	FrenziedRegenerationAura *core.Aura
 	LunarEclipseProcAura     *core.Aura
 	MightOfUrsocAura         *core.Aura

--- a/sim/druid/druid.go
+++ b/sim/druid/druid.go
@@ -67,8 +67,9 @@ type Druid struct {
 	BerserkBearAura          *core.Aura
 	BerserkCatAura           *core.Aura
 	CatFormAura              *core.Aura
-	WeakenedBlowsAuras       core.AuraArray
 	FaerieFireAuras          core.AuraArray
+	FeralFuryAura            *core.Aura
+	FeralRageAura            *core.Aura
 	FrenziedRegenerationAura *core.Aura
 	LunarEclipseProcAura     *core.Aura
 	MightOfUrsocAura         *core.Aura
@@ -78,6 +79,7 @@ type Druid struct {
 	StampedePendingAura      *core.Aura
 	TigersFury4PT15Aura      *core.Aura
 	SurvivalInstinctsAura    *core.Aura
+	WeakenedBlowsAuras       core.AuraArray
 
 	form DruidForm
 

--- a/sim/druid/druid.go
+++ b/sim/druid/druid.go
@@ -76,6 +76,7 @@ type Druid struct {
 	ProwlAura                *core.Aura
 	StampedeAura             *core.Aura
 	StampedePendingAura      *core.Aura
+	TigersFury4PT15Aura      *core.Aura
 	SurvivalInstinctsAura    *core.Aura
 
 	form DruidForm
@@ -117,6 +118,7 @@ const (
 	DruidSpellSwipeCat
 	DruidSpellThrashBear
 	DruidSpellThrashCat
+	DruidSpellTigersFury
 	DruidSpellWildMushroom
 	DruidSpellWildMushroomDetonate
 	DruidSpellWrath

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -111,6 +111,22 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFeral-AllItems-BattlegearoftheHauntedForest"
+ value: {
+  dps: 116386.23376
+  tps: 184420.07089
+  hps: 10573.18323
+ }
+}
+dps_results: {
+ key: "TestFeral-AllItems-BattlegearoftheShatteredVale"
+ value: {
+  dps: 120205.40411
+  tps: 181083.48279
+  hps: 10932.89002
+ }
+}
+dps_results: {
  key: "TestFeral-AllItems-BlossomofPureSnow-89081"
  value: {
   dps: 98450.75426

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -121,9 +121,9 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-BattlegearoftheShatteredVale"
  value: {
-  dps: 120205.40411
-  tps: 181083.48279
-  hps: 10932.89002
+  dps: 119864.61651
+  tps: 179508.02821
+  hps: 11022.65009
  }
 }
 dps_results: {

--- a/sim/druid/feral/feral.go
+++ b/sim/druid/feral/feral.go
@@ -78,6 +78,9 @@ type FeralDruid struct {
 	Shred          *druid.DruidSpell
 	TigersFury     *druid.DruidSpell
 
+	// Bonus references
+	FeralFuryBonus *core.Aura
+
 	tempSnapshotAura *core.Aura
 }
 

--- a/sim/druid/feral/feral.go
+++ b/sim/druid/feral/feral.go
@@ -64,6 +64,8 @@ type FeralDruid struct {
 	// Aura references
 	ClearcastingAura        *core.Aura
 	DreamOfCenariusAura     *core.Aura
+	FeralFuryAura           *core.Aura
+	FeralRageAura           *core.Aura
 	HeartOfTheWildAura      *core.Aura
 	IncarnationAura         *core.Aura
 	PredatorySwiftnessAura  *core.Aura

--- a/sim/druid/feral/items.go
+++ b/sim/druid/feral/items.go
@@ -47,7 +47,7 @@ func (cat *FeralDruid) registerFeralFury(setBonusTracker *core.Aura) {
 		ActionID: core.ActionID{SpellID: 144865},
 		Duration: time.Second * 6,
 
-		OnGain: func(aura *core.Aura, sim *core.Simulation) {
+		OnGain: func(_ *core.Aura, _ *core.Simulation) {
 			feralFuryMod.Activate()
 		},
 
@@ -57,7 +57,7 @@ func (cat *FeralDruid) registerFeralFury(setBonusTracker *core.Aura) {
 			}
 		},
 
-		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
+		OnExpire: func(_ *core.Aura, _ *core.Simulation) {
 			feralFuryMod.Deactivate()
 		},
 	})
@@ -74,7 +74,7 @@ func (cat *FeralDruid) registerFeralRage() {
 		ActionID: actionID,
 		Duration: time.Second * 12,
 
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+		OnSpellHitDealt: func(_ *core.Aura, _ *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if spell.Matches(druid.DruidSpellFinisher) && result.Landed() {
 				resultLanded = true
 			}

--- a/sim/druid/feral/items.go
+++ b/sim/druid/feral/items.go
@@ -69,13 +69,6 @@ func (cat *FeralDruid) registerFeralRage() {
 
 	var resultLanded bool
 
-	proc4pT16 := func(sim *core.Simulation, unit *core.Unit, isRoar bool) {
-		if resultLanded || isRoar {
-			unit.AddComboPoints(sim, 3, cpMetrics)
-		}
-		resultLanded = false
-	}
-
 	cat.FeralRageAura = cat.RegisterAura(core.Aura{
 		Label:    "Feral Rage 4PT16",
 		ActionID: actionID,
@@ -88,10 +81,18 @@ func (cat *FeralDruid) registerFeralRage() {
 		},
 
 		OnCastComplete: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell) {
-			if spell.Matches(druid.DruidSpellFinisher) {
-				proc4pT16(sim, aura.Unit, spell.Matches(druid.DruidSpellSavageRoar))
+			if !spell.Matches(druid.DruidSpellFinisher) {
+				return
+			}
+
+			if spell.Matches(druid.DruidSpellSavageRoar) || resultLanded {
+				aura.Unit.AddComboPoints(sim, 3, cpMetrics)
+				resultLanded = false
 				aura.Deactivate(sim)
 			}
 		},
 	})
+}
+
+func init() {
 }

--- a/sim/druid/feral/items.go
+++ b/sim/druid/feral/items.go
@@ -1,0 +1,97 @@
+package feral
+
+import (
+	"time"
+
+	"github.com/wowsims/mop/sim/core"
+	"github.com/wowsims/mop/sim/druid"
+)
+
+// T16 Feral
+var ItemSetBattlegearOfTheShatteredVale = core.NewItemSet(core.ItemSet{
+	ID:                      1197,
+	DisabledInChallengeMode: true,
+	Name:                    "Battlegear of the Shattered Vale",
+	Bonuses: map[int32]core.ApplySetBonus{
+		2: func(agent core.Agent, setBonusAura *core.Aura) {
+			// Omen of Clarity increases damage of Shred, Mangle, Swipe, and Ravage by 50% for 6 sec.
+			cat := agent.(*FeralDruid)
+			cat.registerFeralFury(setBonusAura)
+		},
+		4: func(agent core.Agent, setBonusAura *core.Aura) {
+			// After using Tiger's Fury, your next finishing move will restore 3 combo points on your current target after being used.
+			cat := agent.(*FeralDruid)
+			cat.registerFeralRage()
+
+			setBonusAura.OnCastComplete = func(_ *core.Aura, sim *core.Simulation, spell *core.Spell) {
+				if spell.Matches(druid.DruidSpellTigersFury) {
+					cat.FeralRageAura.Activate(sim)
+				}
+			}
+		},
+	},
+})
+
+func (cat *FeralDruid) registerFeralFury(setBonusTracker *core.Aura) {
+	cat.FeralFuryBonus = setBonusTracker
+	meleeAbilityMask := druid.DruidSpellMangleCat | druid.DruidSpellShred | druid.DruidSpellRavage | druid.DruidSpellSwipeCat
+
+	feralFuryMod := cat.AddDynamicMod(core.SpellModConfig{
+		ClassMask:  meleeAbilityMask,
+		Kind:       core.SpellMod_DamageDone_Pct,
+		FloatValue: 0.5,
+	})
+
+	cat.FeralFuryAura = cat.RegisterAura(core.Aura{
+		Label:    "Feral Fury 2PT16",
+		ActionID: core.ActionID{SpellID: 144865},
+		Duration: time.Second * 6,
+
+		OnGain: func(aura *core.Aura, sim *core.Simulation) {
+			feralFuryMod.Activate()
+		},
+
+		OnCastComplete: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell) {
+			if spell.Matches(meleeAbilityMask) {
+				aura.Deactivate(sim)
+			}
+		},
+
+		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
+			feralFuryMod.Deactivate()
+		},
+	})
+}
+
+func (cat *FeralDruid) registerFeralRage() {
+	actionID := core.ActionID{SpellID: 146874}
+	cpMetrics := cat.NewComboPointMetrics(actionID)
+
+	var resultLanded bool
+
+	proc4pT16 := func(sim *core.Simulation, unit *core.Unit, isRoar bool) {
+		if resultLanded || isRoar {
+			unit.AddComboPoints(sim, 3, cpMetrics)
+		}
+		resultLanded = false
+	}
+
+	cat.FeralRageAura = cat.RegisterAura(core.Aura{
+		Label:    "Feral Rage 4PT16",
+		ActionID: actionID,
+		Duration: time.Second * 12,
+
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if spell.Matches(druid.DruidSpellFinisher) && result.Landed() {
+				resultLanded = true
+			}
+		},
+
+		OnCastComplete: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell) {
+			if spell.Matches(druid.DruidSpellFinisher) {
+				proc4pT16(sim, aura.Unit, spell.Matches(druid.DruidSpellSavageRoar))
+				aura.Deactivate(sim)
+			}
+		},
+	})
+}

--- a/sim/druid/feral/omen_of_clarity.go
+++ b/sim/druid/feral/omen_of_clarity.go
@@ -35,8 +35,8 @@ func (cat *FeralDruid) applyOmenOfClarity() {
 			for _, spell := range affectedSpells {
 				spell.Cost.PercentModifier *= -1
 			}
-			if cat.Druid.FeralFuryAura != nil {
-				cat.Druid.FeralFuryAura.Activate(sim)
+			if cat.FeralFuryBonus.IsActive() {
+				cat.FeralFuryAura.Activate(sim)
 			}
 		},
 

--- a/sim/druid/feral/omen_of_clarity.go
+++ b/sim/druid/feral/omen_of_clarity.go
@@ -31,9 +31,12 @@ func (cat *FeralDruid) applyOmenOfClarity() {
 			}, func(spell *druid.DruidSpell) bool { return spell != nil })
 		},
 
-		OnGain: func(_ *core.Aura, _ *core.Simulation) {
+		OnGain: func(_ *core.Aura, sim *core.Simulation) {
 			for _, spell := range affectedSpells {
 				spell.Cost.PercentModifier *= -1
+			}
+			if cat.Druid.FeralFuryAura != nil {
+				cat.Druid.FeralFuryAura.Activate(sim)
 			}
 		},
 

--- a/sim/druid/feral/talents.go
+++ b/sim/druid/feral/talents.go
@@ -26,7 +26,7 @@ func (cat *FeralDruid) registerSoulOfTheForest() {
 
 	procSotf := func(sim *core.Simulation) {
 		if cpSnapshot > 0 {
-			cat.AddEnergy(sim, 4.0 * float64(cpSnapshot), energyMetrics)
+			cat.AddEnergy(sim, 4.0*float64(cpSnapshot), energyMetrics)
 			cpSnapshot = 0
 		}
 	}
@@ -115,7 +115,7 @@ func (cat *FeralDruid) registerIncarnation() {
 		Type:  core.CooldownTypeDPS,
 
 		ShouldActivate: func(sim *core.Simulation, _ *core.Character) bool {
-			return cat.BerserkCatAura.IsActive() && !cat.ClearcastingAura.IsActive() && (cat.CurrentEnergy() + cat.EnergyRegenPerSecond() < 100)
+			return cat.BerserkCatAura.IsActive() && !cat.ClearcastingAura.IsActive() && (cat.CurrentEnergy()+cat.EnergyRegenPerSecond() < 100)
 		},
 	})
 }
@@ -204,7 +204,7 @@ func (cat *FeralDruid) registerHeartOfTheWild() {
 		Type:  core.CooldownTypeDPS,
 
 		ShouldActivate: func(sim *core.Simulation, _ *core.Character) bool {
-			return !cat.BerserkCatAura.IsActive() && (cat.Berserk.TimeToReady(sim) > cat.HeartOfTheWildAura.Duration) && !cat.IncarnationAura.IsActive() && !cat.ClearcastingAura.IsActive() && ((cat.ComboPoints() == 5) || (cat.CurrentEnergy() + (cat.Wrath.DefaultCast.CastTime * 2 + core.GCDDefault).Seconds() * cat.EnergyRegenPerSecond() <= 100))
+			return !cat.BerserkCatAura.IsActive() && (cat.Berserk.TimeToReady(sim) > cat.HeartOfTheWildAura.Duration) && !cat.IncarnationAura.IsActive() && !cat.ClearcastingAura.IsActive() && ((cat.ComboPoints() == 5) || (cat.CurrentEnergy()+(cat.Wrath.DefaultCast.CastTime*2+core.GCDDefault).Seconds()*cat.EnergyRegenPerSecond() <= 100))
 		},
 	})
 }

--- a/sim/druid/feral/tigers_fury.go
+++ b/sim/druid/feral/tigers_fury.go
@@ -19,8 +19,14 @@ func (cat *FeralDruid) registerTigersFurySpell() {
 		ActionID: actionID,
 		Duration: 6 * time.Second,
 
-		OnGain: func(aura *core.Aura, _ *core.Simulation) {
+		OnGain: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Unit.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexPhysical] *= 1.15
+			if cat.Druid.TigersFury4PT15Aura != nil {
+				cat.Druid.TigersFury4PT15Aura.Activate(sim)
+			}
+			if cat.Druid.FeralRageAura != nil {
+				cat.Druid.FeralRageAura.Activate(sim)
+			}
 		},
 
 		OnExpire: func(aura *core.Aura, _ *core.Simulation) {

--- a/sim/druid/feral/tigers_fury.go
+++ b/sim/druid/feral/tigers_fury.go
@@ -19,7 +19,7 @@ func (cat *FeralDruid) registerTigersFurySpell() {
 		ActionID: actionID,
 		Duration: 6 * time.Second,
 
-		OnGain: func(aura *core.Aura, sim *core.Simulation) {
+		OnGain: func(aura *core.Aura, _ *core.Simulation) {
 			aura.Unit.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexPhysical] *= 1.15
 		},
 

--- a/sim/druid/feral/tigers_fury.go
+++ b/sim/druid/feral/tigers_fury.go
@@ -33,8 +33,9 @@ func (cat *FeralDruid) registerTigersFurySpell() {
 	})
 
 	cat.TigersFury = cat.RegisterSpell(druid.Cat, core.SpellConfig{
-		ActionID: actionID,
-		Flags:    core.SpellFlagAPL | core.SpellFlagReadinessTrinket,
+		ActionID:       actionID,
+		Flags:          core.SpellFlagAPL | core.SpellFlagReadinessTrinket,
+		ClassSpellMask: druid.DruidSpellTigersFury,
 
 		Cast: core.CastConfig{
 			CD: core.Cooldown{

--- a/sim/druid/feral/tigers_fury.go
+++ b/sim/druid/feral/tigers_fury.go
@@ -21,12 +21,6 @@ func (cat *FeralDruid) registerTigersFurySpell() {
 
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Unit.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexPhysical] *= 1.15
-			if cat.Druid.TigersFury4PT15Aura != nil {
-				cat.Druid.TigersFury4PT15Aura.Activate(sim)
-			}
-			if cat.Druid.FeralRageAura != nil {
-				cat.Druid.FeralRageAura.Activate(sim)
-			}
 		},
 
 		OnExpire: func(aura *core.Aura, _ *core.Simulation) {

--- a/sim/druid/guardian/TestGuardian.results
+++ b/sim/druid/guardian/TestGuardian.results
@@ -130,15 +130,6 @@ dps_results: {
  }
 }
 dps_results: {
- key: "TestGuardian-AllItems-BattlegearoftheShatteredVale"
- value: {
-  dps: 105966.75001
-  tps: 560054.45819
-  dtps: 12946.74909
-  hps: 11527.78555
- }
-}
-dps_results: {
  key: "TestGuardian-AllItems-BlossomofPureSnow-89081"
  value: {
   dps: 108943.90599

--- a/sim/druid/guardian/TestGuardian.results
+++ b/sim/druid/guardian/TestGuardian.results
@@ -121,6 +121,24 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestGuardian-AllItems-BattlegearoftheHauntedForest"
+ value: {
+  dps: 106569.75527
+  tps: 567396.86122
+  dtps: 13069.63271
+  hps: 11356.32468
+ }
+}
+dps_results: {
+ key: "TestGuardian-AllItems-BattlegearoftheShatteredVale"
+ value: {
+  dps: 105966.75001
+  tps: 560054.45819
+  dtps: 12946.74909
+  hps: 11527.78555
+ }
+}
+dps_results: {
  key: "TestGuardian-AllItems-BlossomofPureSnow-89081"
  value: {
   dps: 108943.90599

--- a/sim/druid/items.go
+++ b/sim/druid/items.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/wowsims/mop/sim/core"
+	"github.com/wowsims/mop/sim/core/proto"
 )
 
 // T14 Balance
@@ -221,7 +222,7 @@ var ItemSetBattlegearOfTheHauntedForest = core.NewItemSet(core.ItemSet{
 				}
 			}
 
-			setBonusAura.OnSpellHitDealt = func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			setBonusAura.OnSpellHitDealt = func(_ *core.Aura, _ *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if spell.Matches(DruidSpellFinisher) && result.Landed() {
 					resultLanded = true
 				}
@@ -237,7 +238,18 @@ var ItemSetBattlegearOfTheHauntedForest = core.NewItemSet(core.ItemSet{
 		4: func(agent core.Agent, setBonusAura *core.Aura) {
 			// After using Tiger's Fury, you gain 40% increased critical strike chance on the next 3 uses of Mangle, Shred, Ferocious Bite, Ravage, and Swipe.
 			druid := agent.(DruidAgent).GetDruid()
+
+			if druid.Spec != proto.Spec_SpecFeralDruid {
+				return
+			}
+
 			druid.registerTigersFury4PT15()
+
+			setBonusAura.OnCastComplete = func(_ *core.Aura, sim *core.Simulation, spell *core.Spell) {
+				if spell.Matches(DruidSpellTigersFury) {
+					druid.TigersFury4PT15Aura.Activate(sim)
+				}
+			}
 		},
 	},
 })
@@ -288,88 +300,6 @@ var ItemSetRegaliaOfTheShatteredVale = core.NewItemSet(core.ItemSet{
 		},
 	},
 })
-
-// T16 Feral
-var ItemSetBattlegearOfTheShatteredVale = core.NewItemSet(core.ItemSet{
-	ID:                      1197,
-	DisabledInChallengeMode: true,
-	Name:                    "Battlegear of the Shattered Vale",
-	Bonuses: map[int32]core.ApplySetBonus{
-		2: func(agent core.Agent, setBonusAura *core.Aura) {
-			// Omen of Clarity increases damage of Shred, Mangle, Swipe, and Ravage by 50% for 6 sec.
-			druid := agent.(DruidAgent).GetDruid()
-			druid.registerFeralFury()
-		},
-		4: func(agent core.Agent, setBonusAura *core.Aura) {
-			// After using Tiger's Fury, your next finishing move will restore 3 combo points on your current target after being used.
-			druid := agent.(DruidAgent).GetDruid()
-			druid.registerFeralRage()
-		},
-	},
-})
-
-func (druid *Druid) registerFeralFury() {
-	meleeAbilityMask := DruidSpellMangleCat | DruidSpellShred | DruidSpellRavage | DruidSpellSwipeCat
-
-	feralFuryMod := druid.AddDynamicMod(core.SpellModConfig{
-		ClassMask:  meleeAbilityMask,
-		Kind:       core.SpellMod_DamageDone_Pct,
-		FloatValue: 0.5,
-	})
-
-	druid.FeralFuryAura = druid.RegisterAura(core.Aura{
-		Label:    "Feral Fury 2PT16",
-		ActionID: core.ActionID{SpellID: 144865},
-		Duration: time.Second * 6,
-
-		OnGain: func(aura *core.Aura, sim *core.Simulation) {
-			feralFuryMod.Activate()
-		},
-
-		OnCastComplete: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell) {
-			if spell.Matches(meleeAbilityMask) {
-				aura.Deactivate(sim)
-			}
-		},
-
-		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
-			feralFuryMod.Deactivate()
-		},
-	})
-}
-
-func (druid *Druid) registerFeralRage() {
-	actionID := core.ActionID{SpellID: 146874}
-	cpMetrics := druid.NewComboPointMetrics(actionID)
-
-	var resultLanded bool
-
-	proc4pT16 := func(sim *core.Simulation, unit *core.Unit, isRoar bool) {
-		if resultLanded || isRoar {
-			unit.AddComboPoints(sim, 3, cpMetrics)
-		}
-		resultLanded = false
-	}
-
-	druid.FeralRageAura = druid.RegisterAura(core.Aura{
-		Label:    "Feral Rage 4PT16",
-		ActionID: actionID,
-		Duration: time.Second * 12,
-
-		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-			if spell.Matches(DruidSpellFinisher) && result.Landed() {
-				resultLanded = true
-			}
-		},
-
-		OnCastComplete: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell) {
-			if spell.Matches(DruidSpellFinisher) {
-				proc4pT16(sim, aura.Unit, spell.Matches(DruidSpellSavageRoar))
-				aura.Deactivate(sim)
-			}
-		},
-	})
-}
 
 func init() {
 }


### PR DESCRIPTION
Added the following bonuses for [T15](https://www.wowhead.com/mop-classic/item-set=1153/battlegear-of-the-haunted-forest) and [T16](https://www.wowhead.com/mop-classic/item-set=1199/battlegear-of-the-shattered-vale) : 
- 2P T15: [Gives your finishing moves a 15% chance per combo point to add a combo point to your target.](https://www.wowhead.com/mop-classic/spell=138352/item-druid-t15-feral-2p-bonus)
- 4P T15: [After using Tiger's Fury, you gain 40% increased critical strike chance on the next 3 uses of Mangle, Shred, Ferocious Bite, Ravage, and Swipe.](https://www.wowhead.com/mop-classic/spell=138357/item-druid-t15-feral-4p-bonus) - [(4P T15 Aura)](https://www.wowhead.com/mop-classic/spell=138358/tigers-fury)
- 2P T16: [Omen of Clarity increases damage of Shred, Mangle, Swipe, and Ravage by 50% for 6 sec.](https://www.wowhead.com/mop-classic/spell=144864/item-druid-t16-feral-2p-bonus) - [(2P T16 Aura)](https://www.wowhead.com/mop-classic/spell=144865/feral-fury)
- 4P T16: [After using Tiger's Fury, your next finishing move will restore 3 combo points on your current target after being used.](https://www.wowhead.com/mop-classic/spell=144841/item-druid-t16-feral-4p-bonus) - [(4P T16 Aura)](https://www.wowhead.com/mop-classic/spell=146874/feral-rage)