### PR TITLE
DPS delta % fix

### DIFF
--- a/ui/core/utils.ts
+++ b/ui/core/utils.ts
@@ -204,7 +204,7 @@ export function formatDeltaTextElem(
 	showPercentage?: boolean,
 ) {
 	const delta = after - before;
-	const denom = before;//Math.min(before, after);
+	const denom = before;
 	const deltaPct = Math.abs((delta / (denom === 0 ? 1 : denom)) * 100).toFixed(precision);
 	let deltaStr = delta.toFixed(precision);
 	if (delta >= 0) {


### PR DESCRIPTION
Delta % showed should be shown as a % of the set being compared to, not the worst of the two.

Going from 100k -> 50k dps is -50%, not -100%