### PR TITLE
[SV] Add on-use trinket pop to Survival APL

### DIFF
--- a/sim/hunter/survival/TestSurvival.results
+++ b/sim/hunter/survival/TestSurvival.results
@@ -47,15 +47,15 @@ dps_results: {
 dps_results: {
  key: "TestSurvival-AllItems-ArcaneBadgeoftheShieldwall-93347"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 162930.76731
+  tps: 133814.08854
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-ArrowflightMedallion-93258"
  value: {
-  dps: 170457.72864
-  tps: 140309.39976
+  dps: 172740.66553
+  tps: 142034.61802
  }
 }
 dps_results: {
@@ -96,8 +96,8 @@ dps_results: {
 dps_results: {
  key: "TestSurvival-AllItems-BlossomofPureSnow-89081"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 164321.19862
+  tps: 135284.16218
  }
 }
 dps_results: {
@@ -229,8 +229,8 @@ dps_results: {
 dps_results: {
  key: "TestSurvival-AllItems-CraftedDreadfulGladiator'sBadgeofConquest-93419"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 167749.88475
+  tps: 137844.16128
  }
 }
 dps_results: {
@@ -292,8 +292,8 @@ dps_results: {
 dps_results: {
  key: "TestSurvival-AllItems-CraftedMalevolentGladiator'sBadgeofConquest-98755"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 168779.15533
+  tps: 138624.60862
  }
 }
 dps_results: {
@@ -355,43 +355,43 @@ dps_results: {
 dps_results: {
  key: "TestSurvival-AllItems-CurseofHubris-102307"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 168212.67229
+  tps: 138129.89106
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-CurseofHubris-104649"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 168935.58592
+  tps: 138739.75567
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-CurseofHubris-104898"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 167494.64135
+  tps: 137604.62744
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-CurseofHubris-105147"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 166993.71608
+  tps: 137247.58438
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-CurseofHubris-105396"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 168512.29534
+  tps: 138380.74287
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-CurseofHubris-105645"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 169211.26323
+  tps: 138974.37114
  }
 }
 dps_results: {
@@ -425,8 +425,8 @@ dps_results: {
 dps_results: {
  key: "TestSurvival-AllItems-DeadeyeBadgeoftheShieldwall-93346"
  value: {
-  dps: 168011.76798
-  tps: 138336.98466
+  dps: 168963.28755
+  tps: 139279.10802
  }
 }
 dps_results: {
@@ -453,29 +453,29 @@ dps_results: {
 dps_results: {
  key: "TestSurvival-AllItems-Dominator'sArcaneBadge-93342"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 162930.76731
+  tps: 133814.08854
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Dominator'sDeadeyeBadge-93341"
  value: {
-  dps: 168011.76798
-  tps: 138336.98466
+  dps: 168963.28755
+  tps: 139279.10802
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Dominator'sDurableBadge-93345"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 163161.40242
+  tps: 134614.58581
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Dominator'sKnightlyBadge-93344"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 163161.40242
+  tps: 134614.58581
  }
 }
 dps_results: {
@@ -488,8 +488,8 @@ dps_results: {
 dps_results: {
  key: "TestSurvival-AllItems-DreadfulGladiator'sBadgeofConquest-84344"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 167749.88475
+  tps: 137844.16128
  }
 }
 dps_results: {
@@ -551,8 +551,8 @@ dps_results: {
 dps_results: {
  key: "TestSurvival-AllItems-DurableBadgeoftheShieldwall-93350"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 163161.40242
+  tps: 134614.58581
  }
 }
 dps_results: {
@@ -733,8 +733,8 @@ dps_results: {
 dps_results: {
  key: "TestSurvival-AllItems-FlashingSteelTalisman-81265"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 170263.59607
+  tps: 139335.12234
  }
 }
 dps_results: {
@@ -796,8 +796,8 @@ dps_results: {
 dps_results: {
  key: "TestSurvival-AllItems-Gerp'sPerfectArrow-87495"
  value: {
-  dps: 163691.19308
-  tps: 134889.85255
+  dps: 170446.09756
+  tps: 139763.39374
  }
 }
 dps_results: {
@@ -817,29 +817,29 @@ dps_results: {
 dps_results: {
  key: "TestSurvival-AllItems-GrievousGladiator'sBadgeofConquest-100195"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 172496.66972
+  tps: 141452.24448
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-GrievousGladiator'sBadgeofConquest-100603"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 172496.66972
+  tps: 141452.24448
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-GrievousGladiator'sBadgeofConquest-102856"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 172496.66972
+  tps: 141452.24448
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-GrievousGladiator'sBadgeofConquest-103145"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 172496.66972
+  tps: 141452.24448
  }
 }
 dps_results: {
@@ -1006,8 +1006,8 @@ dps_results: {
 dps_results: {
  key: "TestSurvival-AllItems-Hawkmaster'sTalon-89082"
  value: {
-  dps: 169938.74753
-  tps: 139894.0907
+  dps: 171048.08655
+  tps: 140028.50139
  }
 }
 dps_results: {
@@ -1055,8 +1055,8 @@ dps_results: {
 dps_results: {
  key: "TestSurvival-AllItems-HelmbreakerMedallion-93261"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 164467.53558
+  tps: 135411.60106
  }
 }
 dps_results: {
@@ -1097,8 +1097,8 @@ dps_results: {
 dps_results: {
  key: "TestSurvival-AllItems-IronBellyWok-89083"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 163321.30183
+  tps: 133824.61963
  }
 }
 dps_results: {
@@ -1111,29 +1111,29 @@ dps_results: {
 dps_results: {
  key: "TestSurvival-AllItems-JadeBanditFigurine-86043"
  value: {
-  dps: 169938.74753
-  tps: 139894.0907
+  dps: 171048.08655
+  tps: 140028.50139
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-JadeBanditFigurine-86772"
  value: {
-  dps: 169050.92137
-  tps: 139179.10478
+  dps: 170049.50818
+  tps: 139270.53611
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-JadeCharioteerFigurine-86042"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 163321.30183
+  tps: 133824.61963
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-JadeCharioteerFigurine-86771"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 163197.74973
+  tps: 133791.8997
  }
 }
 dps_results: {
@@ -1153,29 +1153,29 @@ dps_results: {
 dps_results: {
  key: "TestSurvival-AllItems-JadeMagistrateFigurine-86044"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 164321.19862
+  tps: 135284.16218
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-JadeMagistrateFigurine-86773"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 163980.3152
+  tps: 135009.5973
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-JadeWarlordFigurine-86046"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 163552.00284
+  tps: 134985.75367
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-JadeWarlordFigurine-86775"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 163374.02415
+  tps: 134816.62951
  }
 }
 dps_results: {
@@ -1188,8 +1188,8 @@ dps_results: {
 dps_results: {
  key: "TestSurvival-AllItems-KnightlyBadgeoftheShieldwall-93349"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 163161.40242
+  tps: 134614.58581
  }
 }
 dps_results: {
@@ -1209,8 +1209,8 @@ dps_results: {
 dps_results: {
  key: "TestSurvival-AllItems-Lao-Chin'sLiquidCourage-89079"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 163552.00284
+  tps: 134985.75367
  }
 }
 dps_results: {
@@ -1258,15 +1258,15 @@ dps_results: {
 dps_results: {
  key: "TestSurvival-AllItems-MalevolentGladiator'sBadgeofConquest-84934"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 169245.3776
+  tps: 138978.88947
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-MalevolentGladiator'sBadgeofConquest-91452"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 168779.15533
+  tps: 138624.60862
  }
 }
 dps_results: {
@@ -1377,8 +1377,8 @@ dps_results: {
 dps_results: {
  key: "TestSurvival-AllItems-MedallionofMystifyingVapors-93257"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 163657.23111
+  tps: 135085.74678
  }
 }
 dps_results: {
@@ -1524,15 +1524,15 @@ dps_results: {
 dps_results: {
  key: "TestSurvival-AllItems-PridefulGladiator'sBadgeofConquest-102659"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 175667.24787
+  tps: 143841.48632
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-PridefulGladiator'sBadgeofConquest-103342"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 175667.24787
+  tps: 143841.48632
  }
 }
 dps_results: {
@@ -1825,8 +1825,8 @@ dps_results: {
 dps_results: {
  key: "TestSurvival-AllItems-SkullrenderMedallion-93256"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 164467.53558
+  tps: 135411.60106
  }
 }
 dps_results: {
@@ -2028,29 +2028,29 @@ dps_results: {
 dps_results: {
  key: "TestSurvival-AllItems-TyrannicalGladiator'sBadgeofConquest-100043"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 170166.75014
+  tps: 139685.59165
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-TyrannicalGladiator'sBadgeofConquest-91099"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 170166.75014
+  tps: 139685.59165
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-TyrannicalGladiator'sBadgeofConquest-94373"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 170166.75014
+  tps: 139685.59165
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-TyrannicalGladiator'sBadgeofConquest-99772"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 170166.75014
+  tps: 139685.59165
  }
 }
 dps_results: {
@@ -2231,8 +2231,8 @@ dps_results: {
 dps_results: {
  key: "TestSurvival-AllItems-VaporshieldMedallion-93262"
  value: {
-  dps: 162255.72204
-  tps: 133715.48734
+  dps: 163657.23111
+  tps: 135085.74678
  }
 }
 dps_results: {
@@ -2287,8 +2287,8 @@ dps_results: {
 dps_results: {
  key: "TestSurvival-AllItems-WoundripperMedallion-93253"
  value: {
-  dps: 170457.72864
-  tps: 140309.39976
+  dps: 172740.66553
+  tps: 142034.61802
  }
 }
 dps_results: {

--- a/ui/core/proto_utils/action_id.ts
+++ b/ui/core/proto_utils/action_id.ts
@@ -912,9 +912,9 @@ export class ActionId {
 				break;
 			case 'Soul Swap':
 				if (tag == 1) {
-					name += ": Inhale"
+					name += ': Inhale';
 				} else if (tag == 2) {
-					name += ": Soulburn"
+					name += ': Soulburn';
 				}
 				break;
 			default:
@@ -1348,4 +1348,6 @@ export const buffAuraToSpellIdMap: Record<number, ActionId> = {
 
 	132403: ActionId.fromSpellId(53600), // Shield of the Righteous
 	138169: ActionId.fromSpellId(85256), // Paladin T15 Ret 4P Templar's Verdict
+
+	131900: ActionId.fromSpellId(131894), // A Murder of Crows
 };

--- a/ui/hunter/survival/apls/sv.apl.json
+++ b/ui/hunter/survival/apls/sv.apl.json
@@ -49,7 +49,9 @@
 		{
 			"name": "Cooldowns",
 			"actions": [
+				{ "action": { "castAllStatBuffCooldowns": { "statType1": 1, "statType2": -1, "statType3": -1 } } },
 				{ "action": { "castSpell": { "spellId": { "spellId": 126734 } } } },
+				{ "action": { "castAllStatBuffCooldowns": { "statType1": 6, "statType2": 7, "statType3": 11 } } },
 				{ "action": { "castSpell": { "spellId": { "spellId": 53401 } } } },
 				{
 					"action": {


### PR DESCRIPTION
Also fixes the display issue with A Murder of Crows on the timeline (dot spell id differs from the cast spell id)