### PR TITLE
Fix Combo Points to reset when swapping targets.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -328,6 +328,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -351,6 +352,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -1509,6 +1511,7 @@
 			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
 			"integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/popperjs"
@@ -2013,6 +2016,7 @@
 			"resolved": "https://registry.npmjs.org/@svgdotjs/svg.js/-/svg.js-3.2.5.tgz",
 			"integrity": "sha512-/VNHWYhNu+BS7ktbYoVGrCmsXDh+chFMaONMwGNdIBcFHrWqk2jY8fNyr3DLdtQUIalvkPfM554ZSFa3dm3nxQ==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/Fuzzyma"
@@ -2036,6 +2040,7 @@
 			"resolved": "https://registry.npmjs.org/@svgdotjs/svg.select.js/-/svg.select.js-4.0.3.tgz",
 			"integrity": "sha512-qkMgso1sd2hXKd1FZ1weO7ANq12sNmQJeGDjs46QwDVsxSRcHmvWKL2NDF7Yimpwf3sl5esOLkPqtV2bQ3v/Jg==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 14.18"
 			},
@@ -2059,6 +2064,7 @@
 			"integrity": "sha512-03ruubjWyOHlmljCVoxSuNDdmfZDzsrrz0P2LeJsOXr+ZwFQ+0yQIwNCwt/GYhV7Z31fgtXJTAEs+FYlEL851g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/estree": "*",
 				"@types/json-schema": "*"
@@ -2111,6 +2117,7 @@
 			"integrity": "sha512-pAZSHMiagDR7cARo/cch1f3rXy0AEXwsVsVH09FcyeJVAzCnGgmYis7P3JidtTUjyadhTeSo8TgRPswstghDaw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~6.21.0"
 			}
@@ -2141,6 +2148,7 @@
 			"integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.4.0",
 				"@typescript-eslint/scope-manager": "5.62.0",
@@ -2176,6 +2184,7 @@
 			"integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
 			"dev": true,
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "5.62.0",
 				"@typescript-eslint/types": "5.62.0",
@@ -2350,6 +2359,7 @@
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -3701,6 +3711,7 @@
 			"deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
@@ -3757,6 +3768,7 @@
 			"integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
 			},
@@ -5689,6 +5701,7 @@
 			"integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"marked": "bin/marked.js"
 			},
@@ -6369,6 +6382,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -6466,6 +6480,7 @@
 			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -6497,6 +6512,7 @@
 			"integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -6893,6 +6909,7 @@
 			"integrity": "sha512-t+YPtOQHpGW1QWsh1CHQ5cPIr9lbbGZLZnbihP/D/qZj/yuV68m8qarcV17nvkOX81BCrvzAlq2klCQFZghyTg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"chokidar": "^4.0.0",
 				"immutable": "^5.0.2",
@@ -7377,6 +7394,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@csstools/css-parser-algorithms": "^3.0.5",
 				"@csstools/css-tokenizer": "^3.0.4",
@@ -7703,6 +7721,7 @@
 			"integrity": "sha512-nIVck8DK+GM/0Frwd+nIhZ84pR/BX7rmXMfYwyg+Sri5oGVE99/E3KvXqpC2xHFxyqXyGHTKBSioxxplrO4I4w==",
 			"dev": true,
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.3",
 				"acorn": "^8.15.0",
@@ -7794,6 +7813,7 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -7994,6 +8014,7 @@
 			"integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
 			"devOptional": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -8123,6 +8144,7 @@
 			"integrity": "sha512-4nVGliEpxmhCL8DslSAUdxlB6+SMrhB0a1v5ijlh1xB1nEPuy1mxaHxysVucLHuWryAxLWg6a5ei+U4TLn/rFg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"fdir": "^6.5.0",
@@ -8397,6 +8419,7 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},

--- a/sim/core/racials.go
+++ b/sim/core/racials.go
@@ -52,7 +52,7 @@ func applyRaceEffects(agent Agent) {
 				if spell.Unit.HasRunicPowerBar() {
 					spell.Unit.AddRunicPower(sim, 15.0, resourceMetrics)
 				} else if character.Class == proto.Class_ClassMonk {
-					spell.Unit.AddComboPoints(sim, 1, resourceMetrics)
+					spell.Unit.AddComboPoints(sim, 1, nil, resourceMetrics)
 				} else if spell.Unit.HasEnergyBar() {
 					spell.Unit.AddEnergy(sim, 15.0, resourceMetrics)
 				} else if spell.Unit.HasManaBar() {

--- a/sim/druid/feral/items.go
+++ b/sim/druid/feral/items.go
@@ -86,7 +86,7 @@ func (cat *FeralDruid) registerFeralRage() {
 			}
 
 			if spell.Matches(druid.DruidSpellSavageRoar) || resultLanded {
-				aura.Unit.AddComboPoints(sim, 3, cpMetrics)
+				aura.Unit.AddComboPoints(sim, 3, aura.Unit.CurrentComboTarget, cpMetrics)
 				resultLanded = false
 				aura.Deactivate(sim)
 			}

--- a/sim/druid/feral/shred.go
+++ b/sim/druid/feral/shred.go
@@ -53,7 +53,7 @@ func (cat *FeralDruid) registerShredSpell() {
 			result := spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeWeaponSpecialHitAndCrit)
 
 			if result.Landed() {
-				cat.AddComboPoints(sim, 1, spell.ComboPointMetrics())
+				cat.AddComboPoints(sim, 1, target, spell.ComboPointMetrics())
 				cat.ApplyBloodletting(target)
 			} else {
 				spell.IssueRefund(sim)

--- a/sim/druid/items.go
+++ b/sim/druid/items.go
@@ -166,7 +166,7 @@ var ItemSetBattlegearOfTheHauntedForest = core.NewItemSet(core.ItemSet{
 				procChance := 0.15 * float64(cpSnapshot)
 
 				if sim.Proc(procChance, "2pT15") && (resultLanded || isRoar) {
-					unit.AddComboPoints(sim, 1, cpMetrics)
+					unit.AddComboPoints(sim, 1, unit.CurrentComboTarget, cpMetrics)
 				}
 
 				cpSnapshot = 0

--- a/sim/druid/mangle.go
+++ b/sim/druid/mangle.go
@@ -88,7 +88,7 @@ func (druid *Druid) registerMangleCatSpell() {
 			result := spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeWeaponSpecialHitAndCrit)
 
 			if result.Landed() {
-				druid.AddComboPoints(sim, 1, spell.ComboPointMetrics())
+				druid.AddComboPoints(sim, 1, target, spell.ComboPointMetrics())
 				druid.ApplyBloodletting(target)
 			} else {
 				spell.IssueRefund(sim)

--- a/sim/druid/rake.go
+++ b/sim/druid/rake.go
@@ -61,10 +61,7 @@ func (druid *Druid) registerRakeSpell() {
 			result := spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeSpecialHitAndCrit)
 
 			if result.Landed() {
-				if target == spell.Unit.CurrentTarget {
-					druid.AddComboPoints(sim, 1, spell.ComboPointMetrics())
-				}
-
+				druid.AddComboPoints(sim, 1, target, spell.ComboPointMetrics())
 				spell.Dot(target).Apply(sim)
 			} else {
 				spell.IssueRefund(sim)

--- a/sim/druid/ravage.go
+++ b/sim/druid/ravage.go
@@ -49,7 +49,7 @@ func (druid *Druid) registerRavageSpell() {
 			result := spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeWeaponSpecialHitAndCrit)
 
 			if result.Landed() {
-				druid.AddComboPoints(sim, 1, spell.ComboPointMetrics())
+				druid.AddComboPoints(sim, 1, target, spell.ComboPointMetrics())
 			} else {
 				spell.IssueRefund(sim)
 			}

--- a/sim/druid/shared_feral_passives.go
+++ b/sim/druid/shared_feral_passives.go
@@ -54,8 +54,8 @@ func (druid *Druid) ApplyPrimalFury() {
 					druid.AddRage(sim, mangleRageGen, rageMetrics)
 				}
 			} else if druid.InForm(Cat) {
-				if spell.Matches(DruidSpellBuilder) && (result.Target == druid.CurrentTarget) {
-					druid.AddComboPoints(sim, 1, cpMetrics)
+				if spell.Matches(DruidSpellBuilder) {
+					druid.AddComboPoints(sim, 1, result.Target, cpMetrics)
 				}
 			}
 		},

--- a/sim/druid/swipe.go
+++ b/sim/druid/swipe.go
@@ -80,8 +80,8 @@ func (druid *Druid) registerSwipeCatSpell() {
 
 				result := spell.CalcAndDealDamage(sim, aoeTarget, baseDamage, spell.OutcomeMeleeWeaponSpecialHitAndCrit)
 
-				if result.Landed() && (aoeTarget == druid.CurrentTarget) {
-					druid.AddComboPoints(sim, 1, spell.ComboPointMetrics())
+				if result.Landed() && (aoeTarget == druid.CurrentComboTarget) {
+					druid.AddComboPoints(sim, 1, aoeTarget, spell.ComboPointMetrics())
 				}
 			}
 		},

--- a/sim/monk/monk.go
+++ b/sim/monk/monk.go
@@ -115,7 +115,7 @@ func (monk *Monk) RegisterOnStanceChanged(onStanceChanged OnStanceChanged) {
 }
 
 func (monk *Monk) AddChi(sim *core.Simulation, spell *core.Spell, pointsToAdd int32, metrics *core.ResourceMetrics) {
-	monk.AddComboPoints(sim, pointsToAdd, metrics)
+	monk.AddComboPoints(sim, pointsToAdd, &monk.Unit, metrics)
 
 	if spell != nil && spell.Flags.Matches(SpellFlagBuilder) {
 		// TODO: Verify that RJW can trigger Power Strikes

--- a/sim/rogue/ambush.go
+++ b/sim/rogue/ambush.go
@@ -49,7 +49,7 @@ func (rogue *Rogue) registerAmbushSpell() {
 			result := spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeSpecialNoBlockDodgeParry)
 
 			if result.Landed() {
-				rogue.AddComboPointsOrAnticipation(sim, 2, spell.ComboPointMetrics())
+				rogue.AddComboPointsOrAnticipation(sim, 2, target, spell.ComboPointMetrics())
 			} else {
 				spell.IssueRefund(sim)
 			}

--- a/sim/rogue/assassination/dispatch.go
+++ b/sim/rogue/assassination/dispatch.go
@@ -42,7 +42,7 @@ func (sinRogue *AssassinationRogue) registerDispatch() {
 			damage := addedDamage + spell.Unit.MHNormalizedWeaponDamage(sim, spell.MeleeAttackPower())
 			outcome := spell.CalcAndDealDamage(sim, target, damage, spell.OutcomeMeleeSpecialHitAndCrit)
 			if outcome.Landed() {
-				sinRogue.AddComboPointsOrAnticipation(sim, 1, spell.ComboPointMetrics())
+				sinRogue.AddComboPointsOrAnticipation(sim, 1, target, spell.ComboPointMetrics())
 			} else {
 				spell.IssueRefund(sim)
 			}

--- a/sim/rogue/assassination/mutilate.go
+++ b/sim/rogue/assassination/mutilate.go
@@ -76,7 +76,7 @@ func (sinRogue *AssassinationRogue) registerMutilateSpell() {
 			sinRogue.BreakStealth(sim)
 			result := spell.CalcOutcome(sim, target, spell.OutcomeMeleeSpecialHit)
 			if result.Landed() {
-				sinRogue.AddComboPointsOrAnticipation(sim, 2, spell.ComboPointMetrics())
+				sinRogue.AddComboPointsOrAnticipation(sim, 2, target, spell.ComboPointMetrics())
 				sinRogue.MutilateOH.Cast(sim, target)
 				sinRogue.MutilateMH.Cast(sim, target)
 			} else {

--- a/sim/rogue/assassination/sealfate.go
+++ b/sim/rogue/assassination/sealfate.go
@@ -27,7 +27,7 @@ func (sinRogue *AssassinationRogue) applySealFate() {
 			}
 
 			if icd.IsReady(sim) {
-				sinRogue.AddComboPointsOrAnticipation(sim, 1, cpMetrics)
+				sinRogue.AddComboPointsOrAnticipation(sim, 1, result.Target, cpMetrics)
 				icd.Use(sim)
 
 				if sinRogue.T16EnergyAura != nil {

--- a/sim/rogue/combat/revealing_strike.go
+++ b/sim/rogue/combat/revealing_strike.go
@@ -44,7 +44,7 @@ func (comRogue *CombatRogue) registerRevealingStrike() {
 			OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if result.Landed() && spell.ClassSpellMask == rogue.RogueSpellSinisterStrike {
 					if sim.Proc(0.2, "Revealing Strike Extra Combo Point") {
-						comRogue.AddComboPointsOrAnticipation(sim, 1, cpMetric)
+						comRogue.AddComboPointsOrAnticipation(sim, 1, aura.Unit, cpMetric)
 
 						if comRogue.T16EnergyAura != nil {
 							comRogue.T16EnergyAura.Activate(sim)
@@ -88,7 +88,7 @@ func (comRogue *CombatRogue) registerRevealingStrike() {
 
 			result := spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeWeaponSpecialHitAndCrit)
 			if result.Landed() {
-				comRogue.AddComboPointsOrAnticipation(sim, 1, spell.ComboPointMetrics())
+				comRogue.AddComboPointsOrAnticipation(sim, 1, target, spell.ComboPointMetrics())
 				aura := rvsAura.Get(target)
 				if aura.IsActive() {
 					aura.Duration = aura.RemainingDuration(sim)%clipInterval + baseDuration

--- a/sim/rogue/combat/sinister_strike.go
+++ b/sim/rogue/combat/sinister_strike.go
@@ -45,7 +45,7 @@ func (comRogue *CombatRogue) registerSinisterStrikeSpell() {
 			result := spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeWeaponSpecialHitAndCrit)
 
 			if result.Landed() {
-				comRogue.AddComboPointsOrAnticipation(sim, 1, spell.ComboPointMetrics())
+				comRogue.AddComboPointsOrAnticipation(sim, 1, target, spell.ComboPointMetrics())
 			} else {
 				spell.IssueRefund(sim)
 			}

--- a/sim/rogue/expose_armor.go
+++ b/sim/rogue/expose_armor.go
@@ -49,7 +49,7 @@ func (rogue *Rogue) registerExposeArmorSpell() {
 					debuffAura.AddStack(sim)
 				}
 
-				rogue.AddComboPointsOrAnticipation(sim, 1, cpMetric)
+				rogue.AddComboPointsOrAnticipation(sim, 1, target, cpMetric)
 			} else {
 				spell.IssueRefund(sim)
 			}

--- a/sim/rogue/fan_of_knives.go
+++ b/sim/rogue/fan_of_knives.go
@@ -54,8 +54,8 @@ func (rogue *Rogue) registerFanOfKnives() {
 				damage *= sim.Encounter.AOECapMultiplier()
 
 				result := fokSpell.CalcAndDealDamage(sim, aoeTarget, damage, fokSpell.OutcomeMeleeSpecialNoBlockDodgeParry)
-				if result.Landed() && aoeTarget == rogue.CurrentTarget {
-					rogue.AddComboPointsOrAnticipation(sim, 1, cpMetrics)
+				if result.Landed() && aoeTarget == rogue.CurrentComboTarget {
+					rogue.AddComboPointsOrAnticipation(sim, 1, aoeTarget, cpMetrics)
 
 					if hasGlyph {
 						sunder := rogue.ExposeArmorAuras.Get(aoeTarget)

--- a/sim/rogue/garrote.go
+++ b/sim/rogue/garrote.go
@@ -55,7 +55,7 @@ func (rogue *Rogue) registerGarrote() {
 			rogue.BreakStealth(sim)
 			result := spell.CalcOutcome(sim, target, spell.OutcomeMeleeSpecialNoBlockDodgeParryNoCrit)
 			if result.Landed() {
-				rogue.AddComboPointsOrAnticipation(sim, 1, spell.ComboPointMetrics())
+				rogue.AddComboPointsOrAnticipation(sim, 1, target, spell.ComboPointMetrics())
 				spell.Dot(target).Apply(sim)
 			} else {
 				spell.IssueRefund(sim)

--- a/sim/rogue/items_mop.go
+++ b/sim/rogue/items_mop.go
@@ -282,11 +282,11 @@ var FangsOfTheFather = core.NewItemSet(core.ItemSet{
 				ActionID: core.ActionID{SpellID: 109949},
 				Duration: time.Second * 6,
 				OnGain: func(aura *core.Aura, sim *core.Simulation) {
-					aura.Unit.AddComboPoints(sim, 5, cpMetrics)
+					aura.Unit.AddComboPoints(sim, 5, aura.Unit.CurrentComboTarget, cpMetrics)
 				},
 				OnCastComplete: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell) {
 					if spell.Flags.Matches(SpellFlagFinisher) {
-						aura.Unit.AddComboPoints(sim, 5, cpMetrics)
+						aura.Unit.AddComboPoints(sim, 5, aura.Unit.CurrentComboTarget, cpMetrics)
 					}
 				},
 				OnExpire: func(aura *core.Aura, sim *core.Simulation) {

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -122,22 +122,22 @@ func (rogue *Rogue) GetRogue() *Rogue {
 func (rogue *Rogue) AddRaidBuffs(_ *proto.RaidBuffs)   {}
 func (rogue *Rogue) AddPartyBuffs(_ *proto.PartyBuffs) {}
 
-func (rogue *Rogue) AddComboPointsOrAnticipation(sim *core.Simulation, numPoints int32, metric *core.ResourceMetrics) {
+func (rogue *Rogue) AddComboPointsOrAnticipation(sim *core.Simulation, numPoints int32, target *core.Unit, metric *core.ResourceMetrics) {
 	if rogue.Talents.Anticipation && rogue.ComboPoints()+numPoints > 5 {
 		realPoints := 5 - rogue.ComboPoints()
 		antiPoints := rogue.AnticipationAura.GetStacks() + numPoints - realPoints
 
-		rogue.AddComboPoints(sim, realPoints, metric)
+		rogue.AddComboPoints(sim, realPoints, target, metric)
 
 		rogue.AnticipationAura.Activate(sim)
 		rogue.AnticipationAura.Refresh(sim)
 		rogue.AnticipationAura.SetStacks(sim, antiPoints)
 		if antiPoints > 5 {
 			// run AddComboPoints again to report the overcapping into UI
-			rogue.AddComboPoints(sim, antiPoints-5, metric)
+			rogue.AddComboPoints(sim, antiPoints-5, target, metric)
 		}
 	} else {
-		rogue.AddComboPoints(sim, numPoints, metric)
+		rogue.AddComboPoints(sim, numPoints, target, metric)
 	}
 }
 
@@ -149,7 +149,7 @@ func (rogue *Rogue) ApplyFinisher(sim *core.Simulation, spell *core.Spell) {
 	if rogue.Spec == proto.Spec_SpecCombatRogue {
 		// Ruthlessness
 		if sim.Proc(0.2*float64(numPoints), "Ruthlessness") {
-			rogue.AddComboPoints(sim, 1, rogue.ruthlessnessMetrics)
+			rogue.AddComboPoints(sim, 1, rogue.CurrentComboTarget, rogue.ruthlessnessMetrics)
 		}
 
 		// Restless Blades

--- a/sim/rogue/shadow_blades.go
+++ b/sim/rogue/shadow_blades.go
@@ -39,7 +39,7 @@ func (rogue *Rogue) registerShadowBladesCD() {
 
 		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if result.Landed() && spell.Flags.Matches(SpellFlagBuilder) {
-				rogue.AddComboPointsOrAnticipation(sim, 1, cpMetrics)
+				rogue.AddComboPointsOrAnticipation(sim, 1, result.Target, cpMetrics)
 			}
 		},
 	})

--- a/sim/rogue/subtlety/backstab.go
+++ b/sim/rogue/subtlety/backstab.go
@@ -48,7 +48,7 @@ func (subRogue *SubtletyRogue) registerBackstabSpell() {
 			result := spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeWeaponSpecialHitAndCrit)
 
 			if result.Landed() {
-				subRogue.AddComboPointsOrAnticipation(sim, 1, spell.ComboPointMetrics())
+				subRogue.AddComboPointsOrAnticipation(sim, 1, target, spell.ComboPointMetrics())
 			} else {
 				spell.IssueRefund(sim)
 			}

--- a/sim/rogue/subtlety/hemorrhage.go
+++ b/sim/rogue/subtlety/hemorrhage.go
@@ -83,7 +83,7 @@ func (subRogue *SubtletyRogue) registerHemorrhageSpell() {
 			result := spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeWeaponSpecialHitAndCrit)
 
 			if result.Landed() {
-				subRogue.AddComboPointsOrAnticipation(sim, 1, spell.ComboPointMetrics())
+				subRogue.AddComboPointsOrAnticipation(sim, 1, target, spell.ComboPointMetrics())
 				lastHemoDamage = result.Damage
 
 				if hasMinorGlyph { // Prevents triggering the DoT unless Garrote/Rupture/Crimson Tempest are active

--- a/sim/rogue/subtlety/honor_among_thieves.go
+++ b/sim/rogue/subtlety/honor_among_thieves.go
@@ -23,7 +23,7 @@ func (subRogue *SubtletyRogue) registerHonorAmongThieves() {
 
 	maybeProc := func(sim *core.Simulation) {
 		if icd.IsReady(sim) && sim.Proc(procChance, "Honor Among Thieves") {
-			subRogue.AddComboPointsOrAnticipation(sim, 1, comboMetrics)
+			subRogue.AddComboPointsOrAnticipation(sim, 1, subRogue.CurrentComboTarget, comboMetrics)
 
 			if subRogue.T16EnergyAura != nil {
 				subRogue.T16EnergyAura.Activate(sim)

--- a/sim/rogue/subtlety/premeditation.go
+++ b/sim/rogue/subtlety/premeditation.go
@@ -31,7 +31,7 @@ func (subRogue *SubtletyRogue) registerPremeditation() {
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
 			// Remove 2 points because no finisher was casted
 			if shouldTimeout {
-				subRogue.AddComboPoints(sim, -2, comboMetrics)
+				subRogue.AddComboPoints(sim, -2, subRogue.CurrentComboTarget, comboMetrics)
 				shouldTimeout = false
 			}
 		},
@@ -70,7 +70,7 @@ func (subRogue *SubtletyRogue) registerPremeditation() {
 		},
 
 		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, spell *core.Spell) {
-			subRogue.AddComboPointsOrAnticipation(sim, 2, comboMetrics)
+			subRogue.AddComboPointsOrAnticipation(sim, 2, subRogue.CurrentComboTarget, comboMetrics)
 			premedAura.Activate(sim)
 		},
 	})

--- a/sim/rogue/talents.go
+++ b/sim/rogue/talents.go
@@ -62,7 +62,7 @@ func (rogue *Rogue) ApplyTalents() {
 				},
 			},
 			ApplyEffects: func(sim *core.Simulation, unit *core.Unit, spell *core.Spell) {
-				rogue.AddComboPoints(sim, 5, mfdMetrics)
+				rogue.AddComboPoints(sim, 5, rogue.CurrentComboTarget, mfdMetrics)
 			},
 		})
 
@@ -89,7 +89,7 @@ func (rogue *Rogue) ApplyTalents() {
 
 			OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if result.Landed() && spell.Flags.Matches(SpellFlagFinisher) {
-					rogue.AddComboPoints(sim, aura.GetStacks(), antiMetrics)
+					rogue.AddComboPoints(sim, aura.GetStacks(), rogue.CurrentComboTarget, antiMetrics)
 					aura.SetStacks(sim, 0)
 					aura.Deactivate(sim)
 				}


### PR DESCRIPTION
 On branch fix/combo-point-targets
 Changes to be committed:
	modified:   package-lock.json
	modified:   sim/core/energy.go
	modified:   sim/core/racials.go
	modified:   sim/druid/feral/items.go
	modified:   sim/druid/feral/shred.go
	modified:   sim/druid/items.go
	modified:   sim/druid/mangle.go
	modified:   sim/druid/rake.go
	modified:   sim/druid/ravage.go
	modified:   sim/druid/shared_feral_passives.go
	modified:   sim/druid/swipe.go
	modified:   sim/monk/monk.go
	modified:   sim/rogue/ambush.go
	modified:   sim/rogue/assassination/dispatch.go
	modified:   sim/rogue/assassination/mutilate.go
	modified:   sim/rogue/assassination/sealfate.go
	modified:   sim/rogue/combat/revealing_strike.go
	modified:   sim/rogue/combat/sinister_strike.go
	modified:   sim/rogue/expose_armor.go
	modified:   sim/rogue/fan_of_knives.go
	modified:   sim/rogue/garrote.go
	modified:   sim/rogue/items_mop.go
	modified:   sim/rogue/rogue.go
	modified:   sim/rogue/shadow_blades.go
	modified:   sim/rogue/subtlety/backstab.go
	modified:   sim/rogue/subtlety/hemorrhage.go
	modified:   sim/rogue/subtlety/honor_among_thieves.go
	modified:   sim/rogue/subtlety/premeditation.go
	modified:   sim/rogue/talents.go