### PR TITLE
[DK] Revert Runic Empowerment to be random again

### DIFF
--- a/sim/core/runic_power.go
+++ b/sim/core/runic_power.go
@@ -741,35 +741,21 @@ func getHighestCDRune(sim *Simulation, possibleRunes []*depletedRune) int8 {
 	return filteredRunes[randomRuneIndex]
 }
 
-// Runic Empowerment prioritizes fully depleted runes with the highest cd
+// Runic Empowerment regens a randoom fully depleted rune
 func (rp *runicPowerBar) RegenRunicEmpowermentRune(sim *Simulation, runeMetrics []*ResourceMetrics) {
-	possibleRunes := make([]*depletedRune, 0)
-
-	if rp.isDepleted(0) {
-		possibleRunes = append(possibleRunes, &depletedRune{runeSlot: 0, regenAt: rp.runeMeta[1].regenAt})
-	} else if rp.isDepleted(1) {
-		possibleRunes = append(possibleRunes, &depletedRune{runeSlot: 1, regenAt: rp.runeMeta[0].regenAt})
-	}
-	if rp.isDepleted(2) {
-		possibleRunes = append(possibleRunes, &depletedRune{runeSlot: 2, regenAt: rp.runeMeta[3].regenAt})
-	} else if rp.isDepleted(3) {
-		possibleRunes = append(possibleRunes, &depletedRune{runeSlot: 3, regenAt: rp.runeMeta[2].regenAt})
-	}
-	if rp.isDepleted(4) {
-		possibleRunes = append(possibleRunes, &depletedRune{runeSlot: 4, regenAt: rp.runeMeta[5].regenAt})
-	} else if rp.isDepleted(5) {
-		possibleRunes = append(possibleRunes, &depletedRune{runeSlot: 5, regenAt: rp.runeMeta[4].regenAt})
+	possibleRunes := make([]int, 0)
+	for i := range rp.runeMeta {
+		if rp.isDepleted(i) {
+			possibleRunes = append(possibleRunes, i)
+		}
 	}
 
 	if len(possibleRunes) == 0 {
 		return
 	}
 
-	slot := getHighestCDRune(sim, possibleRunes)
-
-	if slot == -1 {
-		return
-	}
+	randomRuneIndex := int(math.Floor(sim.RandomFloat("Rune Regen") * float64(len(possibleRunes))))
+	slot := int8(possibleRunes[randomRuneIndex])
 
 	rp.regenRuneInternal(sim, sim.CurrentTime, slot)
 	if rp.runeStates&isDeaths[slot] > 0 {

--- a/sim/death_knight/frost/TestFrostMasterfrost.results
+++ b/sim/death_knight/frost/TestFrostMasterfrost.results
@@ -722,49 +722,49 @@ dps_results: {
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Orc-p2.masterfrost-RunicEmpowerment-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 697894.66867
-  tps: 685197.44233
-  hps: 1594.41928
+  dps: 692326.61738
+  tps: 679672.24694
+  hps: 1596.83682
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Orc-p2.masterfrost-RunicEmpowerment-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 165031.61931
-  tps: 152445.64374
-  hps: 1729.81147
+  dps: 164546.65539
+  tps: 152010.87425
+  hps: 1719.14526
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Orc-p2.masterfrost-RunicEmpowerment-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 216449.60763
-  tps: 168471.76925
-  hps: 1940.56337
+  dps: 217117.40455
+  tps: 169188.54543
+  hps: 1952.6511
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Orc-p2.masterfrost-RunicEmpowerment-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 505238.49685
-  tps: 497916.52602
-  hps: 1408.72093
+  dps: 507858.3604
+  tps: 500556.14073
+  hps: 1404.1923
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Orc-p2.masterfrost-RunicEmpowerment-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 125932.20312
-  tps: 118613.85805
-  hps: 1535.65843
+  dps: 125570.52245
+  tps: 118197.11771
+  hps: 1531.1298
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Orc-p2.masterfrost-RunicEmpowerment-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 145365.60444
-  tps: 120417.77371
-  hps: 1712.275
+  dps: 144610.83624
+  tps: 119610.92468
+  hps: 1621.02311
  }
 }
 dps_results: {
@@ -962,48 +962,48 @@ dps_results: {
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p2.masterfrost-RunicEmpowerment-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 692783.10839
-  tps: 680051.58535
-  hps: 1608.44783
+  dps: 683504.24494
+  tps: 670758.51774
+  hps: 1614.70424
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p2.masterfrost-RunicEmpowerment-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 164931.67217
-  tps: 152327.72366
-  hps: 1750.51759
+  dps: 164383.97658
+  tps: 151776.38109
+  hps: 1754.0761
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p2.masterfrost-RunicEmpowerment-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 218965.41703
-  tps: 170326.68082
+  dps: 219508.52846
+  tps: 170719.35539
   hps: 2013.75084
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p2.masterfrost-RunicEmpowerment-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 499067.52837
-  tps: 491896.64662
-  hps: 1410.94163
+  dps: 502257.82371
+  tps: 495097.131
+  hps: 1413.20587
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p2.masterfrost-RunicEmpowerment-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 125893.71931
-  tps: 118686.45088
-  hps: 1565.04614
+  dps: 125832.46435
+  tps: 118645.48549
+  hps: 1555.98916
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p2.masterfrost-RunicEmpowerment-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 144140.50807
-  tps: 119402.2264
+  dps: 144219.67553
+  tps: 119536.40641
   hps: 1666.2579
  }
 }
@@ -1202,49 +1202,49 @@ dps_results: {
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Worgen-p2.masterfrost-RunicEmpowerment-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 695881.81762
-  tps: 683619.95767
-  hps: 1604.61856
+  dps: 690467.12795
+  tps: 678252.81809
+  hps: 1607.03603
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Worgen-p2.masterfrost-RunicEmpowerment-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 164455.1504
-  tps: 152302.69158
-  hps: 1742.56895
+  dps: 163828.41894
+  tps: 151721.77068
+  hps: 1731.90308
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Worgen-p2.masterfrost-RunicEmpowerment-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 213704.35712
-  tps: 167437.74321
-  hps: 1953.31414
+  dps: 214462.25775
+  tps: 168255.42645
+  hps: 1965.40148
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Worgen-p2.masterfrost-RunicEmpowerment-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 503095.93763
-  tps: 496045.60428
-  hps: 1423.07798
+  dps: 505512.14518
+  tps: 498472.21641
+  hps: 1416.14939
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Worgen-p2.masterfrost-RunicEmpowerment-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 125351.08259
-  tps: 118300.90771
-  hps: 1552.41166
+  dps: 125120.40313
+  tps: 118021.13746
+  hps: 1547.88317
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Worgen-p2.masterfrost-RunicEmpowerment-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 143758.69442
-  tps: 119779.43432
-  hps: 1712.22207
+  dps: 143045.54822
+  tps: 119025.90477
+  hps: 1620.973
  }
 }
 dps_results: {

--- a/sim/death_knight/frost/TestFrostTwoHand.results
+++ b/sim/death_knight/frost/TestFrostTwoHand.results
@@ -721,48 +721,48 @@ dps_results: {
 dps_results: {
  key: "TestFrostTwoHand-Settings-Orc-p2.2h-obliterate-RunicEmpowerment-Basic-obliterate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 640623.13086
-  tps: 626494.5886
+  dps: 638137.30807
+  tps: 624005.50518
   hps: 2305.11004
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Orc-p2.2h-obliterate-RunicEmpowerment-Basic-obliterate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 164707.72954
-  tps: 150557.09726
-  hps: 2712.30043
+  dps: 165128.30633
+  tps: 150939.58462
+  hps: 2707.41606
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Orc-p2.2h-obliterate-RunicEmpowerment-Basic-obliterate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 224433.47166
-  tps: 170820.68545
-  hps: 2969.01315
+  dps: 224484.81681
+  tps: 170852.18694
+  hps: 2981.22407
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Orc-p2.2h-obliterate-RunicEmpowerment-Basic-obliterate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 469183.95181
-  tps: 461080.31167
-  hps: 1994.01548
+  dps: 472889.10319
+  tps: 464781.2286
+  hps: 2005.17465
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Orc-p2.2h-obliterate-RunicEmpowerment-Basic-obliterate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 129846.84767
-  tps: 121607.15651
-  hps: 2349.82833
+  dps: 129635.48913
+  tps: 121379.94513
+  hps: 2354.40176
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Orc-p2.2h-obliterate-RunicEmpowerment-Basic-obliterate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 149289.04995
-  tps: 121757.28599
+  dps: 148806.94718
+  tps: 121300.35587
   hps: 2465.07877
  }
 }
@@ -961,49 +961,49 @@ dps_results: {
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p2.2h-obliterate-RunicEmpowerment-Basic-obliterate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 636685.64702
-  tps: 622416.96911
-  hps: 2356.04811
+  dps: 631524.10623
+  tps: 617287.09523
+  hps: 2335.92514
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p2.2h-obliterate-RunicEmpowerment-Basic-obliterate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 166644.10108
-  tps: 152345.87532
-  hps: 2732.32811
+  dps: 165634.56725
+  tps: 151348.01542
+  hps: 2727.4439
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p2.2h-obliterate-RunicEmpowerment-Basic-obliterate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 226834.29207
-  tps: 171928.8964
-  hps: 3017.7617
+  dps: 225759.44353
+  tps: 170921.6888
+  hps: 2993.34062
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p2.2h-obliterate-RunicEmpowerment-Basic-obliterate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 470148.76852
-  tps: 462093.09313
-  hps: 2032.82741
+  dps: 470036.18996
+  tps: 461976.93273
+  hps: 2012.2476
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p2.2h-obliterate-RunicEmpowerment-Basic-obliterate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 129438.82408
-  tps: 121293.73851
-  hps: 2372.62285
+  dps: 128827.7726
+  tps: 120680.27607
+  hps: 2356.61634
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p2.2h-obliterate-RunicEmpowerment-Basic-obliterate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 146257.03981
-  tps: 118683.61295
-  hps: 2465.00331
+  dps: 146810.3106
+  tps: 119189.91843
+  hps: 2476.43653
  }
 }
 dps_results: {
@@ -1201,48 +1201,48 @@ dps_results: {
 dps_results: {
  key: "TestFrostTwoHand-Settings-Worgen-p2.2h-obliterate-RunicEmpowerment-Basic-obliterate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 639096.4704
-  tps: 625440.51625
+  dps: 636838.98882
+  tps: 623179.88862
   hps: 2325.1701
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Worgen-p2.2h-obliterate-RunicEmpowerment-Basic-obliterate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 164254.32253
-  tps: 150551.60008
-  hps: 2732.34765
+  dps: 164661.53597
+  tps: 150927.15492
+  hps: 2727.46344
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Worgen-p2.2h-obliterate-RunicEmpowerment-Basic-obliterate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 221647.0977
-  tps: 169820.84885
-  hps: 3030.75371
+  dps: 221939.11605
+  tps: 170099.18424
+  hps: 3042.96425
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Worgen-p2.2h-obliterate-RunicEmpowerment-Basic-obliterate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 467661.03462
-  tps: 459846.78825
-  hps: 2003.64981
+  dps: 471081.24424
+  tps: 463256.96595
+  hps: 2014.80864
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Worgen-p2.2h-obliterate-RunicEmpowerment-Basic-obliterate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 129632.11009
-  tps: 121674.02129
-  hps: 2366.72331
+  dps: 129332.84254
+  tps: 121369.17934
+  hps: 2371.2966
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Worgen-p2.2h-obliterate-RunicEmpowerment-Basic-obliterate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 147802.99903
-  tps: 121307.15439
+  dps: 147383.6992
+  tps: 120912.53363
   hps: 2465.00331
  }
 }

--- a/sim/death_knight/unholy/TestUnholy.results
+++ b/sim/death_knight/unholy/TestUnholy.results
@@ -769,49 +769,49 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-p2-RunicEmpowerment-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 222613.81783
-  tps: 167254.13913
-  hps: 1999.44617
+  dps: 222506.61348
+  tps: 166907.53014
+  hps: 2002.89453
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p2-RunicEmpowerment-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 151168.74736
-  tps: 108215.80476
-  hps: 1999.44617
+  dps: 151068.74444
+  tps: 108168.62197
+  hps: 2002.89453
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p2-RunicEmpowerment-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 237404.83322
-  tps: 123646.14797
-  hps: 2547.44317
+  dps: 237827.31904
+  tps: 123952.72455
+  hps: 2535.23225
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p2-RunicEmpowerment-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 161089.29688
-  tps: 125123.92722
-  hps: 1765.93853
+  dps: 160675.72512
+  tps: 124828.9536
+  hps: 1758.94118
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p2-RunicEmpowerment-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 109614.96919
-  tps: 82623.39192
-  hps: 1765.93853
+  dps: 109029.14232
+  tps: 82074.18909
+  hps: 1758.94118
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p2-RunicEmpowerment-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 142817.70123
-  tps: 85234.34121
-  hps: 1965.43154
+  dps: 142136.48072
+  tps: 84417.4969
+  hps: 1976.86512
  }
 }
 dps_results: {
@@ -1057,49 +1057,49 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Orc-prebis-RunicEmpowerment-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 166822.58947
-  tps: 123899.88353
-  hps: 1554.36704
+  dps: 167866.89997
+  tps: 124743.78896
+  hps: 1535.65707
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-prebis-RunicEmpowerment-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 114359.00534
-  tps: 81021.38338
-  hps: 1554.36704
+  dps: 113696.30672
+  tps: 80244.35311
+  hps: 1535.65707
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-prebis-RunicEmpowerment-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 182632.82895
-  tps: 93115.68216
+  dps: 182873.9265
+  tps: 93481.75514
   hps: 2003.35075
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-prebis-RunicEmpowerment-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 117720.28052
-  tps: 90557.4789
-  hps: 1350.49882
+  dps: 117764.42186
+  tps: 90636.54834
+  hps: 1352.37254
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-prebis-RunicEmpowerment-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 80087.03953
-  tps: 59775.63289
-  hps: 1350.49882
+  dps: 79761.92382
+  tps: 59503.42369
+  hps: 1352.37254
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-prebis-RunicEmpowerment-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 105866.67239
-  tps: 62202.18062
-  hps: 1504.59314
+  dps: 105132.9907
+  tps: 61599.6662
+  hps: 1476.48742
  }
 }
 dps_results: {
@@ -1345,49 +1345,49 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Troll-p2-RunicEmpowerment-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 222439.00341
-  tps: 166515.23353
-  hps: 2007.7156
+  dps: 222208.81834
+  tps: 166450.68134
+  hps: 2012.59981
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p2-RunicEmpowerment-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 151773.37042
-  tps: 108182.62412
-  hps: 2012.59981
+  dps: 151907.17636
+  tps: 108379.07807
+  hps: 2007.7156
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p2-RunicEmpowerment-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 239876.26014
-  tps: 122610.36899
-  hps: 2583.99447
+  dps: 239553.73411
+  tps: 122282.04459
+  hps: 2609.14819
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p2-RunicEmpowerment-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 159722.70594
-  tps: 123924.58019
-  hps: 1775.03105
+  dps: 160573.60028
+  tps: 124592.09375
+  hps: 1768.17111
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p2-RunicEmpowerment-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 108927.22131
-  tps: 81902.59095
+  dps: 109204.47106
+  tps: 82131.22618
   hps: 1781.89098
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p2-RunicEmpowerment-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 139780.47402
-  tps: 81458.52692
-  hps: 1964.68538
+  dps: 139887.73382
+  tps: 81442.70572
+  hps: 1999.67105
  }
 }
 dps_results: {
@@ -1633,49 +1633,49 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Troll-prebis-RunicEmpowerment-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 166910.21462
-  tps: 123532.98076
-  hps: 1548.46268
+  dps: 166462.24436
+  tps: 123362.20707
+  hps: 1565.18412
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-prebis-RunicEmpowerment-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 114317.04158
-  tps: 80580.0003
-  hps: 1565.18412
+  dps: 114236.73213
+  tps: 80360.90944
+  hps: 1564.01529
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-prebis-RunicEmpowerment-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 184180.35848
-  tps: 92467.08942
+  dps: 184259.66384
+  tps: 92524.14273
   hps: 2027.24611
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-prebis-RunicEmpowerment-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 116714.5695
-  tps: 89455.61985
-  hps: 1358.05537
+  dps: 115855.20827
+  tps: 88997.57633
+  hps: 1356.06931
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-prebis-RunicEmpowerment-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 79656.06264
-  tps: 59374.67932
-  hps: 1365.54995
+  dps: 79853.60014
+  tps: 59548.88518
+  hps: 1361.80266
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-prebis-RunicEmpowerment-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 105535.2735
-  tps: 61719.27824
-  hps: 1560.74628
+  dps: 105622.07777
+  tps: 61794.80533
+  hps: 1570.11451
  }
 }
 dps_results: {
@@ -1921,48 +1921,48 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Worgen-p2-RunicEmpowerment-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 223297.90907
-  tps: 168844.94613
-  hps: 2025.42576
+  dps: 221285.85959
+  tps: 166673.17535
+  hps: 2033.61171
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Worgen-p2-RunicEmpowerment-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 150055.60295
-  tps: 107882.28383
-  hps: 2017.80639
+  dps: 150725.86015
+  tps: 108568.99873
+  hps: 2021.40117
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Worgen-p2-RunicEmpowerment-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 233798.64288
-  tps: 122268.77326
-  hps: 2604.16629
+  dps: 234645.14347
+  tps: 123294.45545
+  hps: 2591.95575
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Worgen-p2-RunicEmpowerment-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 159518.22149
-  tps: 124044.64608
-  hps: 1771.14375
+  dps: 159440.31086
+  tps: 124307.95857
+  hps: 1768.85711
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Worgen-p2-RunicEmpowerment-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 108689.55099
-  tps: 82240.80347
-  hps: 1762.13437
+  dps: 108842.23095
+  tps: 82357.18696
+  hps: 1775.71704
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Worgen-p2-RunicEmpowerment-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 140914.54539
-  tps: 84734.77938
+  dps: 139921.25075
+  tps: 83692.6679
   hps: 1990.9818
  }
 }
@@ -2209,49 +2209,49 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Worgen-prebis-RunicEmpowerment-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 166697.79504
-  tps: 124578.29525
-  hps: 1548.00946
+  dps: 166107.86638
+  tps: 124146.57842
+  hps: 1543.09559
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Worgen-prebis-RunicEmpowerment-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 113015.7203
-  tps: 80245.13699
-  hps: 1554.09215
+  dps: 113041.67621
+  tps: 80586.90007
+  hps: 1551.16609
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Worgen-prebis-RunicEmpowerment-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 179975.09349
-  tps: 93069.87095
-  hps: 2017.90341
+  dps: 180153.47491
+  tps: 93225.39493
+  hps: 2007.96437
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Worgen-prebis-RunicEmpowerment-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 115892.49722
-  tps: 89369.08582
-  hps: 1331.93676
+  dps: 116205.21394
+  tps: 89466.93591
+  hps: 1337.55769
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Worgen-prebis-RunicEmpowerment-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 79423.51022
-  tps: 59499.31125
-  hps: 1339.43134
+  dps: 79738.29132
+  tps: 60002.01264
+  hps: 1343.29105
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Worgen-prebis-RunicEmpowerment-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 104346.79209
-  tps: 61544.47686
-  hps: 1495.16871
+  dps: 103546.04128
+  tps: 60930.30866
+  hps: 1485.80048
  }
 }
 dps_results: {


### PR DESCRIPTION
It was random, then it was changed after some testing in Blight Club, now it's being reverted to random again because apparently that first testing was fake news and new testing shows random behavior (again).

The DK rune system is wonderful!