### PR TITLE
[Hunter] Fix some issues with T16 for BM

### DIFF
--- a/sim/hunter/beast_mastery/TestBeastMastery.results
+++ b/sim/hunter/beast_mastery/TestBeastMastery.results
@@ -89,8 +89,8 @@ dps_results: {
 dps_results: {
  key: "TestBeastMastery-AllItems-BattlegearoftheUnblinkingVigil"
  value: {
-  dps: 226533.88286
-  tps: 102531.904
+  dps: 226904.27899
+  tps: 105878.29636
  }
 }
 dps_results: {

--- a/sim/hunter/beast_mastery/focus_fire.go
+++ b/sim/hunter/beast_mastery/focus_fire.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/wowsims/mop/sim/core"
+	"github.com/wowsims/mop/sim/hunter"
 )
 
 func (bmHunter *BeastMasteryHunter) registerFocusFireSpell() {
@@ -39,7 +40,8 @@ func (bmHunter *BeastMasteryHunter) registerFocusFireSpell() {
 	})
 
 	focusFireSpell := bmHunter.RegisterSpell(core.SpellConfig{
-		ActionID: actionID,
+		ActionID:       actionID,
+		ClassSpellMask: hunter.HunterSpellFocusFire,
 
 		FocusCost: core.FocusCostOptions{
 			Cost: 0,

--- a/sim/hunter/hunter.go
+++ b/sim/hunter/hunter.go
@@ -246,10 +246,13 @@ const (
 	HunterSpellGlaiveToss
 	HunterSpellBarrage
 	HunterSpellPowershot
+	HunterSpellFocusFire
+	HunterSpellStampede
 	HunterSpellsAll = HunterSpellSteadyShot | HunterSpellCobraShot |
 		HunterSpellArcaneShot | HunterSpellKillCommand | HunterSpellChimeraShot | HunterSpellExplosiveShot |
 		HunterSpellExplosiveTrap | HunterSpellBlackArrow | HunterSpellMultiShot | HunterSpellAimedShot |
-		HunterSpellSerpentSting | HunterSpellKillShot | HunterSpellRapidFire | HunterSpellBestialWrath
+		HunterSpellSerpentSting | HunterSpellKillShot | HunterSpellRapidFire | HunterSpellBestialWrath |
+		HunterSpellFocusFire | HunterSpellStampede
 	HunterSpellsTalents = HunterSpellFervor | HunterSpellDireBeast | HunterSpellAMurderOfCrows | HunterSpellLynxRush | HunterSpellGlaiveToss | HunterSpellPowershot | HunterSpellBarrage
 
 	// These spells trigger auto shot when their cast time finishes

--- a/sim/hunter/hunters_mark.go
+++ b/sim/hunter/hunters_mark.go
@@ -26,9 +26,12 @@ func (hunter *Hunter) registerHuntersMarkSpell() {
 	config := core.SpellConfig{
 		ActionID: actionID,
 		ProcMask: core.ProcMaskEmpty,
+		Flags:    core.SpellFlagPassiveSpell,
+
 		FocusCost: core.FocusCostOptions{
 			Cost: 0,
 		},
+
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			for _, aura := range hmAura {
 				if aura.IsActive() {

--- a/sim/hunter/item_sets.go
+++ b/sim/hunter/item_sets.go
@@ -236,6 +236,10 @@ func registerBeastMasteryT16(hunter *Hunter, _ *core.Aura) {
 			ClassSpellMask: HunterPetFocusDump,
 
 			Handler: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !hunter.Pet.BestialWrathAura.IsActive() {
+					return
+				}
+
 				brutalKinshipPetAura.Activate(sim)
 				brutalKinshipPetAura.AddStack(sim)
 			},
@@ -260,6 +264,10 @@ func registerBeastMasteryT16(hunter *Hunter, _ *core.Aura) {
 			ClassSpellMask: HunterSpellsAll | HunterSpellsTalents ^ (HunterSpellFervor | HunterSpellDireBeast | HunterSpellBestialWrath),
 
 			Handler: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if !hunter.BestialWrathAura.IsActive() {
+					return
+				}
+
 				brutalKinshipAura.Activate(sim)
 				brutalKinshipAura.AddStack(sim)
 			},

--- a/sim/hunter/item_sets.go
+++ b/sim/hunter/item_sets.go
@@ -248,7 +248,7 @@ func registerBeastMasteryT16(hunter *Hunter, _ *core.Aura) {
 			MaxStacks: 5,
 
 			OnStacksChange: func(aura *core.Aura, sim *core.Simulation, oldStacks, newStacks int32) {
-				hunter.Pet.PseudoStats.DamageDealtMultiplier *= (1.0 + 0.04*float64(newStacks)) / (1.0 + 0.04*float64(oldStacks))
+				hunter.PseudoStats.DamageDealtMultiplier *= (1.0 + 0.04*float64(newStacks)) / (1.0 + 0.04*float64(oldStacks))
 			},
 		})
 

--- a/sim/hunter/stampede.go
+++ b/sim/hunter/stampede.go
@@ -9,8 +9,9 @@ import (
 func (hunter *Hunter) RegisterStampedeSpell() {
 	actionID := core.ActionID{SpellID: 121818}
 	stampedeSpell := hunter.RegisterSpell(core.SpellConfig{
-		ActionID: actionID,
-		Flags:    core.SpellFlagReadinessTrinket,
+		ActionID:       actionID,
+		ClassSpellMask: HunterSpellStampede,
+		Flags:          core.SpellFlagReadinessTrinket,
 		FocusCost: core.FocusCostOptions{
 			Cost: 0,
 		},


### PR DESCRIPTION
* Brutal Kinship (4pc) was buffing pet for both the personal and pet aura
* Stampede and Focus Fire weren't proccing 4pc for BM when they should
* Brutal Kinship on the player was lingering at 1 stack after being deactivated if a spell landed a batch too late
* Fix a display issue with the Replay feature where auto-casted Hunter's Marks were shown as casts since they lacked the SpellFlagPassive flag