### PR TITLE
Disable bulk sim button when combination count exceeds 50,000

### DIFF
--- a/ui/core/components/individual_sim_ui/bulk_tab.tsx
+++ b/ui/core/components/individual_sim_ui/bulk_tab.tsx
@@ -1074,6 +1074,7 @@ export class BulkTab extends SimTab {
 
 	private async getCombinationsCount(): Promise<Element> {
 		await this.calculateBulkCombinations();
+		this.bulkSimButton.disabled = (this.combinations > 50000);
 
 		const warningRef = ref<HTMLButtonElement>();
 		const rtn = (


### PR DESCRIPTION
 On branch feature/batch-sim
 Changes to be committed:
	modified:   ui/core/components/individual_sim_ui/bulk_tab.tsx