### PR TITLE
Ignore tricks of the trade when calculating DK disease snapshot

### DIFF
--- a/sim/core/aura.go
+++ b/sim/core/aura.go
@@ -436,14 +436,6 @@ func (at *auraTracker) GetAuraByID(actionID ActionID) *Aura {
 	}
 	return nil
 }
-func (at *auraTracker) GetAuraByIDIgnoreTag(actionID ActionID) *Aura {
-	for _, aura := range at.auras {
-		if aura.ActionID.SameActionIgnoreTag(actionID) {
-			return aura
-		}
-	}
-	return nil
-}
 func (at *auraTracker) GetIcdAuraByID(actionID ActionID) *Aura {
 	for _, aura := range at.auras {
 		if (aura.ActionID.SameAction(actionID) || aura.ActionIDForProc.SameAction(actionID)) && aura.Icd != nil {

--- a/sim/death_knight/diseases.go
+++ b/sim/death_knight/diseases.go
@@ -38,8 +38,8 @@ func (dk *DeathKnight) getFrostFeverConfig(character *core.Character) core.Spell
 			OnSnapshot: func(sim *core.Simulation, target *core.Unit, dot *core.Dot, isRollover bool) {
 				baseTickDamage := dk.CalcScalingSpellDmg(0.13300000131) + dot.Spell.MeleeAttackPower()*0.15800000727
 				dot.SnapshotPhysical(target, baseTickDamage)
-				tricksAura := dk.GetAuraByIDIgnoreTag(core.ActionID{SpellID: 57933})
-				if tricksAura != nil && tricksAura.IsActive() {
+				//Tricks of the Trade does not snapshot on diseases
+				if dk.HasActiveAuraWithTag(core.TricksOfTheTradeAuraTag) {
 					dot.SnapshotAttackerMultiplier /= 1.15
 				}
 			},
@@ -90,8 +90,8 @@ func (dk *DeathKnight) getBloodPlagueConfig(character *core.Character) core.Spel
 			OnSnapshot: func(sim *core.Simulation, target *core.Unit, dot *core.Dot, isRollover bool) {
 				baseTickDamage := dk.CalcScalingSpellDmg(0.15800000727) + dot.Spell.MeleeAttackPower()*0.15800000727
 				dot.SnapshotPhysical(target, baseTickDamage)
-				tricksAura := dk.GetAuraByIDIgnoreTag(core.ActionID{SpellID: 57933})
-				if tricksAura != nil && tricksAura.IsActive() {
+				//Tricks of the Trade does not snapshot on diseases
+				if dk.HasActiveAuraWithTag(core.TricksOfTheTradeAuraTag) {
 					dot.SnapshotAttackerMultiplier /= 1.15
 				}
 			},


### PR DESCRIPTION
Tricks of the Trade does not apply to Death Knight diseases.