### PR TITLE
Total Damage moved above damage list

### DIFF
--- a/ui/core/components/detailed_results/timeline.tsx
+++ b/ui/core/components/detailed_results/timeline.tsx
@@ -926,6 +926,11 @@ export class Timeline extends ResultComponent {
 						{castLog.castTime > 0 && `${castLog.castTime.toFixed(2)}s, `} {castLog.effectiveTime.toFixed(2)}s GCD Time)
 						{travelTimeStr.length > 0 && travelTimeStr}
 					</span>
+					{totalDamage > 0 && (
+						<span>
+							Total: {totalDamage.toFixed(2)} ({(totalDamage / (castLog.effectiveTime || 1)).toFixed(2)} DPET)
+						</span>
+					)}
 					{castLog.damageDealtLogs.length > 0 && (
 						<ul className="rotation-timeline-cast-damage-list">
 							{castLog.damageDealtLogs.map(ddl => (
@@ -934,14 +939,9 @@ export class Timeline extends ResultComponent {
 										{ddl.timestamp.toFixed(2)}s - {ddl.result()}
 									</span>
 																{ddl.source?.isTarget && <span className="threat-metrics"> ({ddl.threat.toFixed(1)} {i18n.t('results_tab.details.timeline.tooltips.threat')})</span>}
-						</li>
-					))}
-				</ul>
-					)}
-					{totalDamage > 0 && (
-						<span>
-							Total: {totalDamage.toFixed(2)} ({(totalDamage / (castLog.effectiveTime || 1)).toFixed(2)} DPET)
-						</span>
+								</li>
+							))}
+						</ul>
 					)}
 				</div>
 			);


### PR DESCRIPTION
When there are a lot of damage dealt items the total damage is no longer visible.

Merging this until we can come up with a better way to display the items that won't go off page.

Before:
<img width="377" height="250" alt="image" src="https://github.com/user-attachments/assets/a71d9d29-d3c0-47ca-a512-2030bc01f31f" />


After:
<img width="368" height="217" alt="image" src="https://github.com/user-attachments/assets/e37e49c5-bf5f-4386-bb13-c7cf7bfa4f15" />

