### PR TITLE
Add APL Value: Dot Base Duration

### DIFF
--- a/proto/apl.proto
+++ b/proto/apl.proto
@@ -98,7 +98,7 @@ message APLAction {
 }
 
 
-// NextIndex: 114
+// NextIndex: 115
 message APLValue {
 	UUID uuid = 85;
 
@@ -211,6 +211,7 @@ message APLValue {
         APLValueDotRemainingTime dot_remaining_time = 13;
         APLValueDotLowestRemainingTime dot_lowest_remaining_time = 104;
         APLValueDotTickFrequency dot_tick_frequency = 67;
+        APLValueDotBaseDuration dot_base_duration = 114;
 		APLValueDotPercentIncrease dot_percent_increase = 101;
 		APLValueDotPercentIncrease dot_crit_percent_increase = 109;
         APLValueDotPercentIncrease dot_tick_rate_percent_increase = 110;
@@ -754,6 +755,10 @@ message APLValueMonkCurrentChi {}
 message APLValueMonkMaxChi {}
 message APLValueBrewmasterMonkCurrentStaggerPercent {}
 message APLValueProtectionPaladinDamageTakenLastGlobal {}
+
+message APLValueDotBaseDuration {
+	ActionID spell_id = 1;
+}
 
 message APLValueDotPercentIncrease {
 	ActionID spell_id = 1;

--- a/sim/core/apl_value.go
+++ b/sim/core/apl_value.go
@@ -267,6 +267,8 @@ func (rot *APLRotation) newAPLValueWithContext(config *proto.APLValue, groupVari
 		value = rot.newValueDotLowestRemainingTime(config.GetDotLowestRemainingTime(), config.Uuid)
 	case *proto.APLValue_DotTickFrequency:
 		value = rot.newValueDotTickFrequency(config.GetDotTickFrequency(), config.Uuid)
+	case *proto.APLValue_DotBaseDuration:
+		value = rot.newValueDotBaseDuration(config.GetDotBaseDuration(), config.Uuid)
 	case *proto.APLValue_DotPercentIncrease:
 		value = rot.newValueDotPercentIncrease(config.GetDotPercentIncrease(), config.Uuid)
 	case *proto.APLValue_DotCritPercentIncrease:

--- a/sim/core/apl_values_dot.go
+++ b/sim/core/apl_values_dot.go
@@ -194,6 +194,37 @@ func (value *APLValueDotTickFrequency) String() string {
 	return fmt.Sprintf("Dot Tick Frequency(%s)", value.dot.Get().Spell.ActionID)
 }
 
+type APLValueDotBaseDuration struct {
+	DefaultAPLValueImpl
+	baseDuration time.Duration
+	spell        *Spell
+}
+
+func (rot *APLRotation) newValueDotBaseDuration(config *proto.APLValueDotBaseDuration, _ *proto.UUID) APLValue {
+	dot := rot.GetAPLDot(rot.GetTargetUnit(&proto.UnitReference{
+		Type:  proto.UnitReference_Target,
+		Index: rot.unit.Index,
+	}), config.SpellId)
+
+	if dot == nil {
+		return nil
+	}
+	return &APLValueDotBaseDuration{
+		baseDuration: dot.BaseDuration(),
+		spell:        dot.Spell,
+	}
+}
+
+func (value *APLValueDotBaseDuration) Type() proto.APLValueType {
+	return proto.APLValueType_ValueTypeDuration
+}
+func (value *APLValueDotBaseDuration) GetDuration(_ *Simulation) time.Duration {
+	return value.baseDuration
+}
+func (value *APLValueDotBaseDuration) String() string {
+	return fmt.Sprintf("Dot Base Duration(%s)", value.spell.ActionID)
+}
+
 type APLValueDotIncreaseCheck struct {
 	DefaultAPLValueImpl
 	spell    *Spell

--- a/ui/core/components/individual_sim_ui/apl_values.ts
+++ b/ui/core/components/individual_sim_ui/apl_values.ts
@@ -107,6 +107,7 @@ import {
 	APLValueAuraIsInactive,
 	APLValueAuraICDIsReady,
 	APLValueActiveItemSwapSet,
+	APLValueDotBaseDuration,
 } from '../../proto/apl.js';
 import { Class, Spec } from '../../proto/common.js';
 import { ShamanTotems_TotemType as TotemType } from '../../proto/shaman.js';
@@ -1400,6 +1401,13 @@ const valueKindFactories: { [f in ValidAPLValueKind]: ValueKindConfig<APLValueIm
 		shortDescription: 'The time between each tick.',
 		newValue: APLValueDotTickFrequency.create,
 		fields: [AplHelpers.unitFieldConfig('targetUnit', 'targets'), AplHelpers.actionIdFieldConfig('spellId', 'dot_spells', '')],
+	}),
+	dotBaseDuration: inputBuilder({
+		label: 'Dot Base Duration',
+		submenu: ['DoT'],
+		shortDescription: 'The base duration of the DoT.',
+		newValue: APLValueDotBaseDuration.create,
+		fields: [AplHelpers.actionIdFieldConfig('spellId', 'dot_spells', '')],
 	}),
 	dotPercentIncrease: inputBuilder({
 		label: 'Dot Damage Increase %',


### PR DESCRIPTION
- Used by Warlock for calculating Pandemic range (as this is Base Duration based) and if specific DoTs are glyphed or not (different logic based on base duration). Will become more common with more complex DoT logic as UVLS enters the game.