### PR TITLE
[Hunter] Capacitive Primal Diamond Hunter fixes

### DIFF
--- a/sim/common/mop/metagems.go
+++ b/sim/common/mop/metagems.go
@@ -33,12 +33,18 @@ func init() {
 		character := agent.GetCharacter()
 		var target *core.Unit
 
+		isHunter := character.Class == proto.Class_ClassHunter
+		flags := core.SpellFlagNoOnCastComplete
+		if isHunter {
+			flags |= core.SpellFlagRanged
+		}
+
 		lightningStrike := character.RegisterSpell(core.SpellConfig{
-			ActionID:    core.ActionID{SpellID: 137597},
+			ActionID:    core.ActionID{SpellID: core.TernaryInt32(isHunter, 141004, 137597)},
 			SpellSchool: core.SpellSchoolNature,
 			// @TODO: TEST ON PTR: See if weapon enchants can/cannot be procced by this spell.
-			ProcMask: core.ProcMaskMeleeProc,
-			Flags:    core.SpellFlagNoOnCastComplete | core.SpellFlagRanged,
+			ProcMask: core.Ternary(isHunter, core.ProcMaskRangedProc, core.ProcMaskMeleeProc),
+			Flags:    flags,
 
 			MaxRange: 45,
 
@@ -48,9 +54,9 @@ func init() {
 
 			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 				baseDamage := sim.Roll(core.CalcScalingSpellEffectVarianceMinMax(proto.Class_ClassUnknown, 0.13300000131, 0.15000000596))
-				apDamage := 0.75 * core.Ternary(spell.IsRanged(), spell.RangedAttackPower(), spell.MeleeAttackPower())
+				apDamage := 0.75 * core.Ternary(isHunter, spell.RangedAttackPower(), spell.MeleeAttackPower())
 
-				outcome := core.Ternary(spell.IsRanged(), spell.OutcomeRangedHitAndCritNoBlock, spell.OutcomeMeleeSpecialNoBlockDodgeParry)
+				outcome := core.Ternary(isHunter, spell.OutcomeRangedHitAndCritNoBlock, spell.OutcomeMeleeSpecialNoBlockDodgeParry)
 				spell.CalcAndDealDamage(sim, target, baseDamage+apDamage, outcome)
 			},
 		})

--- a/sim/hunter/beast_mastery/TestBeastMastery.results
+++ b/sim/hunter/beast_mastery/TestBeastMastery.results
@@ -152,8 +152,8 @@ dps_results: {
 dps_results: {
  key: "TestBeastMastery-AllItems-CapacitivePrimalDiamond"
  value: {
-  dps: 177413.51485
-  tps: 85971.76801
+  dps: 179481.71724
+  tps: 88039.9704
  }
 }
 dps_results: {

--- a/sim/hunter/marksmanship/TestMarksmanship.results
+++ b/sim/hunter/marksmanship/TestMarksmanship.results
@@ -152,8 +152,8 @@ dps_results: {
 dps_results: {
  key: "TestMarksmanship-AllItems-CapacitivePrimalDiamond"
  value: {
-  dps: 178324.61944
-  tps: 147379.67138
+  dps: 180344.44318
+  tps: 149399.49512
  }
 }
 dps_results: {

--- a/sim/hunter/survival/TestSurvival.results
+++ b/sim/hunter/survival/TestSurvival.results
@@ -152,8 +152,8 @@ dps_results: {
 dps_results: {
  key: "TestSurvival-AllItems-CapacitivePrimalDiamond"
  value: {
-  dps: 180124.27052
-  tps: 148855.23487
+  dps: 182148.66302
+  tps: 150879.62737
  }
 }
 dps_results: {


### PR DESCRIPTION
It should benefit from Hunter's Mark (cast after 1st Lightning Strike hit):
<img width="402" height="95" alt="image" src="https://github.com/user-attachments/assets/00a3c7e9-8c54-4296-bb02-07761d0c7e18" />

And it was not actually using Ranged Attack Power at all for Hunters which should be fixed now.