### PR TITLE
Added Toast warning when importing from a non up-to-date addon version

### DIFF
--- a/ui/core/components/individual_sim_ui/importers/individual_addon_importer.tsx
+++ b/ui/core/components/individual_sim_ui/importers/individual_addon_importer.tsx
@@ -147,9 +147,6 @@ function getWSEVersion(): Promise<string|null> {
 			return resp.json().then(json => {
 				return json.tag_name as string;
 			})
-			.catch(_ => {
-				return null;
-			})
 		})
 		.catch(_ => {
 			return null;


### PR DESCRIPTION
<img width="379" height="119" alt="image" src="https://github.com/user-attachments/assets/dc29e315-63d6-489e-9763-2e7b2f09d413" />
