### PR TITLE
In-flight haunt soulshard reduction

### DIFF
--- a/sim/core/unit.go
+++ b/sim/core/unit.go
@@ -825,6 +825,11 @@ func (unit *Unit) GetSpellsMatchingSchool(school SpellSchool) []*Spell {
 	return spells
 }
 
+func (unit *Unit) SpellInFlight(spellID int32) bool {
+	spell := unit.GetSpell(ActionID{SpellID: spellID})
+	return unit.SpellsInFlight[spell] > 0
+}
+
 func (unit *Unit) GetUnit(ref *proto.UnitReference) *Unit {
 	return unit.Env.GetUnit(ref, unit)
 }

--- a/sim/warlock/affliction/affliction.go
+++ b/sim/warlock/affliction/affliction.go
@@ -43,6 +43,7 @@ type AfflictionWarlock struct {
 	SoulShards         core.SecondaryResourceBar
 	Agony              *core.Spell
 	UnstableAffliction *core.Spell
+	Haunt              *core.Spell
 
 	SoulBurnAura     *core.Aura
 	HauntDebuffAuras core.AuraArray
@@ -111,6 +112,9 @@ func (affliction *AfflictionWarlock) Reset(sim *core.Simulation) {
 func (affliction *AfflictionWarlock) OnEncounterStart(sim *core.Simulation) {
 	defaultShards := MaxSoulShards
 	if affliction.SoulBurnAura.IsActive() {
+		defaultShards -= 1
+	}
+	if affliction.SpellInFlight(affliction.Haunt.SpellID) {
 		defaultShards -= 1
 	}
 


### PR DESCRIPTION
Pre-cast haunts were not having their shard cost removed from affliction on pull.