### PR TITLE
Add Phase 3 BiS gear sets for all mage specs

### DIFF
--- a/ui/mage/arcane/gear_sets/p3_bis.gear.json
+++ b/ui/mage/arcane/gear_sets/p3_bis.gear.json
@@ -1,0 +1,20 @@
+{
+      "items": [
+        {"id":96635,"gems":[95347,76700],"reforging":140,"upgradeStep":"UpgradeStepTwo"},
+        {"id":96453,"reforging":147,"upgradeStep":"UpgradeStepTwo"},
+        {"id":96638,"enchant":4806,"gems":[76672,76700],"reforging":147,"upgradeStep":"UpgradeStepTwo"},
+        {"id":95014,"enchant":4892,"gems":[76700],"reforging":140,"upgradeStep":"UpgradeStepTwo"},
+        {"id":96637,"enchant":4419,"gems":[76672,76700,76643],"reforging":138,"upgradeStep":"UpgradeStepTwo"},
+        {"id":96432,"enchant":4414,"gems":[0],"reforging":145,"upgradeStep":"UpgradeStepTwo"},
+        {"id":96634,"enchant":4433,"gems":[76672,0],"reforging":145,"upgradeStep":"UpgradeStepTwo","tinker":4898},
+        {"id":94996,"gems":[76643,76643,76700],"reforging":147,"upgradeStep":"UpgradeStepTwo"},
+        {"id":95030,"enchant":4825,"gems":[76672,76700,76700],"upgradeStep":"UpgradeStepTwo"},
+        {"id":95004,"enchant":4429,"gems":[76700,76643],"reforging":144,"upgradeStep":"UpgradeStepTwo"},
+        {"id":96529,"gems":[76643],"reforging":145,"upgradeStep":"UpgradeStepTwo"},
+        {"id":95019,"gems":[76643],"reforging":154,"upgradeStep":"UpgradeStepTwo"},
+        {"id":96516,"reforging":147,"upgradeStep":"UpgradeStepTwo"},
+        {"id":96558,"upgradeStep":"UpgradeStepTwo"},
+        {"id":96518,"enchant":4442,"gems":[76672,76700],"upgradeStep":"UpgradeStepTwo"},
+        {"id":96562,"enchant":4434,"gems":[76672],"reforging":147,"upgradeStep":"UpgradeStepTwo"}
+      ]
+    }

--- a/ui/mage/arcane/presets.ts
+++ b/ui/mage/arcane/presets.ts
@@ -9,6 +9,7 @@ import ArcaneCleaveApl from './apls/arcane_cleave.apl.json';
 import P1PreBISGear from './gear_sets/p1_prebis.gear.json';
 import P1BISGear from './gear_sets/p1_bis.gear.json';
 import P2BISGear from './gear_sets/p2_bis.gear.json';
+import P3BISGear from './gear_sets/p3_bis.gear.json';
 
 // Preset options for this spec.
 // Eventually we will import these values for the raid sim too, so its good to
@@ -16,6 +17,7 @@ import P2BISGear from './gear_sets/p2_bis.gear.json';
 export const P1_PREBIS = PresetUtils.makePresetGear('P1 - Pre-BIS', P1PreBISGear);
 export const P1_BIS = PresetUtils.makePresetGear('P1 - BIS', P1BISGear);
 export const P2_BIS = PresetUtils.makePresetGear('P2 - BIS', P2BISGear);
+export const P3_BIS = PresetUtils.makePresetGear('P3 - BIS', P3BISGear);
 
 export const ROTATION_PRESET_DEFAULT = PresetUtils.makePresetAPLRotation('Default', ArcaneApl);
 // export const ROTATION_PRESET_CLEAVE = PresetUtils.makePresetAPLRotation('Cleave', ArcaneCleaveApl);
@@ -54,7 +56,7 @@ export const ArcaneTalents = {
 		glyphs: Glyphs.create({
 			major1: MajorGlyph.GlyphOfArcanePower,
 			major2: MajorGlyph.GlyphOfRapidDisplacement,
-			major3: MajorGlyph.GlyphOfConeOfCold,
+			major3: MajorGlyph.GlyphOfManaGem,
 			minor1: MageMinorGlyph.GlyphOfMomentum,
 			minor2: MageMinorGlyph.GlyphOfRapidTeleportation,
 			minor3: MageMinorGlyph.GlyphOfLooseMana,
@@ -69,7 +71,7 @@ export const ArcaneTalentsCleave = {
 		glyphs: Glyphs.create({
 			major1: MajorGlyph.GlyphOfArcanePower,
 			major2: MajorGlyph.GlyphOfRapidDisplacement,
-			major3: MajorGlyph.GlyphOfConeOfCold,
+			major3: MajorGlyph.GlyphOfManaGem,
 			minor1: MageMinorGlyph.GlyphOfMomentum,
 			minor2: MageMinorGlyph.GlyphOfRapidTeleportation,
 			minor3: MageMinorGlyph.GlyphOfLooseMana,

--- a/ui/mage/arcane/sim.tsx
+++ b/ui/mage/arcane/sim.tsx
@@ -110,7 +110,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecArcaneMage, {
 		// Preset talents that the user can quickly select.
 		talents: [Presets.ArcaneTalents, Presets.ArcaneTalentsCleave],
 		// Preset gear configurations that the user can quickly select.
-		gear: [Presets.P1_PREBIS, Presets.P1_BIS, Presets.P2_BIS],
+		gear: [Presets.P1_PREBIS, Presets.P1_BIS, Presets.P2_BIS, Presets.P3_BIS],
 
 		builds: [Presets.P1_PRESET_BUILD_DEFAULT, Presets.P1_PRESET_BUILD_CLEAVE],
 	},

--- a/ui/mage/fire/gear_sets/p3_bis.gear.json
+++ b/ui/mage/fire/gear_sets/p3_bis.gear.json
@@ -1,0 +1,20 @@
+{
+      "items": [
+        {"id":96635,"gems":[95347,76697],"reforging":137,"upgradeStep":"UpgradeStepTwo"},
+        {"id":96453,"reforging":140,"upgradeStep":"UpgradeStepTwo"},
+        {"id":96638,"enchant":4806,"gems":[76660,76697],"reforging":154,"upgradeStep":"UpgradeStepTwo"},
+        {"id":95014,"enchant":4892,"gems":[76697],"reforging":137,"upgradeStep":"UpgradeStepTwo"},
+        {"id":96637,"enchant":4419,"gems":[76660,76697,76641],"reforging":137,"upgradeStep":"UpgradeStepTwo"},
+        {"id":96432,"enchant":4414,"gems":[0],"upgradeStep":"UpgradeStepTwo"},
+        {"id":96634,"enchant":4433,"gems":[76660,0],"upgradeStep":"UpgradeStepTwo","tinker":4898},
+        {"id":94996,"gems":[76641,76641,76697],"reforging":140,"upgradeStep":"UpgradeStepTwo"},
+        {"id":95030,"enchant":4825,"gems":[76660,76697,76697],"reforging":152,"upgradeStep":"UpgradeStepTwo"},
+        {"id":95004,"enchant":4429,"gems":[76697,76641],"upgradeStep":"UpgradeStepTwo"},
+        {"id":96529,"gems":[76697],"upgradeStep":"UpgradeStepTwo"},
+        {"id":95019,"gems":[76697],"reforging":152,"upgradeStep":"UpgradeStepTwo"},
+        {"id":96516,"upgradeStep":"UpgradeStepTwo"},
+        {"id":96413,"reforging":137,"upgradeStep":"UpgradeStepTwo"},
+        {"id":96610,"enchant":4442,"gems":[76697,76697],"reforging":140,"upgradeStep":"UpgradeStepTwo"},
+        {"id":96562,"enchant":4434,"gems":[76660],"reforging":154,"upgradeStep":"UpgradeStepTwo"}
+      ]
+    }

--- a/ui/mage/fire/presets.ts
+++ b/ui/mage/fire/presets.ts
@@ -9,6 +9,7 @@ import FireCleaveApl from './apls/fire_cleave.apl.json';
 import P1PreBISGear from './gear_sets/p1_prebis.gear.json';
 import P1BISGear from './gear_sets/p1_bis.gear.json';
 import P2BISGear from './gear_sets/p2_bis.gear.json';
+import P3BISGear from './gear_sets/p3_bis.gear.json';
 
 // Preset options for this spec.
 // Eventually we will import these values for the raid sim too, so its good to
@@ -16,6 +17,7 @@ import P2BISGear from './gear_sets/p2_bis.gear.json';
 export const P1_PREBIS = PresetUtils.makePresetGear('P1 - Pre-BIS', P1PreBISGear);
 export const P1_BIS = PresetUtils.makePresetGear('P1 - BIS', P1BISGear);
 export const P2_BIS = PresetUtils.makePresetGear('P2 - BIS', P2BISGear);
+export const P3_BIS = PresetUtils.makePresetGear('P3 - BIS', P3BISGear);
 
 // export const P1TrollDefaultSimpleRotation = FireMage_Rotation.create({
 // 	combustThreshold: 515000,
@@ -74,6 +76,7 @@ export const FireTalents = {
 			major3: MajorGlyph.GlyphOfRapidDisplacement,
 			minor1: MinorGlyph.GlyphOfMomentum,
 			minor2: MinorGlyph.GlyphOfLooseMana,
+			minor3: MinorGlyph.GlyphOfRapidTeleportation
 		}),
 	}),
 };

--- a/ui/mage/fire/sim.tsx
+++ b/ui/mage/fire/sim.tsx
@@ -156,7 +156,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFireMage, {
 		// Preset talents that the user can quickly select.
 		talents: [Presets.FireTalents, Presets.FireTalentsCleave],
 		// Preset gear configurations that the user can quickly select.
-		gear: [Presets.P1_PREBIS, Presets.P1_BIS, Presets.P2_BIS],
+		gear: [Presets.P1_PREBIS, Presets.P1_BIS, Presets.P2_BIS, Presets.P3_BIS],
 
 		builds: [Presets.P1_PRESET_BUILD_DEFAULT, Presets.P1_PRESET_BUILD_CLEAVE],
 	},

--- a/ui/mage/frost/gear_sets/p3_bis.gear.json
+++ b/ui/mage/frost/gear_sets/p3_bis.gear.json
@@ -1,0 +1,20 @@
+ {
+      "items": [
+        {"id":96635,"gems":[95347,76668],"reforging":140,"upgradeStep":"UpgradeStepTwo"},
+        {"id":96453,"reforging":145,"upgradeStep":"UpgradeStepTwo"},
+        {"id":96638,"enchant":4806,"gems":[76694,76668],"reforging":147,"upgradeStep":"UpgradeStepTwo"},
+        {"id":95014,"enchant":4892,"gems":[76668],"reforging":140,"upgradeStep":"UpgradeStepTwo"},
+        {"id":95039,"enchant":4419,"gems":[76694,76694,76694],"upgradeStep":"UpgradeStepTwo"},
+        {"id":96506,"enchant":4414,"gems":[0],"reforging":147,"upgradeStep":"UpgradeStepTwo"},
+        {"id":96634,"enchant":4430,"gems":[76694,0],"reforging":145,"upgradeStep":"UpgradeStepTwo","tinker":4898},
+        {"id":94996,"gems":[76682,76682,76694],"reforging":145,"upgradeStep":"UpgradeStepTwo"},
+        {"id":96636,"enchant":4895,"gems":[76668,76682],"reforging":147,"upgradeStep":"UpgradeStepTwo"},
+        {"id":95004,"enchant":4429,"gems":[76668,76682],"reforging":145,"upgradeStep":"UpgradeStepTwo"},
+        {"id":95019,"gems":[76682],"reforging":140,"upgradeStep":"UpgradeStepTwo"},
+        {"id":96529,"gems":[76682],"reforging":145,"upgradeStep":"UpgradeStepTwo"},
+        {"id":96455,"upgradeStep":"UpgradeStepTwo"},
+        {"id":96413,"reforging":138,"upgradeStep":"UpgradeStepTwo"},
+        {"id":96404,"enchant":4442,"gems":[76682,76694],"reforging":147,"upgradeStep":"UpgradeStepTwo"},
+        {"id":96562,"enchant":4434,"gems":[76694],"reforging":147,"upgradeStep":"UpgradeStepTwo"}
+      ]
+    }

--- a/ui/mage/frost/presets.ts
+++ b/ui/mage/frost/presets.ts
@@ -9,6 +9,7 @@ import FrostAoeApl from './apls/frost_aoe.apl.json';
 import P1PreBISGear from './gear_sets/p1_prebis.gear.json';
 import P1BISGear from './gear_sets/p1_bis.gear.json';
 import P2BSISGear from './gear_sets/p2_bis.gear.json';
+import P3BSISGear from './gear_sets/p3_bis.gear.json';
 // Preset options for this spec.
 // Eventually we will import these values for the raid sim too, so its good to
 // keep them in a separate file.
@@ -16,6 +17,7 @@ import P2BSISGear from './gear_sets/p2_bis.gear.json';
 export const P1_PREBIS = PresetUtils.makePresetGear('P1 - Pre-BIS', P1PreBISGear);
 export const P1_BIS = PresetUtils.makePresetGear('P1 - BIS', P1BISGear);
 export const P2_BIS = PresetUtils.makePresetGear('P2 - BIS', P2BSISGear);
+export const P3_BIS = PresetUtils.makePresetGear('P3 - BIS', P3BSISGear);
 
 export const ROTATION_PRESET_DEFAULT = PresetUtils.makePresetAPLRotation('Default', FrostApl);
 export const ROTATION_PRESET_AOE = PresetUtils.makePresetAPLRotation('AOE', FrostAoeApl);
@@ -52,13 +54,13 @@ export const P1_PREBIS_EP_PRESET = PresetUtils.makePresetEpWeights(
 export const FrostDefaultTalents = {
 	name: 'Default',
 	data: SavedTalents.create({
-		talentsString: '111122',
+		talentsString: '311122',
 		glyphs: Glyphs.create({
 			major1: MageMajorGlyph.GlyphOfSplittingIce,
 			major2: MageMajorGlyph.GlyphOfIcyVeins,
 			major3: MageMajorGlyph.GlyphOfWaterElemental,
 			minor1: MageMinorGlyph.GlyphOfMomentum,
-			minor2: MageMinorGlyph.GlyphOfMirrorImage,
+			minor2: MageMinorGlyph.GlyphOfLooseMana,
 			minor3: MageMinorGlyph.GlyphOfTheUnboundElemental,
 		}),
 	}),
@@ -74,13 +76,13 @@ export const DefaultConsumables = ConsumesSpec.create({
 export const FrostTalentsCleave = {
 	name: 'Cleave',
 	data: SavedTalents.create({
-		talentsString: '111122',
+		talentsString: '311122',
 		glyphs: Glyphs.create({
 			major1: MageMajorGlyph.GlyphOfSplittingIce,
 			major2: MageMajorGlyph.GlyphOfIcyVeins,
 			major3: MageMajorGlyph.GlyphOfWaterElemental,
 			minor1: MageMinorGlyph.GlyphOfMomentum,
-			minor2: MageMinorGlyph.GlyphOfMirrorImage,
+			minor2: MageMinorGlyph.GlyphOfLooseMana,
 			minor3: MageMinorGlyph.GlyphOfTheUnboundElemental,
 		}),
 	}),
@@ -89,13 +91,13 @@ export const FrostTalentsCleave = {
 export const FrostTalentsAoE = {
 	name: 'AoE (5+)',
 	data: SavedTalents.create({
-		talentsString: '111112',
+		talentsString: '311112',
 		glyphs: Glyphs.create({
 			major1: MageMajorGlyph.GlyphOfSplittingIce,
 			major2: MageMajorGlyph.GlyphOfIcyVeins,
 			major3: MageMajorGlyph.GlyphOfWaterElemental,
 			minor1: MageMinorGlyph.GlyphOfMomentum,
-			minor2: MageMinorGlyph.GlyphOfMirrorImage,
+			minor2: MageMinorGlyph.GlyphOfLooseMana,
 			minor3: MageMinorGlyph.GlyphOfTheUnboundElemental,
 		}),
 	}),
@@ -133,5 +135,5 @@ export const OtherDefaults = {
 	distanceFromTarget: 20,
 	profession1: Profession.Engineering,
 	profession2: Profession.Tailoring,
-	race: Race.RaceTroll,
+	race: Race.RaceOrc,
 };

--- a/ui/mage/frost/sim.ts
+++ b/ui/mage/frost/sim.ts
@@ -129,7 +129,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFrostMage, {
 		// Preset talents that the user can quickly select.
 		talents: [Presets.FrostDefaultTalents, Presets.FrostTalentsCleave, Presets.FrostTalentsAoE],
 		// Preset gear configurations that the user can quickly select.
-		gear: [Presets.P1_PREBIS, Presets.P1_BIS, Presets.P2_BIS],
+		gear: [Presets.P1_PREBIS, Presets.P1_BIS, Presets.P2_BIS, Presets.P3_BIS],
 
 		builds: [Presets.P1_PRESET_BUILD_DEFAULT, Presets.P1_PRESET_BUILD_CLEAVE, Presets.P1_PRESET_BUILD_AOE],
 	},
@@ -154,8 +154,8 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFrostMage, {
 			otherDefaults: Presets.OtherDefaults,
 			defaultFactionRaces: {
 				[Faction.Unknown]: Race.RaceUnknown,
-				[Faction.Alliance]: Race.RaceGnome,
-				[Faction.Horde]: Race.RaceTroll,
+				[Faction.Alliance]: Race.RaceAlliancePandaren,
+				[Faction.Horde]: Race.RaceOrc,
 			},
 			defaultGear: {
 				[Faction.Unknown]: {},


### PR DESCRIPTION
This pull request adds Phase 3 Best-in-Slot (P3 BIS) gear presets for Arcane, Fire, and Frost Mage specs, updates the available gear presets in the simulation UI, and makes several improvements to talent and glyph presets for all Mage specs. The changes ensure that the latest gear options and recommended talent/glyph setups are available for users, and update default race selections for Frost Mage.

**Phase 3 Gear Presets**
* Added new `p3_bis.gear.json` files for Arcane, Fire, and Frost Mage specs, each specifying item, gem, enchant, and upgrade details for Phase 3 BIS gear. [[1]](diffhunk://#diff-706ecac6bbb9557cced59e2cf6b91e1fc8b31849c29a2490cb8f2ae42605cc86R1-R20) [[2]](diffhunk://#diff-bf2deb59a3b8193cb91717a8aa7243d3d59692a599b6cdaa712a6a36fc68e933R1-R20) [[3]](diffhunk://#diff-967beea6ef2afd191a666a8f25c7350ac5b30deac32d0adda79a96f97bdff2d4R1-R20)
* Imported and exposed the new P3 BIS gear presets in each spec's `presets.ts` file, and made them selectable in the simulation UI by updating the `gear` arrays in `sim.tsx`. [[1]](diffhunk://#diff-277cba32fd9754e2eee71ba4fbcf03944a002f5c2f24be393e39ffa89c9d3c8bR12-R20) [[2]](diffhunk://#diff-7db5b33ac7af2fbf94f56c36515714e36c9ef4676c2a1b5d1826abe6d6210632R12-R20) [[3]](diffhunk://#diff-b88692c22f9ce4a2a6184cff5c9891e38155a34596ed3017d5c1cf0f715997afR12-R20) [[4]](diffhunk://#diff-f55ce04f26dac79926e56a893fa12886f65a650ac7eed47ffcba2b180ac5d610L113-R113) [[5]](diffhunk://#diff-387723de2e5e8ff81a9842512baa74723b192c4dd2aba5124a549ecb22dade36L159-R159) [[6]](diffhunk://#diff-0adc18f65184ecea596501cc7eb1eb4111370ec41a8fda176f3b3b8c35ccf848L132-R132)

**Talent and Glyph Preset Improvements**
* Updated Arcane Mage talent presets to use `GlyphOfManaGem` instead of `GlyphOfConeOfCold` for the third major glyph. [[1]](diffhunk://#diff-277cba32fd9754e2eee71ba4fbcf03944a002f5c2f24be393e39ffa89c9d3c8bL57-R59) [[2]](diffhunk://#diff-277cba32fd9754e2eee71ba4fbcf03944a002f5c2f24be393e39ffa89c9d3c8bL72-R74)
* Added `GlyphOfRapidTeleportation` as the third minor glyph in Fire Mage talent presets.
* Changed Frost Mage talent strings to start with `3` instead of `1` for all presets, and replaced the second minor glyph from `GlyphOfMirrorImage` to `GlyphOfLooseMana`. [[1]](diffhunk://#diff-b88692c22f9ce4a2a6184cff5c9891e38155a34596ed3017d5c1cf0f715997afL55-R63) [[2]](diffhunk://#diff-b88692c22f9ce4a2a6184cff5c9891e38155a34596ed3017d5c1cf0f715997afL77-R85) [[3]](diffhunk://#diff-b88692c22f9ce4a2a6184cff5c9891e38155a34596ed3017d5c1cf0f715997afL92-R100)

**Default Race Updates for Frost Mage**
* Changed the default race for Frost Mage from Troll to Orc, and updated faction default races to Alliance Pandaren and Horde Orc. [[1]](diffhunk://#diff-b88692c22f9ce4a2a6184cff5c9891e38155a34596ed3017d5c1cf0f715997afL136-R138) [[2]](diffhunk://#diff-0adc18f65184ecea596501cc7eb1eb4111370ec41a8fda176f3b3b8c35ccf848L157-R158)