### PR TITLE
Deduct shard for each Haunt in-flight

### DIFF
--- a/sim/warlock/affliction/affliction.go
+++ b/sim/warlock/affliction/affliction.go
@@ -112,10 +112,10 @@ func (affliction *AfflictionWarlock) OnEncounterStart(sim *core.Simulation) {
 	if affliction.SoulBurnAura.IsActive() {
 		defaultShards -= 1
 	}
-	//Haunt in-flight
-	if affliction.SpellInFlightByID(HauntSpellID) {
-		defaultShards -= 1
-	}
+
+	haunt := affliction.GetSpell(core.ActionID{SpellID: HauntSpellID})
+	count := affliction.SpellsInFlight[haunt]
+	defaultShards -= count
 
 	affliction.SoulShards.ResetBarTo(sim, defaultShards)
 	affliction.Warlock.OnEncounterStart(sim)


### PR DESCRIPTION
Updating affliction pre-pull behaviour per Blizzard response on Bug Tracker repo.

See: https://github.com/ClassicWoWCommunity/mop-classic-bugs/issues/2474