### PR TITLE
Fixed a bug where RoRo Reforges were sometimes being applied without the trinket equipped

### DIFF
--- a/ui/core/components/suggest_reforges_action.tsx
+++ b/ui/core/components/suggest_reforges_action.tsx
@@ -373,6 +373,10 @@ export class ReforgeOptimizer {
 				this.setUseSoftCapBreakpoints(eventID, false);
 			}
 		});
+
+		this.player.gearChangeEmitter.on(eventID => {
+			this.setRelativeStatCap(eventID, this.relativeStatCapStat);
+		});
 	}
 
 	private bindToggleExperimental(element: Element) {
@@ -595,7 +599,7 @@ export class ReforgeOptimizer {
 	}
 	setRelativeStatCap(eventID: EventID, newValue: number) {
 		this.relativeStatCapStat = newValue;
-		if (this.relativeStatCapStat === -1) {
+		if ((this.relativeStatCapStat === -1) || !RelativeStatCap.hasRoRo(this.player)) {
 			this.relativeStatCap = null;
 		} else {
 			this.relativeStatCap = new RelativeStatCap(this.relativeStatCapStat, this.player, this.playerClass);


### PR DESCRIPTION
On branch auto-reforge
 Changes to be committed:
	modified:   ui/core/components/suggest_reforges_action.tsx