### PR TITLE
Fix Flamestrike dot scaling

### DIFF
--- a/sim/mage/flamestrike.go
+++ b/sim/mage/flamestrike.go
@@ -59,15 +59,15 @@ func (mage *Mage) registerFlamestrikeSpell() {
 		DamageMultiplier: 1,
 		CritMultiplier:   mage.DefaultCritMultiplier(),
 		ThreatMultiplier: 1,
-		BonusCoefficient: flameStrikeDotCoefficient,
 
 		Dot: core.DotConfig{
 			IsAOE: true,
 			Aura: core.Aura{
 				Label: "FlameStrike DOT",
 			},
-			NumberOfTicks: 4,
-			TickLength:    time.Second * 2,
+			NumberOfTicks:    4,
+			TickLength:       time.Second * 2,
+			BonusCoefficient: flameStrikeDotCoefficient,
 			OnSnapshot: func(_ *core.Simulation, target *core.Unit, dot *core.Dot, _ bool) {
 				dot.Snapshot(target, mage.CalcScalingSpellDmg(flameStrikeDotScaling))
 			},


### PR DESCRIPTION
This pull request makes a small but important fix to the `Flamestrike` spell configuration in `flamestrike.go`. The change ensures that the spell's damage-over-time (DoT) component correctly uses the intended bonus coefficient for its damage calculation.

- Moved the `BonusCoefficient` for `Flamestrike` from the main spell config to the DoT config, so that the DoT portion properly receives the bonus scaling. [[1]](diffhunk://#diff-216ffb37a572f2451e01276acb63afaeb9fc4dcf1bff7a4c75be90e09bfb993dL62) [[2]](diffhunk://#diff-216ffb37a572f2451e01276acb63afaeb9fc4dcf1bff7a4c75be90e09bfb993dR70)