### PR TITLE
Fix Living Bomb explosion incorrectly proccing Arcane Missiles

### DIFF
--- a/sim/mage/arcane/TestArcane.results
+++ b/sim/mage/arcane/TestArcane.results
@@ -33,463 +33,463 @@ character_stats_results: {
 dps_results: {
  key: "TestArcane-AllItems-AgilePrimalDiamond"
  value: {
-  dps: 146546.58501
-  tps: 143063.78136
+  dps: 144908.1227
+  tps: 141365.09536
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-AssuranceofConsequence-105472"
  value: {
-  dps: 144804.90456
-  tps: 141321.0138
+  dps: 142549.8078
+  tps: 139020.79277
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-AusterePrimalDiamond"
  value: {
-  dps: 145807.79542
-  tps: 142347.03619
+  dps: 144160.23659
+  tps: 140640.86574
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BurningPrimalDiamond"
  value: {
-  dps: 147799.95057
-  tps: 144291.80298
+  dps: 146237.68128
+  tps: 142669.63411
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CapacitivePrimalDiamond"
  value: {
-  dps: 146394.18259
-  tps: 142929.47243
+  dps: 144855.38651
+  tps: 141331.60702
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ChronomancerRegalia"
  value: {
-  dps: 132196.71266
-  tps: 129228.54308
+  dps: 130764.89683
+  tps: 127777.39084
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CourageousPrimalDiamond"
  value: {
-  dps: 147646.24205
-  tps: 144147.53713
+  dps: 146120.73097
+  tps: 142563.51039
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DelicateVialoftheSanguinaire-96895"
  value: {
-  dps: 144804.90456
-  tps: 141321.0138
+  dps: 142549.8078
+  tps: 139020.79277
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DestructivePrimalDiamond"
  value: {
-  dps: 146686.91124
-  tps: 143220.10507
+  dps: 145085.0543
+  tps: 141557.41023
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EffulgentPrimalDiamond"
  value: {
-  dps: 145807.79542
-  tps: 142347.03619
+  dps: 144160.23659
+  tps: 140640.86574
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EmberPrimalDiamond"
  value: {
-  dps: 147051.51791
-  tps: 143565.57304
+  dps: 145475.81181
+  tps: 141931.59101
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnchantWeapon-BloodyDancingSteel-5125"
  value: {
-  dps: 139665.00479
-  tps: 137289.41104
+  dps: 138427.60709
+  tps: 136052.86152
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnchantWeapon-Colossus-4445"
  value: {
-  dps: 139665.00479
-  tps: 137289.41104
+  dps: 138435.25863
+  tps: 136060.51306
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnchantWeapon-DancingSteel-4444"
  value: {
-  dps: 139665.00479
-  tps: 137289.41104
+  dps: 138427.60709
+  tps: 136052.86152
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnchantWeapon-ElementalForce-4443"
  value: {
-  dps: 141330.61498
-  tps: 138934.74668
+  dps: 140927.513
+  tps: 138536.91308
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnchantWeapon-River'sSong-4446"
  value: {
-  dps: 139662.9202
-  tps: 137287.32645
+  dps: 138423.12814
+  tps: 136048.38257
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnchantWeapon-SpiritofConquest-5124"
  value: {
-  dps: 147589.05719
-  tps: 144097.06174
+  dps: 146085.61935
+  tps: 142549.05832
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnchantWeapon-Windsong-4441"
  value: {
-  dps: 142543.30727
-  tps: 140081.20023
+  dps: 140262.12343
+  tps: 137840.03214
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnigmaticPrimalDiamond"
  value: {
-  dps: 146686.91124
-  tps: 143220.10507
+  dps: 145085.0543
+  tps: 141557.41023
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EternalPrimalDiamond"
  value: {
-  dps: 145807.79542
-  tps: 142347.03619
+  dps: 144160.23659
+  tps: 140640.86574
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EvilEyeofGalakras-105491"
  value: {
-  dps: 144799.2023
-  tps: 141315.31154
+  dps: 142541.5904
+  tps: 139012.57537
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FabledFeatherofJi-Kun-96842"
  value: {
-  dps: 144894.62585
-  tps: 141443.64242
+  dps: 142218.08192
+  tps: 138694.15471
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Fen-Yu,FuryofXuen-102248"
  value: {
-  dps: 145263.882
-  tps: 141778.94134
+  dps: 144654.12367
+  tps: 141141.3475
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FleetPrimalDiamond"
  value: {
-  dps: 147019.10096
-  tps: 143536.53241
+  dps: 145356.19634
+  tps: 141814.46666
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForlornPrimalDiamond"
  value: {
-  dps: 147051.51791
-  tps: 143565.57304
+  dps: 145475.81181
+  tps: 141931.59101
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GazeoftheTwins-96915"
  value: {
-  dps: 144503.7016
-  tps: 141922.85923
+  dps: 142677.08942
+  tps: 140149.56914
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Gladiator'sRegalia"
  value: {
-  dps: 146395.74555
-  tps: 143082.21779
+  dps: 145507.22224
+  tps: 142170.58831
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Gong-Lu,StrengthofXuen-102249"
  value: {
-  dps: 145263.882
-  tps: 141778.94134
+  dps: 144654.12367
+  tps: 141141.3475
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Horridon'sLastGasp-96757"
  value: {
-  dps: 154953.19935
-  tps: 151258.8262
+  dps: 152783.26392
+  tps: 149046.51137
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpassivePrimalDiamond"
  value: {
-  dps: 146686.91124
-  tps: 143220.10507
+  dps: 145085.0543
+  tps: 141557.41023
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-IndomitablePrimalDiamond"
  value: {
-  dps: 145807.79542
-  tps: 142347.03619
+  dps: 144160.23659
+  tps: 140640.86574
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InscribedBagofHydra-Spawn-96828"
  value: {
-  dps: 144804.90456
-  tps: 141321.0138
+  dps: 142549.8078
+  tps: 139020.79277
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Ji-Kun'sRisingWinds-96843"
  value: {
-  dps: 144804.90456
-  tps: 141321.0138
+  dps: 142549.8078
+  tps: 139020.79277
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-NitroBoosts-4223"
  value: {
-  dps: 147799.95057
-  tps: 144291.80298
+  dps: 146237.68128
+  tps: 142669.63411
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PhaseFingers-4697"
  value: {
-  dps: 147953.43098
-  tps: 144439.39665
+  dps: 145864.32218
+  tps: 142322.71265
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PowerfulPrimalDiamond"
  value: {
-  dps: 145807.79542
-  tps: 142347.03619
+  dps: 144160.23659
+  tps: 140640.86574
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PriceofProgress-81266"
  value: {
-  dps: 149735.21577
-  tps: 146148.69978
+  dps: 147461.01961
+  tps: 143832.89744
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Primordius'TalismanofRage-96873"
  value: {
-  dps: 148417.08072
-  tps: 144812.1505
+  dps: 146098.00936
+  tps: 142459.56396
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PurifiedBindingsofImmerseus-105422"
  value: {
-  dps: 162551.12842
-  tps: 159153.85488
+  dps: 160766.3368
+  tps: 157335.57917
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Qian-Le,CourageofNiuzao-102245"
  value: {
-  dps: 144706.37114
-  tps: 141224.64237
+  dps: 143405.89861
+  tps: 139855.12809
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Qian-Ying,FortitudeofNiuzao-102250"
  value: {
-  dps: 142584.60567
-  tps: 139155.33459
+  dps: 141363.15878
+  tps: 137864.45955
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RegaliaoftheBurningScroll"
  value: {
-  dps: 130543.42396
-  tps: 127610.55503
+  dps: 130096.27661
+  tps: 127142.13003
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RegaliaoftheChromaticHydra"
  value: {
-  dps: 143375.85961
-  tps: 139916.29826
+  dps: 143256.20663
+  tps: 139754.20382
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Renataki'sSoulCharm-96741"
  value: {
-  dps: 144809.42665
-  tps: 141325.53589
+  dps: 142488.74083
+  tps: 138956.24645
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ReverberatingPrimalDiamond"
  value: {
-  dps: 146546.58501
-  tps: 143063.78136
+  dps: 144908.1227
+  tps: 141365.09536
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RevitalizingPrimalDiamond"
  value: {
-  dps: 146546.58501
-  tps: 143063.78136
+  dps: 144908.1227
+  tps: 141365.09536
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RuneofRe-Origination-96918"
  value: {
-  dps: 144804.90456
-  tps: 141321.0138
+  dps: 142549.8078
+  tps: 139020.79277
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SinisterPrimalDiamond"
  value: {
-  dps: 155180.69056
-  tps: 150938.384
+  dps: 152817.1784
+  tps: 148624.45283
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SoothingTalismanoftheShado-PanAssault-94509"
  value: {
-  dps: 153808.4908
-  tps: 150011.25236
+  dps: 152236.05113
+  tps: 148409.93159
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SoulBarrier-96927"
  value: {
-  dps: 144804.90456
-  tps: 141321.0138
+  dps: 142549.8078
+  tps: 139020.79277
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SparkofZandalar-96770"
  value: {
-  dps: 148730.76352
-  tps: 145177.19761
+  dps: 147340.60914
+  tps: 143751.35538
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SynapseSprings(MarkII)-4898"
  value: {
-  dps: 151157.83095
-  tps: 147452.11987
+  dps: 149022.64212
+  tps: 145279.78789
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TalismanofBloodlust-96864"
  value: {
-  dps: 146206.91218
-  tps: 143646.2814
+  dps: 144776.99603
+  tps: 142251.9478
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheGloamingBlade-88149"
  value: {
-  dps: 147799.95057
-  tps: 144291.80298
+  dps: 146237.68128
+  tps: 142669.63411
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TyrannicalPrimalDiamond"
  value: {
-  dps: 145807.79542
-  tps: 142347.03619
+  dps: 144160.23659
+  tps: 140640.86574
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-UnerringVisionofLeiShen-96930"
  value: {
-  dps: 163800.03415
-  tps: 159391.83449
+  dps: 162453.96855
+  tps: 157978.43764
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Wushoolay'sFinalChoice-96785"
  value: {
-  dps: 156092.16105
-  tps: 152792.82416
+  dps: 153689.60336
+  tps: 150466.86648
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Xing-Ho,BreathofYu'lon-102246"
  value: {
-  dps: 181120.74083
-  tps: 177420.45107
+  dps: 180124.41596
+  tps: 176387.38824
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ZenAlchemistStone-75274"
  value: {
-  dps: 155080.91799
-  tps: 151149.23005
+  dps: 152904.40156
+  tps: 148949.2618
  }
 }
 dps_results: {
  key: "TestArcane-Average-Default"
  value: {
-  dps: 152231.12273
-  tps: 148234.17804
+  dps: 150393.21387
+  tps: 146450.28233
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_bis-DefaultTalents-Arcane-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 383419.33719
-  tps: 382148.57217
+  dps: 381004.81811
+  tps: 379910.96572
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_bis-DefaultTalents-Arcane-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 148330.60151
-  tps: 144554.69813
+  dps: 147561.63163
+  tps: 143869.73604
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_bis-DefaultTalents-Arcane-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 224270.09445
-  tps: 208185.84235
+  dps: 223431.54261
+  tps: 207788.54429
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_bis-DefaultTalents-Arcane-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 279996.05756
-  tps: 281895.7897
+  dps: 277847.05798
+  tps: 280454.5492
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_bis-DefaultTalents-Arcane-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 108516.86497
-  tps: 107609.6946
+  dps: 107565.91753
+  tps: 106674.02909
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_bis-DefaultTalents-Arcane-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 128690.32115
-  tps: 126561.1789
+  dps: 127932.77105
+  tps: 125808.18465
  }
 }
 dps_results: {
@@ -579,127 +579,127 @@ dps_results: {
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_bis-Row6_Talent1-Arcane-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 266883.01383
-  tps: 275242.18832
+  dps: 259983.25722
+  tps: 270142.47622
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_bis-Row6_Talent1-Arcane-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 58132.49277
-  tps: 56058.51729
+  dps: 58007.70479
+  tps: 55930.55113
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_bis-Row6_Talent1-Arcane-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 190459.6477
-  tps: 178847.14194
+  dps: 189683.32221
+  tps: 177940.46691
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_bis-Row6_Talent1-Arcane-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 196350.05879
-  tps: 207023.18181
+  dps: 196290.73926
+  tps: 207710.64688
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_bis-Row6_Talent1-Arcane-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 39637.99041
-  tps: 39600.13159
+  dps: 39201.27301
+  tps: 39200.10517
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_bis-Row6_Talent1-Arcane-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 116050.89872
-  tps: 114759.13237
+  dps: 113420.16398
+  tps: 112239.13712
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_bis-Row6_Talent3-Arcane-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 313831.373
-  tps: 323662.26976
+  dps: 306785.54254
+  tps: 318750.70191
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_bis-Row6_Talent3-Arcane-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 111231.09474
-  tps: 110320.06667
+  dps: 108975.35667
+  tps: 108118.27549
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_bis-Row6_Talent3-Arcane-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 163543.01377
-  tps: 158559.95019
+  dps: 160065.09823
+  tps: 155193.80429
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_bis-Row6_Talent3-Arcane-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 235871.27083
-  tps: 246117.24457
+  dps: 232461.75021
+  tps: 244468.80195
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_bis-Row6_Talent3-Arcane-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 84001.54807
-  tps: 83764.2773
+  dps: 82347.18112
+  tps: 82175.85546
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_bis-Row6_Talent3-Arcane-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 100557.62629
-  tps: 98614.55233
+  dps: 100151.80359
+  tps: 98242.43745
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_prebis-DefaultTalents-Arcane-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 301281.23683
-  tps: 301172.76346
+  dps: 298383.92087
+  tps: 298340.08241
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_prebis-DefaultTalents-Arcane-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 117016.13116
-  tps: 113923.60206
+  dps: 116204.46418
+  tps: 113156.95191
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_prebis-DefaultTalents-Arcane-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 177667.84222
-  tps: 164693.11288
+  dps: 176576.18833
+  tps: 163915.74855
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_prebis-DefaultTalents-Arcane-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 215542.66379
-  tps: 217323.1856
+  dps: 214682.45713
+  tps: 217210.0573
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_prebis-DefaultTalents-Arcane-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 84319.40493
-  tps: 83493.67124
+  dps: 83171.41525
+  tps: 82354.90139
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_prebis-DefaultTalents-Arcane-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 100239.53927
-  tps: 98305.02903
+  dps: 99434.7635
+  tps: 97504.54858
  }
 }
 dps_results: {
@@ -789,127 +789,127 @@ dps_results: {
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_prebis-Row6_Talent1-Arcane-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 209282.14767
-  tps: 218111.80889
+  dps: 203851.89637
+  tps: 214419.61887
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_prebis-Row6_Talent1-Arcane-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 46129.78436
-  tps: 44517.62018
+  dps: 46112.38308
+  tps: 44505.4951
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_prebis-Row6_Talent1-Arcane-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 153707.57137
-  tps: 144405.65955
+  dps: 152661.0126
+  tps: 143312.6843
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_prebis-Row6_Talent1-Arcane-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 150506.13233
-  tps: 161126.10821
+  dps: 150072.37359
+  tps: 161514.75271
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_prebis-Row6_Talent1-Arcane-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 30767.31153
-  tps: 30767.75389
+  dps: 30469.23986
+  tps: 30503.78125
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_prebis-Row6_Talent1-Arcane-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 91461.67304
-  tps: 90351.66604
+  dps: 90035.04877
+  tps: 89071.97719
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_prebis-Row6_Talent3-Arcane-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 249403.88421
-  tps: 259321.98451
+  dps: 244940.80855
+  tps: 257145.61777
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_prebis-Row6_Talent3-Arcane-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 89359.06651
-  tps: 88662.66431
+  dps: 88070.2203
+  tps: 87424.13335
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_prebis-Row6_Talent3-Arcane-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 131425.68471
-  tps: 127205.0293
+  dps: 128988.31803
+  tps: 124877.65262
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_prebis-Row6_Talent3-Arcane-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 182302.27072
-  tps: 192896.9494
+  dps: 181248.23154
+  tps: 193392.4873
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_prebis-Row6_Talent3-Arcane-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 66340.1979
-  tps: 66194.32108
+  dps: 65275.29348
+  tps: 65189.14219
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Orc-p1_prebis-Row6_Talent3-Arcane-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 79558.12659
-  tps: 77817.28429
+  dps: 79347.4759
+  tps: 77640.78948
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_bis-DefaultTalents-Arcane-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 381684.72021
-  tps: 379619.60523
+  dps: 383021.23666
+  tps: 382764.37522
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_bis-DefaultTalents-Arcane-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 151549.94832
-  tps: 147854.25355
+  dps: 149722.24664
+  tps: 145959.3602
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_bis-DefaultTalents-Arcane-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 229868.7337
-  tps: 213986.84264
+  dps: 228166.52682
+  tps: 211964.9175
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_bis-DefaultTalents-Arcane-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 283753.69073
-  tps: 286027.14438
+  dps: 282744.25314
+  tps: 285956.61929
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_bis-DefaultTalents-Arcane-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 109527.99132
-  tps: 108724.41035
+  dps: 108172.94235
+  tps: 107369.09697
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_bis-DefaultTalents-Arcane-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 132771.23887
-  tps: 130837.74492
+  dps: 130697.67943
+  tps: 128743.72721
  }
 }
 dps_results: {
@@ -999,127 +999,127 @@ dps_results: {
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_bis-Row6_Talent1-Arcane-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 267053.57516
-  tps: 276825.28883
+  dps: 266888.20693
+  tps: 277466.21631
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_bis-Row6_Talent1-Arcane-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 59187.97255
-  tps: 57292.02137
+  dps: 58672.85301
+  tps: 56798.88636
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_bis-Row6_Talent1-Arcane-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 194798.80512
-  tps: 184245.36098
+  dps: 193538.97116
+  tps: 182945.00122
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_bis-Row6_Talent1-Arcane-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 195974.87252
-  tps: 208045.94094
+  dps: 196351.45901
+  tps: 209161.02034
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_bis-Row6_Talent1-Arcane-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 39768.16981
-  tps: 39799.23964
+  dps: 39123.78611
+  tps: 39184.61597
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_bis-Row6_Talent1-Arcane-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 115503.92334
-  tps: 114569.43241
+  dps: 113505.11816
+  tps: 112626.41355
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_bis-Row6_Talent3-Arcane-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 316212.57037
-  tps: 327736.42285
+  dps: 312172.79469
+  tps: 325288.77478
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_bis-Row6_Talent3-Arcane-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 112944.93154
-  tps: 112166.62931
+  dps: 110662.75383
+  tps: 109913.26956
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_bis-Row6_Talent3-Arcane-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 168486.61231
-  tps: 163928.55537
+  dps: 164619.46902
+  tps: 160084.28224
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_bis-Row6_Talent3-Arcane-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 238063.74661
-  tps: 248506.65765
+  dps: 233459.24933
+  tps: 246340.10181
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_bis-Row6_Talent3-Arcane-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 84921.29284
-  tps: 84771.7313
+  dps: 83665.82453
+  tps: 83593.7339
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_bis-Row6_Talent3-Arcane-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 104297.04641
-  tps: 102680.83228
+  dps: 102266.8037
+  tps: 100664.24773
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_prebis-DefaultTalents-Arcane-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 301066.54796
-  tps: 299732.37147
+  dps: 300303.01548
+  tps: 300818.9806
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_prebis-DefaultTalents-Arcane-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 118918.52732
-  tps: 115889.05568
+  dps: 117672.54974
+  tps: 114600.32478
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_prebis-DefaultTalents-Arcane-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 179990.94762
-  tps: 167151.10399
+  dps: 179273.24313
+  tps: 166228.75787
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_prebis-DefaultTalents-Arcane-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 218714.89343
-  tps: 221178.46637
+  dps: 217919.03958
+  tps: 221386.98155
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_prebis-DefaultTalents-Arcane-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 84455.75219
-  tps: 83742.20825
+  dps: 83798.59532
+  tps: 83080.74655
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_prebis-DefaultTalents-Arcane-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 103029.5385
-  tps: 101273.60788
+  dps: 101303.74855
+  tps: 99528.80307
  }
 }
 dps_results: {
@@ -1209,91 +1209,91 @@ dps_results: {
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_prebis-Row6_Talent1-Arcane-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 210212.89807
-  tps: 220236.76184
+  dps: 208332.98917
+  tps: 219106.51086
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_prebis-Row6_Talent1-Arcane-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 46928.21088
-  tps: 45481.76527
+  dps: 46553.44066
+  tps: 45127.39492
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_prebis-Row6_Talent1-Arcane-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 157043.07491
-  tps: 148725.65886
+  dps: 156188.38162
+  tps: 147811.68283
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_prebis-Row6_Talent1-Arcane-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 149986.43815
-  tps: 161969.55513
+  dps: 150461.26963
+  tps: 163211.03637
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_prebis-Row6_Talent1-Arcane-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 30795.2033
-  tps: 30862.84091
+  dps: 30287.92328
+  tps: 30385.58602
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_prebis-Row6_Talent1-Arcane-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 90795.0052
-  tps: 90044.51685
+  dps: 89510.06004
+  tps: 88815.14616
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_prebis-Row6_Talent3-Arcane-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 249928.32583
-  tps: 261808.5982
+  dps: 247640.60562
+  tps: 261029.52721
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_prebis-Row6_Talent3-Arcane-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 90966.33646
-  tps: 90389.36116
+  dps: 89347.75966
+  tps: 88798.24042
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_prebis-Row6_Talent3-Arcane-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 134880.08921
-  tps: 131057.53303
+  dps: 131647.08974
+  tps: 127865.64977
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_prebis-Row6_Talent3-Arcane-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 184769.55723
-  tps: 195377.88666
+  dps: 181615.52007
+  tps: 194588.55104
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_prebis-Row6_Talent3-Arcane-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 67037.05998
-  tps: 66973.59129
+  dps: 65885.88773
+  tps: 65907.9843
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_prebis-Row6_Talent3-Arcane-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 81807.70194
-  tps: 80385.71772
+  dps: 80154.205
+  tps: 78743.5391
  }
 }
 dps_results: {
  key: "TestArcane-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 151549.94832
-  tps: 147854.25355
+  dps: 149722.24664
+  tps: 145959.3602
  }
 }

--- a/sim/mage/arcane/arcane_missiles.go
+++ b/sim/mage/arcane/arcane_missiles.go
@@ -119,7 +119,7 @@ func (arcane *ArcaneMage) registerArcaneMissilesSpell() {
 	core.MakeProcTriggerAura(&arcane.Unit, core.ProcTrigger{
 		Name:              "Arcane Missiles - Activation",
 		ActionID:          core.ActionID{SpellID: 79684},
-		ClassSpellMask:    mage.MageSpellsAll ^ (mage.MageSpellArcaneMissilesCast | mage.MageSpellArcaneMissilesTick | mage.MageSpellNetherTempestDot | mage.MageSpellLivingBombDot),
+		ClassSpellMask:    mage.MageSpellsAll ^ (mage.MageSpellArcaneMissilesCast | mage.MageSpellArcaneMissilesTick | mage.MageSpellNetherTempestDot | mage.MageSpellLivingBombDot | mage.MageSpellLivingBombExplosion),
 		SpellFlagsExclude: core.SpellFlagHelpful,
 		ProcChance:        0.3,
 		Callback:          core.CallbackOnSpellHitDealt,


### PR DESCRIPTION
This pull request makes a targeted update to the proc trigger configuration for Arcane Missiles in the Mage simulation. The change refines which spell events do not activate the Arcane Missiles proc by adding an additional exclusion.

* Spell proc exclusions updated: The `ClassSpellMask` for the Arcane Missiles activation proc now also excludes `mage.MageSpellLivingBombExplosion`, ensuring this spell event does not incorrectly trigger Arcane Missiles procs.