### PR TITLE
hunter fervor pet nil

### DIFF
--- a/sim/hunter/fervor.go
+++ b/sim/hunter/fervor.go
@@ -41,7 +41,9 @@ func (hunter *Hunter) registerFervorSpell() {
 				Period:   time.Second * 1,
 				OnAction: func(sim *core.Simulation) {
 					hunter.AddFocus(sim, 5, focusMetrics)
-					hunter.Pet.AddFocus(sim, 5, focusMetrics)
+					if hunter.Pet != nil {
+						hunter.Pet.AddFocus(sim, 5, focusMetrics)
+					}
 				},
 			})
 		},


### PR DESCRIPTION
Fervor has a nil check on hunter pet for the initial focus gain but no check on the periodic focus gain.