### PR TITLE
ExpectedTickDamage support for Flame Shock

### DIFF
--- a/sim/shaman/shocks.go
+++ b/sim/shaman/shocks.go
@@ -69,7 +69,7 @@ func (shaman *Shaman) registerFlameShockSpell(shockTimer *core.Timer) {
 		ActionID:         core.ActionID{SpellID: 8050, Tag: 1},
 		SpellSchool:      core.SpellSchoolFire,
 		ProcMask:         core.ProcMaskSpellDamage,
-		Flags:            core.SpellFlagPassiveSpell,
+		Flags:            config.Flags & ^core.SpellFlagAPL | core.SpellFlagPassiveSpell,
 		ClassSpellMask:   SpellMaskFlameShockDot,
 		DamageMultiplier: 1,
 		CritMultiplier:   shaman.DefaultCritMultiplier(),


### PR DESCRIPTION
Allows APL comparison of Flame Shock damage

This is a DPS increase for all shaman specs with APL optimization.