### PR TITLE
Added extra tooltip to SpellHit Tooltip

### DIFF
--- a/ui/core/components/character_stats.tsx
+++ b/ui/core/components/character_stats.tsx
@@ -362,11 +362,6 @@ export class CharacterStats extends Component {
 
 			const tooltipContent = (
 				<div>
-					{unitStat.isPseudoStat() && unitStat.getPseudoStat() === PseudoStat.PseudoStatSpellHitPercent && (
-					<div className="character-stats-tooltip-row">
-						<span>Includes Expertise (MoP)</span>
-					</div>
-					)}
 					<div className="character-stats-tooltip-row">
 						<span>{i18n.t('sidebar.character_stats.tooltip.base')}</span>
 						<span>{this.statDisplayString(baseDelta, unitStat, true)}</span>
@@ -397,6 +392,11 @@ export class CharacterStats extends Component {
 						<span>{i18n.t('sidebar.character_stats.tooltip.total')}</span>
 						<span>{this.statDisplayString(finalStats, unitStat, true)}</span>
 					</div>
+					{unitStat.isPseudoStat() && unitStat.getPseudoStat() === PseudoStat.PseudoStatSpellHitPercent && (
+					<div className="character-stats-tooltip-row">
+						<span><i>Total Includes Expertise</i></span>
+					</div>
+					)}
 				</div>
 			);
 


### PR DESCRIPTION
Small QoL change to expand tooltip on SpellHitChance tooltip...so many issues/questions about this.

<img width="280" height="239" alt="image" src="https://github.com/user-attachments/assets/1091c3b2-92d6-4e6c-9468-da625017d94d" />
