### PR TITLE
Improve bulk/reforge improvement (headless)

### DIFF
--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -803,7 +803,7 @@
 			"combinations_count": "{{count}} Combinations",
 			"combination_singular": "1 Combination",
 			"iterations": "Iterations",
-			"default_gems": "Default Gems",
+			"fallback_gems": "Fallback Gems",
 			"inherit_upgrades": {
 				"label": "Inherit Upgrades",
 				"tooltip": "When enabled, items will inherit upgrades from the equipped item. Otherwise, items will be simmed without any upgrades."
@@ -819,10 +819,11 @@
 		},
 		"progress": {
 			"total_combinations": "{{count}} total combinations.",
-			"refining_rounds": "{{current}} / {{total}} refining rounds",
-			"simulations_complete": "{{completed}} / {{total}}<br />simulations complete",
+			"reforging_rounds": "Running reforges",
+			"baseline_round": "Running baseline round",
+			"refining_rounds": "Running refining rounds",
 			"iterations_complete": "{{completed}} / {{total}}<br />iterations complete",
-			"seconds_remaining": "{{seconds}} seconds remaining."
+			"seconds_remaining": "{{seconds}} seconds remaining"
 		},
 		"notifications": {
 			"bulk_sim_cancelled": "Bulk sim cancelled.",
@@ -844,7 +845,7 @@
 			"current_gear": "Current Gear"
 		},
 		"gem_selector": {
-			"title": "Choose Default Gem"
+			"title": "Choose fallback Gem"
 		},
 		"import_modal": {
 			"title": "Bag Item Import",

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -830,7 +830,7 @@
 			"failed_to_remove_item": "Failed to remove item, please report this issue."
 		},
 		"warning": {
-			"iterations_limit": "Simming over {{limit}} iterations in the web sim will take a long time or may not run at all. For larger batch sims we recommend using Fast Mode or downloading the executable and running on your machine."
+			"iterations_limit": "Simming over {{limit}} iterations in the sim will take a long time or may not run at all. For larger batch sims we recommend downloading the executable and running on your machine."
 		},
 		"picker": {
 			"no_items": "No items selected.",

--- a/assets/locales/fr/translation.json
+++ b/assets/locales/fr/translation.json
@@ -803,7 +803,7 @@
             "combinations_count": "{{count}} Combinaisons",
             "combination_singular": "1 Combinaison",
             "iterations": "Itérations",
-            "default_gems": "Gemmes par défaut",
+            "fallback_gems": "Gemmes de secours",
             "inherit_upgrades": {
                 "label": "Hériter des améliorations",
                 "tooltip": "Lorsque cette option est activée, les objets hériteront des améliorations de l'objet équipé. Sinon, les objets seront simulés sans aucune amélioration."
@@ -819,10 +819,11 @@
         },
         "progress": {
             "total_combinations": "{{count}} combinaisons totales.",
-            "refining_rounds": "{{current}} / {{total}} tours d'affinage",
-            "simulations_complete": "{{completed}} / {{total}}<br />simulations terminées",
+			"reforging_rounds": "Exécution des reforges",
+			"baseline_round": "Exécution du tour de référence",
+            "refining_rounds": "Exécution des tours d'affinage",
             "iterations_complete": "{{completed}} / {{total}}<br />itérations terminées",
-            "seconds_remaining": "{{seconds}} secondes restantes."
+            "seconds_remaining": "{{seconds}} secondes restantes"
         },
         "notifications": {
             "bulk_sim_cancelled": "Simulation par lot annulée.",

--- a/assets/locales/fr/translation.json
+++ b/assets/locales/fr/translation.json
@@ -830,7 +830,7 @@
             "failed_to_remove_item": "Échec de la suppression de l'objet, veuillez signaler ce problème."
         },
         "warning": {
-            "iterations_limit": "Simuler plus de {{limit}} itérations dans le simulateur web prendra beaucoup de temps ou ne fonctionnera peut-être pas du tout. Pour les simulations par lot plus importantes, nous recommandons d'utiliser le mode rapide ou de télécharger l'exécutable et de l'exécuter sur votre machine."
+			"iterations_limit": "Simuler plus de {{limit}} itérations dans le simulateur prendra beaucoup de temps ou ne fonctionnera peut-être pas du tout. Pour les simulations par lot plus importantes, nous recommandons de télécharger l'exécutable et de l'exécuter sur votre machine."
         },
         "picker": {
             "no_items": "Aucun objet sélectionné.",

--- a/schemas/translation.schema.json
+++ b/schemas/translation.schema.json
@@ -1,10464 +1,8805 @@
 {
-  "type": "object",
-  "properties": {
-    "landing": {
-      "type": "object",
-      "properties": {
-        "navigation": {
-          "type": "object",
-          "properties": {
-            "home": {
-              "type": "string"
-            },
-            "simulations": {
-              "type": "string"
-            },
-            "about": {
-              "type": "string"
-            },
-            "toggle": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "home",
-            "simulations",
-            "about",
-            "toggle"
-          ]
-        },
-        "simulations": {
-          "type": "object",
-          "properties": {
-            "full_raid": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "full_raid"
-          ]
-        },
-        "home": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "welcomeDescription": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "description",
-            "welcomeDescription"
-          ]
-        },
-        "header": {
-          "type": "object",
-          "properties": {
-            "wowsims": {
-              "type": "string"
-            },
-            "expansion": {
-              "type": "string"
-            },
-            "supportDevs": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "wowsims",
-            "expansion",
-            "supportDevs"
-          ]
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "navigation",
-        "simulations",
-        "home",
-        "header"
-      ]
-    },
-    "common": {
-      "type": "object",
-      "properties": {
-        "none": {
-          "type": "string"
-        },
-        "custom": {
-          "type": "string"
-        },
-        "name": {
-          "type": "string"
-        },
-        "search": {
-          "type": "string"
-        },
-        "filter": {
-          "type": "string"
-        },
-        "elapsed_time": {
-          "type": "string"
-        },
-        "phases": {
-          "type": "object",
-          "properties": {
-            "1": {
-              "type": "string"
-            },
-            "2": {
-              "type": "string"
-            },
-            "3": {
-              "type": "string"
-            },
-            "4": {
-              "type": "string"
-            },
-            "5": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "1",
-            "2",
-            "3",
-            "4",
-            "5"
-          ]
-        },
-        "tanks": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "main_tank": {
-              "type": "string"
-            },
-            "tank_2": {
-              "type": "string"
-            },
-            "tank_3": {
-              "type": "string"
-            },
-            "tank_4": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "main_tank",
-            "tank_2",
-            "tank_3",
-            "tank_4"
-          ]
-        },
-        "status": {
-          "type": "object",
-          "properties": {
-            "unlaunched": {
-              "type": "string"
-            },
-            "alpha": {
-              "type": "string"
-            },
-            "beta": {
-              "type": "string"
-            },
-            "launched": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "unlaunched",
-            "alpha",
-            "beta",
-            "launched"
-          ]
-        },
-        "mob_types": {
-          "type": "object",
-          "properties": {
-            "unknown": {
-              "type": "string"
-            },
-            "beast": {
-              "type": "string"
-            },
-            "demon": {
-              "type": "string"
-            },
-            "dragonkin": {
-              "type": "string"
-            },
-            "elemental": {
-              "type": "string"
-            },
-            "giant": {
-              "type": "string"
-            },
-            "humanoid": {
-              "type": "string"
-            },
-            "mechanical": {
-              "type": "string"
-            },
-            "undead": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "unknown",
-            "beast",
-            "demon",
-            "dragonkin",
-            "elemental",
-            "giant",
-            "humanoid",
-            "mechanical",
-            "undead"
-          ]
-        },
-        "sources": {
-          "type": "object",
-          "properties": {
-            "unknown": {
-              "type": "string"
-            },
-            "crafting": {
-              "type": "string"
-            },
-            "quest": {
-              "type": "string"
-            },
-            "sold_by": {
-              "type": "string"
-            },
-            "reputation": {
-              "type": "string"
-            },
-            "pvp": {
-              "type": "string"
-            },
-            "dungeon": {
-              "type": "string"
-            },
-            "dungeon_h": {
-              "type": "string"
-            },
-            "raid": {
-              "type": "string"
-            },
-            "raid_h": {
-              "type": "string"
-            },
-            "raid_rf": {
-              "type": "string"
-            },
-            "raid_flex": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "unknown",
-            "crafting",
-            "quest",
-            "sold_by",
-            "reputation",
-            "pvp",
-            "dungeon",
-            "dungeon_h",
-            "raid",
-            "raid_h",
-            "raid_rf",
-            "raid_flex"
-          ]
-        },
-        "raids": {
-          "type": "object",
-          "properties": {
-            "unknown": {
-              "type": "string"
-            },
-            "mogushan_vaults": {
-              "type": "string"
-            },
-            "heart_of_fear": {
-              "type": "string"
-            },
-            "terrace_of_endless_spring": {
-              "type": "string"
-            },
-            "throne_of_thunder": {
-              "type": "string"
-            },
-            "siege_of_orgrimmar": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "unknown",
-            "mogushan_vaults",
-            "heart_of_fear",
-            "terrace_of_endless_spring",
-            "throne_of_thunder",
-            "siege_of_orgrimmar"
-          ]
-        },
-        "armor_types": {
-          "type": "object",
-          "properties": {
-            "unknown": {
-              "type": "string"
-            },
-            "cloth": {
-              "type": "string"
-            },
-            "leather": {
-              "type": "string"
-            },
-            "mail": {
-              "type": "string"
-            },
-            "plate": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "unknown",
-            "cloth",
-            "leather",
-            "mail",
-            "plate"
-          ]
-        },
-        "weapon_types": {
-          "type": "object",
-          "properties": {
-            "unknown": {
-              "type": "string"
-            },
-            "axe": {
-              "type": "string"
-            },
-            "dagger": {
-              "type": "string"
-            },
-            "fist": {
-              "type": "string"
-            },
-            "mace": {
-              "type": "string"
-            },
-            "off_hand": {
-              "type": "string"
-            },
-            "polearm": {
-              "type": "string"
-            },
-            "shield": {
-              "type": "string"
-            },
-            "staff": {
-              "type": "string"
-            },
-            "sword": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "unknown",
-            "axe",
-            "dagger",
-            "fist",
-            "mace",
-            "off_hand",
-            "polearm",
-            "shield",
-            "staff",
-            "sword"
-          ]
-        },
-        "ranged_weapon_types": {
-          "type": "object",
-          "properties": {
-            "unknown": {
-              "type": "string"
-            },
-            "bow": {
-              "type": "string"
-            },
-            "crossbow": {
-              "type": "string"
-            },
-            "gun": {
-              "type": "string"
-            },
-            "thrown": {
-              "type": "string"
-            },
-            "wand": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "unknown",
-            "bow",
-            "crossbow",
-            "gun",
-            "thrown",
-            "wand"
-          ]
-        },
-        "spell_schools": {
-          "type": "object",
-          "properties": {
-            "physical": {
-              "type": "string"
-            },
-            "arcane": {
-              "type": "string"
-            },
-            "fire": {
-              "type": "string"
-            },
-            "frost": {
-              "type": "string"
-            },
-            "holy": {
-              "type": "string"
-            },
-            "nature": {
-              "type": "string"
-            },
-            "shadow": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "physical",
-            "arcane",
-            "fire",
-            "frost",
-            "holy",
-            "nature",
-            "shadow"
-          ]
-        },
-        "resource_types": {
-          "type": "object",
-          "properties": {
-            "health": {
-              "type": "string"
-            },
-            "mana": {
-              "type": "string"
-            },
-            "energy": {
-              "type": "string"
-            },
-            "rage": {
-              "type": "string"
-            },
-            "focus": {
-              "type": "string"
-            },
-            "runic_power": {
-              "type": "string"
-            },
-            "chi": {
-              "type": "string"
-            },
-            "holy_power": {
-              "type": "string"
-            },
-            "shadow_orbs": {
-              "type": "string"
-            },
-            "combo_points": {
-              "type": "string"
-            },
-            "maelstrom": {
-              "type": "string"
-            },
-            "demonic_fury": {
-              "type": "string"
-            },
-            "burning_embers": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "health",
-            "mana",
-            "energy",
-            "rage",
-            "focus",
-            "runic_power",
-            "chi",
-            "holy_power",
-            "shadow_orbs",
-            "combo_points",
-            "maelstrom",
-            "demonic_fury",
-            "burning_embers"
-          ]
-        },
-        "stats": {
-          "type": "object",
-          "properties": {
-            "strength": {
-              "type": "string"
-            },
-            "agility": {
-              "type": "string"
-            },
-            "stamina": {
-              "type": "string"
-            },
-            "intellect": {
-              "type": "string"
-            },
-            "spirit": {
-              "type": "string"
-            },
-            "hit": {
-              "type": "string"
-            },
-            "crit": {
-              "type": "string"
-            },
-            "haste": {
-              "type": "string"
-            },
-            "expertise": {
-              "type": "string"
-            },
-            "dodge": {
-              "type": "string"
-            },
-            "parry": {
-              "type": "string"
-            },
-            "mastery": {
-              "type": "string"
-            },
-            "attack_power": {
-              "type": "string"
-            },
-            "ranged_attack_power": {
-              "type": "string"
-            },
-            "spell_power": {
-              "type": "string"
-            },
-            "pvp_resilience": {
-              "type": "string"
-            },
-            "pvp_power": {
-              "type": "string"
-            },
-            "armor": {
-              "type": "string"
-            },
-            "bonus_armor": {
-              "type": "string"
-            },
-            "health": {
-              "type": "string"
-            },
-            "mana": {
-              "type": "string"
-            },
-            "mp5": {
-              "type": "string"
-            },
-            "main_hand_dps": {
-              "type": "string"
-            },
-            "off_hand_dps": {
-              "type": "string"
-            },
-            "ranged_dps": {
-              "type": "string"
-            },
-            "block": {
-              "type": "string"
-            },
-            "melee_speed_multiplier": {
-              "type": "string"
-            },
-            "ranged_speed_multiplier": {
-              "type": "string"
-            },
-            "cast_speed_multiplier": {
-              "type": "string"
-            },
-            "spell_hit": {
-              "type": "string"
-            },
-            "spell_crit": {
-              "type": "string"
-            },
-            "spell_haste": {
-              "type": "string"
-            },
-            "melee_hit": {
-              "type": "string"
-            },
-            "melee_crit": {
-              "type": "string"
-            },
-            "melee_haste": {
-              "type": "string"
-            },
-            "ranged_haste": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "strength",
-            "agility",
-            "stamina",
-            "intellect",
-            "spirit",
-            "hit",
-            "crit",
-            "haste",
-            "expertise",
-            "dodge",
-            "parry",
-            "mastery",
-            "attack_power",
-            "ranged_attack_power",
-            "spell_power",
-            "pvp_resilience",
-            "pvp_power",
-            "armor",
-            "bonus_armor",
-            "health",
-            "mana",
-            "mp5",
-            "main_hand_dps",
-            "off_hand_dps",
-            "ranged_dps",
-            "block",
-            "melee_speed_multiplier",
-            "ranged_speed_multiplier",
-            "cast_speed_multiplier",
-            "spell_hit",
-            "spell_crit",
-            "spell_haste",
-            "melee_hit",
-            "melee_crit",
-            "melee_haste",
-            "ranged_haste"
-          ]
-        },
-        "mastery_spell_names": {
-          "type": "object",
-          "properties": {
-            "unknown": {
-              "type": "string"
-            },
-            "potent_poisons": {
-              "type": "string"
-            },
-            "main_gauche": {
-              "type": "string"
-            },
-            "executioner": {
-              "type": "string"
-            },
-            "blood_shield": {
-              "type": "string"
-            },
-            "frozen_heart": {
-              "type": "string"
-            },
-            "dreadblade": {
-              "type": "string"
-            },
-            "total_eclipse": {
-              "type": "string"
-            },
-            "razor_claws": {
-              "type": "string"
-            },
-            "natures_guardian": {
-              "type": "string"
-            },
-            "harmony": {
-              "type": "string"
-            },
-            "illuminated_healing": {
-              "type": "string"
-            },
-            "divine_bulwark": {
-              "type": "string"
-            },
-            "hand_of_light": {
-              "type": "string"
-            },
-            "elemental_overload": {
-              "type": "string"
-            },
-            "enhanced_elements": {
-              "type": "string"
-            },
-            "deep_healing": {
-              "type": "string"
-            },
-            "master_of_beasts": {
-              "type": "string"
-            },
-            "wild_quiver": {
-              "type": "string"
-            },
-            "essence_of_the_viper": {
-              "type": "string"
-            },
-            "strikes_of_opportunity": {
-              "type": "string"
-            },
-            "unshackled_fury": {
-              "type": "string"
-            },
-            "critical_block": {
-              "type": "string"
-            },
-            "mana_adept": {
-              "type": "string"
-            },
-            "ignite": {
-              "type": "string"
-            },
-            "icicles": {
-              "type": "string"
-            },
-            "shield_discipline": {
-              "type": "string"
-            },
-            "echo_of_light": {
-              "type": "string"
-            },
-            "shadow_orb_power": {
-              "type": "string"
-            },
-            "potent_afflictions": {
-              "type": "string"
-            },
-            "master_demonologist": {
-              "type": "string"
-            },
-            "emberstorm": {
-              "type": "string"
-            },
-            "elusive_brawler": {
-              "type": "string"
-            },
-            "gift_of_the_serpent": {
-              "type": "string"
-            },
-            "bottled_fury": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "unknown",
-            "potent_poisons",
-            "main_gauche",
-            "executioner",
-            "blood_shield",
-            "frozen_heart",
-            "dreadblade",
-            "total_eclipse",
-            "razor_claws",
-            "natures_guardian",
-            "harmony",
-            "illuminated_healing",
-            "divine_bulwark",
-            "hand_of_light",
-            "elemental_overload",
-            "enhanced_elements",
-            "deep_healing",
-            "master_of_beasts",
-            "wild_quiver",
-            "essence_of_the_viper",
-            "strikes_of_opportunity",
-            "unshackled_fury",
-            "critical_block",
-            "mana_adept",
-            "ignite",
-            "icicles",
-            "shield_discipline",
-            "echo_of_light",
-            "shadow_orb_power",
-            "potent_afflictions",
-            "master_demonologist",
-            "emberstorm",
-            "elusive_brawler",
-            "gift_of_the_serpent",
-            "bottled_fury"
-          ]
-        },
-        "currency": {
-          "type": "object",
-          "properties": {
-            "valorPoints": {
-              "type": "string"
-            },
-            "justicePoints": {
-              "type": "string"
-            },
-            "honorPoints": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "valorPoints",
-            "justicePoints",
-            "honorPoints"
-          ]
-        },
-        "copy_button": {
-          "type": "object",
-          "properties": {
-            "default_text": {
-              "type": "string"
-            },
-            "copied": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "default_text",
-            "copied"
-          ]
-        },
-        "list_picker": {
-          "type": "object",
-          "properties": {
-            "new_item": {
-              "type": "string"
-            },
-            "delete_item": {
-              "type": "string"
-            },
-            "copy_to_new": {
-              "type": "string"
-            },
-            "move_drag_drop": {
-              "type": "string"
-            },
-            "warnings": {
-              "type": "string"
-            },
-            "additional_information": {
-              "type": "string"
-            },
-            "action_has_warnings": {
-              "type": "string"
-            },
-            "action_has_errors": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "new_item",
-            "delete_item",
-            "copy_to_new",
-            "move_drag_drop",
-            "warnings",
-            "additional_information",
-            "action_has_warnings",
-            "action_has_errors"
-          ]
-        },
-        "preset": {
-          "type": "object",
-          "properties": {
-            "ep_weights": {
-              "type": "string"
-            },
-            "gear": {
-              "type": "string"
-            },
-            "talents": {
-              "type": "string"
-            },
-            "rotation": {
-              "type": "string"
-            },
-            "encounter": {
-              "type": "string"
-            },
-            "settings": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "stat_weights": {
-              "type": "string"
-            },
-            "class_spec_options": {
-              "type": "string"
-            },
-            "consumables": {
-              "type": "string"
-            },
-            "other_settings": {
-              "type": "string"
-            },
-            "buffs": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "ep_weights",
-            "gear",
-            "talents",
-            "rotation",
-            "encounter",
-            "settings",
-            "description",
-            "stat_weights",
-            "class_spec_options",
-            "consumables",
-            "other_settings",
-            "buffs"
-          ]
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "none",
-        "custom",
-        "name",
-        "search",
-        "filter",
-        "elapsed_time",
-        "phases",
-        "tanks",
-        "status",
-        "mob_types",
-        "sources",
-        "raids",
-        "armor_types",
-        "weapon_types",
-        "ranged_weapon_types",
-        "spell_schools",
-        "resource_types",
-        "stats",
-        "mastery_spell_names",
-        "currency",
-        "copy_button",
-        "list_picker",
-        "preset"
-      ]
-    },
-    "sim": {
-      "type": "object",
-      "properties": {
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "basic_bis_disclaimer": {
-          "type": "string"
-        },
-        "healing_sim_disclaimer": {
-          "type": "string"
-        },
-        "notice_local_download": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "message": {
-              "type": "string"
-            },
-            "download_button": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "message",
-            "download_button"
-          ]
-        },
-        "crash_modal": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "header": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "header"
-          ]
-        },
-        "unlaunched": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "contribute_message": {
-              "type": "string"
-            },
-            "discord_message": {
-              "type": "string"
-            },
-            "healing_message": {
-              "type": "string"
-            },
-            "qe_live_message": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "contribute_message",
-            "discord_message",
-            "healing_message",
-            "qe_live_message"
-          ]
-        },
-        "notifications": {
-          "type": "object",
-          "properties": {
-            "raid_sim_cancelled": {
-              "type": "string"
-            },
-            "simulation_failed": {
-              "type": "string"
-            },
-            "failed_to_file_report": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "raid_sim_cancelled",
-            "simulation_failed",
-            "failed_to_file_report"
-          ]
-        },
-        "crash_report": {
-          "type": "object",
-          "properties": {
-            "confirm_title": {
-              "type": "string"
-            },
-            "confirm_message": {
-              "type": "string"
-            },
-            "report_title": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "confirm_title",
-            "confirm_message",
-            "report_title"
-          ]
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "title",
-        "description",
-        "basic_bis_disclaimer",
-        "healing_sim_disclaimer",
-        "notice_local_download",
-        "crash_modal",
-        "unlaunched",
-        "notifications",
-        "crash_report"
-      ]
-    },
-    "gear_tab": {
-      "type": "object",
-      "properties": {
-        "title": {
-          "type": "string"
-        },
-        "gem_summary": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "reset_gems": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "reset_gems"
-          ]
-        },
-        "reforge_summary": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "reset_reforges": {
-              "type": "string"
-            },
-            "copy_to_reforge_lite": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "reset_reforges",
-            "copy_to_reforge_lite"
-          ]
-        },
-        "reforge_success": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "removed_reforge": {
-              "type": "string"
-            },
-            "no_changes": {
-              "type": "string"
-            },
-            "copy_to_reforge_lite": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "removed_reforge",
-            "no_changes",
-            "copy_to_reforge_lite"
-          ]
-        },
-        "gear_sets": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "gear_set": {
-              "type": "string"
-            },
-            "gear_set_name": {
-              "type": "string"
-            },
-            "save_gear_set": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "gear_set",
-            "gear_set_name",
-            "save_gear_set"
-          ]
-        },
-        "gear_picker": {
-          "type": "object",
-          "properties": {
-            "tabs": {
-              "type": "object",
-              "properties": {
-                "items": {
-                  "type": "string"
-                },
-                "random_suffix": {
-                  "type": "string"
-                },
-                "enchants": {
-                  "type": "string"
-                },
-                "tinkers": {
-                  "type": "string"
-                },
-                "reforging": {
-                  "type": "string"
-                },
-                "upgrades": {
-                  "type": "string"
-                },
-                "gem1": {
-                  "type": "string"
-                },
-                "gem2": {
-                  "type": "string"
-                },
-                "gem3": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "items",
-                "random_suffix",
-                "enchants",
-                "tinkers",
-                "reforging",
-                "upgrades",
-                "gem1",
-                "gem2",
-                "gem3"
-              ]
-            },
-            "remove_buttons": {
-              "type": "object",
-              "properties": {
-                "remove_enchant": {
-                  "type": "string"
-                },
-                "remove_tinkers": {
-                  "type": "string"
-                },
-                "remove_reforge": {
-                  "type": "string"
-                },
-                "remove_random_suffix": {
-                  "type": "string"
-                },
-                "remove_upgrade": {
-                  "type": "string"
-                },
-                "remove_gem": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "remove_enchant",
-                "remove_tinkers",
-                "remove_reforge",
-                "remove_random_suffix",
-                "remove_upgrade",
-                "remove_gem"
-              ]
-            },
-            "filters": {
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "general": {
-                  "type": "string"
-                },
-                "min_ilvl": {
-                  "type": "string"
-                },
-                "max_ilvl": {
-                  "type": "string"
-                },
-                "faction_restrictions": {
-                  "type": "string"
-                },
-                "source": {
-                  "type": "string"
-                },
-                "raids": {
-                  "type": "string"
-                },
-                "faction_labels": {
-                  "type": "object",
-                  "properties": {
-                    "none": {
-                      "type": "string"
-                    },
-                    "alliance_only": {
-                      "type": "string"
-                    },
-                    "horde_only": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "none",
-                    "alliance_only",
-                    "horde_only"
-                  ]
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "title",
-                "general",
-                "min_ilvl",
-                "max_ilvl",
-                "faction_restrictions",
-                "source",
-                "raids",
-                "faction_labels"
-              ]
-            },
-            "quick_popovers": {
-              "type": "object",
-              "properties": {
-                "favorite_gems": {
-                  "type": "object",
-                  "properties": {
-                    "title": {
-                      "type": "string"
-                    },
-                    "empty_message": {
-                      "type": "string"
-                    },
-                    "open_gems": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "title",
-                    "empty_message",
-                    "open_gems"
-                  ]
-                },
-                "favorite_enchants": {
-                  "type": "object",
-                  "properties": {
-                    "title": {
-                      "type": "string"
-                    },
-                    "empty_message": {
-                      "type": "string"
-                    },
-                    "open_enchants": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "title",
-                    "empty_message",
-                    "open_enchants"
-                  ]
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "favorite_gems",
-                "favorite_enchants"
-              ]
-            },
-            "missing_gear_message": {
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "title",
-                "description"
-              ]
-            },
-            "cooldowns": {
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "title",
-                "tooltip"
-              ]
-            },
-            "ep_tooltip": {
-              "type": "string"
-            },
-            "filters_button": {
-              "type": "string"
-            },
-            "unequip_item": {
-              "type": "string"
-            },
-            "table_headers": {
-              "type": "object",
-              "properties": {
-                "ilvl": {
-                  "type": "string"
-                },
-                "item": {
-                  "type": "string"
-                },
-                "source": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "ilvl",
-                "item",
-                "source"
-              ]
-            },
-            "show_ep": {
-              "type": "string"
-            },
-            "armor_type": {
-              "type": "string"
-            },
-            "weapon_type": {
-              "type": "string"
-            },
-            "weapon_speed": {
-              "type": "string"
-            },
-            "min_mh_speed": {
-              "type": "string"
-            },
-            "max_mh_speed": {
-              "type": "string"
-            },
-            "min_oh_speed": {
-              "type": "string"
-            },
-            "max_oh_speed": {
-              "type": "string"
-            },
-            "ranged_weapon_type": {
-              "type": "string"
-            },
-            "ranged_weapon_speed": {
-              "type": "string"
-            },
-            "min_ranged_speed": {
-              "type": "string"
-            },
-            "max_ranged_speed": {
-              "type": "string"
-            },
-            "reforge_text": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "tabs",
-            "remove_buttons",
-            "filters",
-            "quick_popovers",
-            "missing_gear_message",
-            "cooldowns",
-            "ep_tooltip",
-            "filters_button",
-            "unequip_item",
-            "table_headers",
-            "show_ep",
-            "armor_type",
-            "weapon_type",
-            "weapon_speed",
-            "min_mh_speed",
-            "max_mh_speed",
-            "min_oh_speed",
-            "max_oh_speed",
-            "ranged_weapon_type",
-            "ranged_weapon_speed",
-            "min_ranged_speed",
-            "max_ranged_speed",
-            "reforge_text"
-          ]
-        },
-        "preset_configurations": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "tooltip": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "tooltip"
-          ]
-        },
-        "upgrade_summary": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "upgrade_all_items": {
-              "type": "string"
-            },
-            "reset_upgrades": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "upgrade_all_items",
-            "reset_upgrades"
-          ]
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "title",
-        "gem_summary",
-        "reforge_summary",
-        "reforge_success",
-        "gear_sets",
-        "gear_picker",
-        "preset_configurations",
-        "upgrade_summary"
-      ]
-    },
-    "settings_tab": {
-      "type": "object",
-      "properties": {
-        "title": {
-          "type": "string"
-        },
-        "raid_buffs": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "tooltip": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "misc": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "stats": {
-              "type": "string"
-            },
-            "attack_power": {
-              "type": "string"
-            },
-            "attack_speed": {
-              "type": "string"
-            },
-            "spell_power": {
-              "type": "string"
-            },
-            "spell_haste": {
-              "type": "string"
-            },
-            "crit_percent": {
-              "type": "string"
-            },
-            "mastery": {
-              "type": "string"
-            },
-            "stamina": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "tooltip",
-            "description",
-            "misc",
-            "stats",
-            "attack_power",
-            "attack_speed",
-            "spell_power",
-            "spell_haste",
-            "crit_percent",
-            "mastery",
-            "stamina"
-          ]
-        },
-        "external_damage_cooldowns": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "tooltip": {
-              "type": "string"
-            },
-            "bloodlust": {
-              "type": "string"
-            },
-            "skull_banner": {
-              "type": "string"
-            },
-            "stormlash_totem": {
-              "type": "string"
-            },
-            "tricks_of_the_trade": {
-              "type": "string"
-            },
-            "unholy_frenzy": {
-              "type": "string"
-            },
-            "shattering_throw": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "tooltip",
-            "bloodlust",
-            "skull_banner",
-            "stormlash_totem",
-            "tricks_of_the_trade",
-            "unholy_frenzy",
-            "shattering_throw"
-          ]
-        },
-        "external_defensive_cooldowns": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "tooltip": {
-              "type": "string"
-            },
-            "vigilance": {
-              "type": "string"
-            },
-            "devotion_aura": {
-              "type": "string"
-            },
-            "pain_suppression": {
-              "type": "string"
-            },
-            "rallying_cry": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "tooltip",
-            "vigilance",
-            "devotion_aura",
-            "pain_suppression",
-            "rallying_cry"
-          ]
-        },
-        "debuffs": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "tooltip": {
-              "type": "string"
-            },
-            "misc": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "armor_reduction": {
-              "type": "string"
-            },
-            "phys_dmg_reduction": {
-              "type": "string"
-            },
-            "cast_speed": {
-              "type": "string"
-            },
-            "phys_dmg": {
-              "type": "string"
-            },
-            "spell_dmg": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "tooltip",
-            "misc",
-            "armor_reduction",
-            "phys_dmg_reduction",
-            "cast_speed",
-            "phys_dmg",
-            "spell_dmg"
-          ]
-        },
-        "other": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "challenge_mode": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "input_delay": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "channel_clip_delay": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "in_front_of_target": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "distance_from_target": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "tank_assignment": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "incoming_hps": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "healing_cadence": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "healing_cadence_variation": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "absorb_frac": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "burst_window": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "hp_percent_for_defensives": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "pet_uptime": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "glaive_toss_chance": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "detonate_seed": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "stance_snapshot": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "assume_bleed_active": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "cannot_shred_target": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "okf_uptime": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "sync_type": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                },
-                "values": {
-                  "type": "object",
-                  "properties": {
-                    "automatic": {
-                      "type": "string"
-                    },
-                    "none": {
-                      "type": "string"
-                    },
-                    "perfect_sync": {
-                      "type": "string"
-                    },
-                    "delayed_offhand": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "automatic",
-                    "none",
-                    "perfect_sync",
-                    "delayed_offhand"
-                  ]
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip",
-                "values"
-              ]
-            },
-            "show_1h_weapons": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "show_2h_weapons": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "show_matching_gems": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "show_ep_values": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "phase_selector": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "enable_item_swap": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "item_swap": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "assume_prepull_mastery_elixir": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "blessings": {
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "title",
-                "tooltip"
-              ]
-            },
-            "shaman_disable_immolate": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "shaman_disable_immolate_duration": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "challenge_mode",
-            "input_delay",
-            "channel_clip_delay",
-            "in_front_of_target",
-            "distance_from_target",
-            "tank_assignment",
-            "incoming_hps",
-            "healing_cadence",
-            "healing_cadence_variation",
-            "absorb_frac",
-            "burst_window",
-            "hp_percent_for_defensives",
-            "pet_uptime",
-            "glaive_toss_chance",
-            "detonate_seed",
-            "stance_snapshot",
-            "assume_bleed_active",
-            "cannot_shred_target",
-            "okf_uptime",
-            "sync_type",
-            "show_1h_weapons",
-            "show_2h_weapons",
-            "show_matching_gems",
-            "show_ep_values",
-            "phase_selector",
-            "enable_item_swap",
-            "item_swap",
-            "assume_prepull_mastery_elixir",
-            "blessings",
-            "shaman_disable_immolate",
-            "shaman_disable_immolate_duration"
-          ]
-        },
-        "consumables": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "potions": {
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "prepop": {
-                  "type": "string"
-                },
-                "combat": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "title",
-                "prepop",
-                "combat"
-              ]
-            },
-            "elixirs": {
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "title"
-              ]
-            },
-            "food": {
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "title"
-              ]
-            },
-            "engineering": {
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "explosives": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "title",
-                "explosives"
-              ]
-            },
-            "pet": {
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "title"
-              ]
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "potions",
-            "elixirs",
-            "food",
-            "engineering",
-            "pet"
-          ]
-        },
-        "encounter": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "target_inputs": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "frenzy_time": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "spiritual_grasp_frequency": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "jalak_death_time": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "taunt_swap_for_triple_puncture": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "movement_interval": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "reaction_time": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "yards": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "adds_respawn_time": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "adds_lifetime": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "adds_spawn_delay": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "frenzy_time",
-                "spiritual_grasp_frequency",
-                "jalak_death_time",
-                "taunt_swap_for_triple_puncture",
-                "movement_interval",
-                "reaction_time",
-                "yards",
-                "adds_respawn_time",
-                "adds_lifetime",
-                "adds_spawn_delay"
-              ]
-            },
-            "duration": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "duration_variation": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "execute_duration_20": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "execute_duration_25": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "execute_duration_35": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "execute_duration_45": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "duration_below_high_hp": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "encounter_preset": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "advanced": {
-              "type": "string"
-            },
-            "use_health": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "target": {
-              "type": "string"
-            },
-            "num_allies": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "min_base_damage": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "npc": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "ai": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "level": {
-              "type": "string"
-            },
-            "mob_type": {
-              "type": "string"
-            },
-            "tanked_by": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "swing_speed": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "dual_wield": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "dual_wield_penalty": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "parry_haste": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "spell_school": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "damage_spread": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "suppress_dodge": {
-              "type": "string"
-            },
-            "second_tank_index": {
-              "type": "string"
-            },
-            "disabled_at_start": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "target_inputs",
-            "duration",
-            "duration_variation",
-            "execute_duration_20",
-            "execute_duration_25",
-            "execute_duration_35",
-            "execute_duration_45",
-            "duration_below_high_hp",
-            "encounter_preset",
-            "advanced",
-            "use_health",
-            "target",
-            "num_allies",
-            "min_base_damage",
-            "npc",
-            "ai",
-            "level",
-            "mob_type",
-            "tanked_by",
-            "swing_speed",
-            "dual_wield",
-            "dual_wield_penalty",
-            "parry_haste",
-            "spell_school",
-            "damage_spread",
-            "suppress_dodge",
-            "second_tank_index",
-            "disabled_at_start"
-          ]
-        },
-        "player": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "race": {
-              "type": "string"
-            },
-            "profession_1": {
-              "type": "string"
-            },
-            "profession_2": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "race",
-            "profession_1",
-            "profession_2"
-          ]
-        },
-        "saved_encounters": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "encounter": {
-              "type": "string"
-            },
-            "encounter_name": {
-              "type": "string"
-            },
-            "save_encounter": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "encounter",
-            "encounter_name",
-            "save_encounter"
-          ]
-        },
-        "saved_settings": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "settings": {
-              "type": "string"
-            },
-            "settings_name": {
-              "type": "string"
-            },
-            "save_settings": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "settings",
-            "settings_name",
-            "save_settings"
-          ]
-        },
-        "external_buffs": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "tooltip": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "tooltip"
-          ]
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "title",
-        "raid_buffs",
-        "external_damage_cooldowns",
-        "external_defensive_cooldowns",
-        "debuffs",
-        "other",
-        "consumables",
-        "encounter",
-        "player",
-        "saved_encounters",
-        "saved_settings",
-        "external_buffs"
-      ]
-    },
-    "talents_tab": {
-      "type": "object",
-      "properties": {
-        "title": {
-          "type": "string"
-        },
-        "copy_button": {
-          "type": "object",
-          "properties": {
-            "label": {
-              "type": "string"
-            },
-            "tooltip": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "label",
-            "tooltip"
-          ]
-        },
-        "reset_button": {
-          "type": "object",
-          "properties": {
-            "tooltip": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "tooltip"
-          ]
-        },
-        "glyphs": {
-          "type": "object",
-          "properties": {
-            "major": {
-              "type": "string"
-            },
-            "minor": {
-              "type": "string"
-            },
-            "modal": {
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "title"
-              ]
-            },
-            "empty": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "major",
-            "minor",
-            "modal",
-            "empty"
-          ]
-        },
-        "saved_talents": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "label": {
-              "type": "string"
-            },
-            "name_label": {
-              "type": "string"
-            },
-            "save_button": {
-              "type": "string"
-            },
-            "delete": {
-              "type": "object",
-              "properties": {
-                "confirm": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "confirm",
-                "tooltip"
-              ]
-            },
-            "alerts": {
-              "type": "object",
-              "properties": {
-                "choose_name": {
-                  "type": "string"
-                },
-                "name_exists": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "choose_name",
-                "name_exists"
-              ]
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "label",
-            "name_label",
-            "save_button",
-            "delete",
-            "alerts"
-          ]
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "title",
-        "copy_button",
-        "reset_button",
-        "glyphs",
-        "saved_talents"
-      ]
-    },
-    "bulk_tab": {
-      "type": "object",
-      "properties": {
-        "title": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "download_local": {
-          "type": "string"
-        },
-        "tabs": {
-          "type": "object",
-          "properties": {
-            "setup": {
-              "type": "string"
-            },
-            "results": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "setup",
-            "results"
-          ]
-        },
-        "actions": {
-          "type": "object",
-          "properties": {
-            "import_bags": {
-              "type": "string"
-            },
-            "import_favorites": {
-              "type": "string"
-            },
-            "clear_items": {
-              "type": "string"
-            },
-            "simulate_batch": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "import_bags",
-            "import_favorites",
-            "clear_items",
-            "simulate_batch"
-          ]
-        },
-        "search": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "name_label": {
-              "type": "string"
-            },
-            "clear_search": {
-              "type": "string"
-            },
-            "min_ilvl": {
-              "type": "string"
-            },
-            "max_ilvl": {
-              "type": "string"
-            },
-            "no_results": {
-              "type": "string"
-            },
-            "showing_results": {
-              "type": "string"
-            },
-            "item_added": {
-              "type": "string"
-            },
-            "item_removed": {
-              "type": "string"
-            },
-            "item_unique": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "name_label",
-            "clear_search",
-            "min_ilvl",
-            "max_ilvl",
-            "no_results",
-            "showing_results",
-            "item_added",
-            "item_removed",
-            "item_unique"
-          ]
-        },
-        "settings": {
-          "type": "object",
-          "properties": {
-            "combinations_count": {
-              "type": "string"
-            },
-            "combination_singular": {
-              "type": "string"
-            },
-            "iterations": {
-              "type": "string"
-            },
-            "default_gems": {
-              "type": "string"
-            },
-            "inherit_upgrades": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "freeze_ring": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "freeze_trinket": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "combinations_count",
-            "combination_singular",
-            "iterations",
-            "default_gems",
-            "inherit_upgrades",
-            "freeze_ring",
-            "freeze_trinket"
-          ]
-        },
-        "progress": {
-          "type": "object",
-          "properties": {
-            "total_combinations": {
-              "type": "string"
-            },
-            "refining_rounds": {
-              "type": "string"
-            },
-            "simulations_complete": {
-              "type": "string"
-            },
-            "iterations_complete": {
-              "type": "string"
-            },
-            "seconds_remaining": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "total_combinations",
-            "refining_rounds",
-            "simulations_complete",
-            "iterations_complete",
-            "seconds_remaining"
-          ]
-        },
-        "notifications": {
-          "type": "object",
-          "properties": {
-            "bulk_sim_cancelled": {
-              "type": "string"
-            },
-            "failed_to_remove_item": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "bulk_sim_cancelled",
-            "failed_to_remove_item"
-          ]
-        },
-        "warning": {
-          "type": "object",
-          "properties": {
-            "iterations_limit": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "iterations_limit"
-          ]
-        },
-        "picker": {
-          "type": "object",
-          "properties": {
-            "no_items": {
-              "type": "string"
-            },
-            "remove_tooltip": {
-              "type": "string"
-            },
-            "failed_update": {
-              "type": "string"
-            },
-            "failed_remove": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "no_items",
-            "remove_tooltip",
-            "failed_update",
-            "failed_remove"
-          ]
-        },
-        "results": {
-          "type": "object",
-          "properties": {
-            "run_simulation": {
-              "type": "string"
-            },
-            "equip_button": {
-              "type": "string"
-            },
-            "gear_equipped": {
-              "type": "string"
-            },
-            "current_gear": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "run_simulation",
-            "equip_button",
-            "gear_equipped",
-            "current_gear"
-          ]
-        },
-        "gem_selector": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title"
-          ]
-        },
-        "import_modal": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "description_line1": {
-              "type": "string"
-            },
-            "description_line2": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "description_line1",
-            "description_line2"
-          ]
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "title",
-        "description",
-        "download_local",
-        "tabs",
-        "actions",
-        "search",
-        "settings",
-        "progress",
-        "notifications",
-        "warning",
-        "picker",
-        "results",
-        "gem_selector",
-        "import_modal"
-      ]
-    },
-    "rotation_tab": {
-      "type": "object",
-      "properties": {
-        "title": {
-          "type": "string"
-        },
-        "common": {
-          "type": "object",
-          "properties": {
-            "rotation_type": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "auto": {
-                  "type": "string"
-                },
-                "simple": {
-                  "type": "string"
-                },
-                "apl": {
-                  "type": "string"
-                },
-                "single_target": {
-                  "type": "string"
-                },
-                "aoe": {
-                  "type": "string"
-                },
-                "custom": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "auto",
-                "simple",
-                "apl",
-                "single_target",
-                "aoe",
-                "custom"
-              ]
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "rotation_type"
-          ]
-        },
-        "apl": {
-          "type": "object",
-          "properties": {
-            "actionGroups": {
-              "type": "object",
-              "properties": {
-                "attributes": {
-                  "type": "object",
-                  "properties": {
-                    "actions": {
-                      "type": "string"
-                    },
-                    "name": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "actions",
-                    "name"
-                  ]
-                },
-                "header": {
-                  "type": "string"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "newGroupName": {
-                  "type": "string"
-                },
-                "tooltips": {
-                  "type": "object",
-                  "properties": {
-                    "actions": {
-                      "type": "string"
-                    },
-                    "name": {
-                      "type": "string"
-                    },
-                    "overview": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "actions",
-                    "name",
-                    "overview"
-                  ]
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "attributes",
-                "header",
-                "name",
-                "newGroupName",
-                "tooltips"
-              ]
-            },
-            "floatingActionBar": {
-              "type": "object",
-              "properties": {
-                "new": {
-                  "type": "string"
-                },
-                "reset": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "new",
-                "reset"
-              ]
-            },
-            "nameModal": {
-              "type": "object",
-              "properties": {
-                "create": {
-                  "type": "string"
-                },
-                "nameConflict": {
-                  "type": "string"
-                },
-                "extract": {
-                  "type": "string"
-                },
-                "rename": {
-                  "type": "string"
-                },
-                "renameConfirm": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "create",
-                "nameConflict",
-                "extract",
-                "rename",
-                "renameConfirm"
-              ]
-            },
-            "prePullActions": {
-              "type": "object",
-              "properties": {
-                "header": {
-                  "type": "string"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "tooltips": {
-                  "type": "object",
-                  "properties": {
-                    "overview": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "overview"
-                  ]
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "header",
-                "name",
-                "tooltips"
-              ]
-            },
-            "priorityList": {
-              "type": "object",
-              "properties": {
-                "header": {
-                  "type": "string"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "tooltips": {
-                  "type": "object",
-                  "properties": {
-                    "overview": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "overview"
-                  ]
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "header",
-                "name",
-                "tooltips"
-              ]
-            },
-            "tabs": {
-              "type": "object",
-              "properties": {
-                "actionGroups": {
-                  "type": "string"
-                },
-                "priorityList": {
-                  "type": "string"
-                },
-                "variables": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "actionGroups",
-                "priorityList",
-                "variables"
-              ]
-            },
-            "variables": {
-              "type": "object",
-              "properties": {
-                "attributes": {
-                  "type": "object",
-                  "properties": {
-                    "name": {
-                      "type": "string"
-                    },
-                    "nameTooltip": {
-                      "type": "string"
-                    },
-                    "value": {
-                      "type": "string"
-                    },
-                    "valueTooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "name",
-                    "nameTooltip",
-                    "value",
-                    "valueTooltip"
-                  ]
-                },
-                "enterVariableName": {
-                  "type": "string"
-                },
-                "extractToVariable": {
-                  "type": "string"
-                },
-                "header": {
-                  "type": "string"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "newVariableName": {
-                  "type": "string"
-                },
-                "tooltips": {
-                  "type": "object",
-                  "properties": {
-                    "name": {
-                      "type": "string"
-                    },
-                    "overview": {
-                      "type": "string"
-                    },
-                    "value": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "name",
-                    "overview",
-                    "value"
-                  ]
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "attributes",
-                "enterVariableName",
-                "extractToVariable",
-                "header",
-                "name",
-                "newVariableName",
-                "tooltips"
-              ]
-            },
-            "variablePlaceholder": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "nameLabel": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "name",
-                "nameLabel"
-              ]
-            },
-            "prepull_actions": {
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                },
-                "item_label": {
-                  "type": "string"
-                },
-                "do_at": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "new_action": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "title",
-                "tooltip",
-                "item_label",
-                "do_at",
-                "new_action"
-              ]
-            },
-            "priority_list": {
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                },
-                "item_label": {
-                  "type": "string"
-                },
-                "if_label": {
-                  "type": "string"
-                },
-                "new_action": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "title",
-                "tooltip",
-                "item_label",
-                "if_label",
-                "new_action"
-              ]
-            },
-            "actions": {
-              "type": "object",
-              "properties": {
-                "cast": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "cancel_cast": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "cast_at_player": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "multi_dot": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    },
-                    "max_dots": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    },
-                    "overlap": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip",
-                    "max_dots",
-                    "overlap"
-                  ]
-                },
-                "strict_multi_dot": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    },
-                    "max_dots": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    },
-                    "overlap": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip",
-                    "max_dots",
-                    "overlap"
-                  ]
-                },
-                "multi_shield": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    },
-                    "max_shields": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    },
-                    "overlap": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip",
-                    "max_shields",
-                    "overlap"
-                  ]
-                },
-                "channel": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    },
-                    "full_description": {
-                      "type": "string"
-                    },
-                    "interrupt_if": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    },
-                    "recast": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip",
-                    "full_description",
-                    "interrupt_if",
-                    "recast"
-                  ]
-                },
-                "cast_all_stat_buff_cooldowns": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    },
-                    "full_description": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip",
-                    "full_description"
-                  ]
-                },
-                "autocast_other_cooldowns": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    },
-                    "full_description": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip",
-                    "full_description"
-                  ]
-                },
-                "wait": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "wait_until": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "scheduled_action": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    },
-                    "do_at": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip",
-                    "do_at"
-                  ]
-                },
-                "do_at": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "sequence": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    },
-                    "full_description": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip",
-                    "full_description"
-                  ]
-                },
-                "reset_sequence": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    },
-                    "full_description": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip",
-                    "full_description"
-                  ]
-                },
-                "strict_sequence": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    },
-                    "full_description": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip",
-                    "full_description"
-                  ]
-                },
-                "change_target": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "activate_aura": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "activate_aura_with_stacks": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    },
-                    "stacks": {
-                      "type": "string"
-                    },
-                    "stacks_tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip",
-                    "stacks",
-                    "stacks_tooltip"
-                  ]
-                },
-                "activate_all_stat_buff_proc_auras": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "cancel_aura": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "trigger_icd": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "damage_amplification": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    },
-                    "amount": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label"
-                      ]
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip",
-                    "amount"
-                  ]
-                },
-                "item_swap": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "move": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    },
-                    "to_range": {
-                      "type": "string"
-                    },
-                    "to_range_tooltip": {
-                      "type": "string"
-                    },
-                    "move_duration": {
-                      "type": "string"
-                    },
-                    "duration": {
-                      "type": "string"
-                    },
-                    "duration_tooltip": {
-                      "type": "string"
-                    },
-                    "move_duration_tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip",
-                    "to_range",
-                    "to_range_tooltip",
-                    "move_duration",
-                    "duration",
-                    "duration_tooltip",
-                    "move_duration_tooltip"
-                  ]
-                },
-                "custom_rotation": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "optimal_rotation_action": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    },
-                    "wrath_weave": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip",
-                    "wrath_weave"
-                  ]
-                },
-                "guardian_hotw_dps_rotation": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "warlock_next_exhale_target": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "cast",
-                "cancel_cast",
-                "cast_at_player",
-                "multi_dot",
-                "strict_multi_dot",
-                "multi_shield",
-                "channel",
-                "cast_all_stat_buff_cooldowns",
-                "autocast_other_cooldowns",
-                "wait",
-                "wait_until",
-                "scheduled_action",
-                "do_at",
-                "sequence",
-                "reset_sequence",
-                "strict_sequence",
-                "change_target",
-                "activate_aura",
-                "activate_aura_with_stacks",
-                "activate_all_stat_buff_proc_auras",
-                "cancel_aura",
-                "trigger_icd",
-                "damage_amplification",
-                "item_swap",
-                "move",
-                "custom_rotation",
-                "optimal_rotation_action",
-                "guardian_hotw_dps_rotation",
-                "warlock_next_exhale_target"
-              ]
-            },
-            "values": {
-              "type": "object",
-              "properties": {
-                "item_label": {
-                  "type": "string"
-                },
-                "no_condition": {
-                  "type": "string"
-                },
-                "none": {
-                  "type": "string"
-                },
-                "const": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    },
-                    "full_description": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip",
-                    "full_description"
-                  ]
-                },
-                "compare": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "math": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "max": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "min": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "all_of": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "any_of": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "not": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "current_time": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "current_time_percent": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "remaining_time": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "remaining_time_percent": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "is_execute_phase": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "num_targets": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "spell_is_casting": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "spell_time_to_ready": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "in_front_of_target": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "boss_cast": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "boss_cast_time_to_ready": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "boss_current_target": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "unit_is_moving": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "distance_to_unit": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "current_health": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "current_health_percent": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "max_health": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "current_mana": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "current_mana_percent": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "current_rage": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "max_rage": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "current_focus": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "max_focus": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "focus_regen_per_second": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "estimated_time_to_target_focus": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "current_energy": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "max_energy": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "energy_regen_per_second": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "estimated_time_to_target_energy": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "current_combo_points": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "max_combo_points": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "current_chi": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "max_chi": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "current_runic_power": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "max_runic_power": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "solar_energy": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "lunar_energy": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "current_eclipse_phase": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "generic_resource": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "num_runes": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "num_non_death_runes": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "rune_is_ready": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "rune_is_death": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "rune_cooldown": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "next_rune_cooldown": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "rune_slot_cooldown": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "full_rune_cooldown": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "gcd_is_ready": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "gcd_time_to_ready": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "time_to_next_auto": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "remaining_cast_time": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "spell_known": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "current_cost": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "can_cast": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    },
-                    "full_description": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip",
-                    "full_description"
-                  ]
-                },
-                "is_ready": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "time_to_ready": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "cast_time": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "travel_time": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "cpm": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "is_casting": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "is_channeling": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "channeled_ticks": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "number_of_charges": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "time_to_next_charge": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "gcd_hasted_duration": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "full_cooldown": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "channel_clip_delay": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "input_delay": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "spell_in_flight": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "aura_known": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "aura_active": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "aura_active_with_reaction_time": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "aura_inactive": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "aura_inactive_with_reaction_time": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "aura_remaining_time": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "aura_num_stacks": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "aura_should_refresh": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    },
-                    "full_description": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip",
-                    "full_description"
-                  ]
-                },
-                "all_trinket_stat_procs_active": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    },
-                    "full_description": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip",
-                    "full_description"
-                  ]
-                },
-                "any_trinket_stat_procs_active": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    },
-                    "full_description": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip",
-                    "full_description"
-                  ]
-                },
-                "any_trinket_stat_procs_available": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "trinket_procs_min_remaining_time": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "trinket_procs_max_remaining_icd": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "num_equipped_stat_proc_trinkets": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "num_stat_buff_cooldowns": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    },
-                    "full_description": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip",
-                    "full_description"
-                  ]
-                },
-                "any_stat_buff_cooldowns_active": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    },
-                    "full_description": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip",
-                    "full_description"
-                  ]
-                },
-                "any_stat_buff_cooldowns_min_duration": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "dot_is_active": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "dot_is_active_on_all_targets": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "dot_remaining_time": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "dot_lowest_remaining_time": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "dot_tick_frequency": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "dot_time_to_next_tick": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "dot_percent_increase": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "sequence_is_complete": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "sequence_is_ready": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "sequence_time_to_ready": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "totem_remaining_time": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "shaman_fire_elemental_duration": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "cat_excess_energy": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "cat_new_savage_roar_duration": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "warlock_hand_of_guldan_in_flight": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "warlock_haunt_in_flight": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "affliction_current_snapshot": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "affliction_exhale_window": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "mage_current_combustion_dot_estimate": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "brewmaster_monk_current_stagger_percent": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "protection_paladin_damage_taken_last_global": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "aura_remaining_icd": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "aura_icd_is_ready": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "aura_icd_is_ready_with_reaction_time": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "overlap": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "item_label",
-                "no_condition",
-                "none",
-                "const",
-                "compare",
-                "math",
-                "max",
-                "min",
-                "all_of",
-                "any_of",
-                "not",
-                "current_time",
-                "current_time_percent",
-                "remaining_time",
-                "remaining_time_percent",
-                "is_execute_phase",
-                "num_targets",
-                "spell_is_casting",
-                "spell_time_to_ready",
-                "in_front_of_target",
-                "boss_cast",
-                "boss_cast_time_to_ready",
-                "boss_current_target",
-                "unit_is_moving",
-                "distance_to_unit",
-                "current_health",
-                "current_health_percent",
-                "max_health",
-                "current_mana",
-                "current_mana_percent",
-                "current_rage",
-                "max_rage",
-                "current_focus",
-                "max_focus",
-                "focus_regen_per_second",
-                "estimated_time_to_target_focus",
-                "current_energy",
-                "max_energy",
-                "energy_regen_per_second",
-                "estimated_time_to_target_energy",
-                "current_combo_points",
-                "max_combo_points",
-                "current_chi",
-                "max_chi",
-                "current_runic_power",
-                "max_runic_power",
-                "solar_energy",
-                "lunar_energy",
-                "current_eclipse_phase",
-                "generic_resource",
-                "num_runes",
-                "num_non_death_runes",
-                "rune_is_ready",
-                "rune_is_death",
-                "rune_cooldown",
-                "next_rune_cooldown",
-                "rune_slot_cooldown",
-                "full_rune_cooldown",
-                "gcd_is_ready",
-                "gcd_time_to_ready",
-                "time_to_next_auto",
-                "remaining_cast_time",
-                "spell_known",
-                "current_cost",
-                "can_cast",
-                "is_ready",
-                "time_to_ready",
-                "cast_time",
-                "travel_time",
-                "cpm",
-                "is_casting",
-                "is_channeling",
-                "channeled_ticks",
-                "number_of_charges",
-                "time_to_next_charge",
-                "gcd_hasted_duration",
-                "full_cooldown",
-                "channel_clip_delay",
-                "input_delay",
-                "spell_in_flight",
-                "aura_known",
-                "aura_active",
-                "aura_active_with_reaction_time",
-                "aura_inactive",
-                "aura_inactive_with_reaction_time",
-                "aura_remaining_time",
-                "aura_num_stacks",
-                "aura_should_refresh",
-                "all_trinket_stat_procs_active",
-                "any_trinket_stat_procs_active",
-                "any_trinket_stat_procs_available",
-                "trinket_procs_min_remaining_time",
-                "trinket_procs_max_remaining_icd",
-                "num_equipped_stat_proc_trinkets",
-                "num_stat_buff_cooldowns",
-                "any_stat_buff_cooldowns_active",
-                "any_stat_buff_cooldowns_min_duration",
-                "dot_is_active",
-                "dot_is_active_on_all_targets",
-                "dot_remaining_time",
-                "dot_lowest_remaining_time",
-                "dot_tick_frequency",
-                "dot_time_to_next_tick",
-                "dot_percent_increase",
-                "sequence_is_complete",
-                "sequence_is_ready",
-                "sequence_time_to_ready",
-                "totem_remaining_time",
-                "shaman_fire_elemental_duration",
-                "cat_excess_energy",
-                "cat_new_savage_roar_duration",
-                "warlock_hand_of_guldan_in_flight",
-                "warlock_haunt_in_flight",
-                "affliction_current_snapshot",
-                "affliction_exhale_window",
-                "mage_current_combustion_dot_estimate",
-                "brewmaster_monk_current_stagger_percent",
-                "protection_paladin_damage_taken_last_global",
-                "aura_remaining_icd",
-                "aura_icd_is_ready",
-                "aura_icd_is_ready_with_reaction_time",
-                "overlap"
-              ]
-            },
-            "operators": {
-              "type": "object",
-              "properties": {
-                "equals": {
-                  "type": "string"
-                },
-                "not_equals": {
-                  "type": "string"
-                },
-                "greater_than_or_equal": {
-                  "type": "string"
-                },
-                "greater_than": {
-                  "type": "string"
-                },
-                "less_than_or_equal": {
-                  "type": "string"
-                },
-                "less_than": {
-                  "type": "string"
-                },
-                "add": {
-                  "type": "string"
-                },
-                "subtract": {
-                  "type": "string"
-                },
-                "multiply": {
-                  "type": "string"
-                },
-                "divide": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "equals",
-                "not_equals",
-                "greater_than_or_equal",
-                "greater_than",
-                "less_than_or_equal",
-                "less_than",
-                "add",
-                "subtract",
-                "multiply",
-                "divide"
-              ]
-            },
-            "execute_phases": {
-              "type": "object",
-              "properties": {
-                "e20": {
-                  "type": "string"
-                },
-                "e25": {
-                  "type": "string"
-                },
-                "e35": {
-                  "type": "string"
-                },
-                "e45": {
-                  "type": "string"
-                },
-                "e90": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "e20",
-                "e25",
-                "e35",
-                "e45",
-                "e90"
-              ]
-            },
-            "totem_types": {
-              "type": "object",
-              "properties": {
-                "earth": {
-                  "type": "string"
-                },
-                "air": {
-                  "type": "string"
-                },
-                "fire": {
-                  "type": "string"
-                },
-                "water": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "earth",
-                "air",
-                "fire",
-                "water"
-              ]
-            },
-            "submenus": {
-              "type": "object",
-              "properties": {
-                "logic": {
-                  "type": "string"
-                },
-                "encounter": {
-                  "type": "string"
-                },
-                "boss": {
-                  "type": "string"
-                },
-                "unit": {
-                  "type": "string"
-                },
-                "resources": {
-                  "type": "string"
-                },
-                "gcd": {
-                  "type": "string"
-                },
-                "auto": {
-                  "type": "string"
-                },
-                "spell": {
-                  "type": "string"
-                },
-                "aura": {
-                  "type": "string"
-                },
-                "aura_sets": {
-                  "type": "string"
-                },
-                "dot": {
-                  "type": "string"
-                },
-                "sequence": {
-                  "type": "string"
-                },
-                "casting": {
-                  "type": "string"
-                },
-                "timing": {
-                  "type": "string"
-                },
-                "sequences": {
-                  "type": "string"
-                },
-                "misc": {
-                  "type": "string"
-                },
-                "feral_druid": {
-                  "type": "string"
-                },
-                "guardian_druid": {
-                  "type": "string"
-                },
-                "shaman": {
-                  "type": "string"
-                },
-                "warlock": {
-                  "type": "string"
-                },
-                "mage": {
-                  "type": "string"
-                },
-                "tank": {
-                  "type": "string"
-                },
-                "health": {
-                  "type": "string"
-                },
-                "mana": {
-                  "type": "string"
-                },
-                "rage": {
-                  "type": "string"
-                },
-                "focus": {
-                  "type": "string"
-                },
-                "energy": {
-                  "type": "string"
-                },
-                "combo_points": {
-                  "type": "string"
-                },
-                "chi": {
-                  "type": "string"
-                },
-                "runic_power": {
-                  "type": "string"
-                },
-                "eclipse": {
-                  "type": "string"
-                },
-                "runes": {
-                  "type": "string"
-                },
-                "cooldowns": {
-                  "type": "string"
-                },
-                "non_combat_potions": {
-                  "type": "string"
-                },
-                "placeholders": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "logic",
-                "encounter",
-                "boss",
-                "unit",
-                "resources",
-                "gcd",
-                "auto",
-                "spell",
-                "aura",
-                "aura_sets",
-                "dot",
-                "sequence",
-                "casting",
-                "timing",
-                "sequences",
-                "misc",
-                "feral_druid",
-                "guardian_druid",
-                "shaman",
-                "warlock",
-                "mage",
-                "tank",
-                "health",
-                "mana",
-                "rage",
-                "focus",
-                "energy",
-                "combo_points",
-                "chi",
-                "runic_power",
-                "eclipse",
-                "runes",
-                "cooldowns",
-                "non_combat_potions",
-                "placeholders"
-              ]
-            },
-            "item_swap_sets": {
-              "type": "object",
-              "properties": {
-                "main": {
-                  "type": "string"
-                },
-                "swapped": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "main",
-                "swapped"
-              ]
-            },
-            "helpers": {
-              "type": "object",
-              "properties": {
-                "action_id_sets": {
-                  "type": "object",
-                  "properties": {
-                    "auras": {
-                      "type": "string"
-                    },
-                    "stackable_auras": {
-                      "type": "string"
-                    },
-                    "icd_auras": {
-                      "type": "string"
-                    },
-                    "exclusive_effect_auras": {
-                      "type": "string"
-                    },
-                    "spells": {
-                      "type": "string"
-                    },
-                    "castable_spells": {
-                      "type": "string"
-                    },
-                    "channel_spells": {
-                      "type": "string"
-                    },
-                    "dot_spells": {
-                      "type": "string"
-                    },
-                    "castable_dot_spells": {
-                      "type": "string"
-                    },
-                    "shield_spells": {
-                      "type": "string"
-                    },
-                    "non_instant_spells": {
-                      "type": "string"
-                    },
-                    "friendly_spells": {
-                      "type": "string"
-                    },
-                    "expected_dot_spells": {
-                      "type": "string"
-                    },
-                    "spells_with_travelTime": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "auras",
-                    "stackable_auras",
-                    "icd_auras",
-                    "exclusive_effect_auras",
-                    "spells",
-                    "castable_spells",
-                    "channel_spells",
-                    "dot_spells",
-                    "castable_dot_spells",
-                    "shield_spells",
-                    "non_instant_spells",
-                    "friendly_spells",
-                    "expected_dot_spells",
-                    "spells_with_travelTime"
-                  ]
-                },
-                "field_configs": {
-                  "type": "object",
-                  "properties": {
-                    "type": {
-                      "type": "string"
-                    },
-                    "strategy": {
-                      "type": "string"
-                    },
-                    "buff_type": {
-                      "type": "string"
-                    },
-                    "min_icd": {
-                      "type": "string"
-                    },
-                    "min_icd_tooltip": {
-                      "type": "string"
-                    },
-                    "include_reaction_time": {
-                      "type": "string"
-                    },
-                    "include_reaction_time_tooltip": {
-                      "type": "string"
-                    },
-                    "use_base_value": {
-                      "type": "string"
-                    },
-                    "use_base_value_tooltip": {
-                      "type": "string"
-                    },
-                    "variable_assignment_tooltip": {
-                      "type": "string"
-                    },
-                    "amplification_type": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "type",
-                    "strategy",
-                    "buff_type",
-                    "min_icd",
-                    "min_icd_tooltip",
-                    "include_reaction_time",
-                    "include_reaction_time_tooltip",
-                    "use_base_value",
-                    "use_base_value_tooltip",
-                    "variable_assignment_tooltip",
-                    "amplification_type"
-                  ]
-                },
-                "eclipse_types": {
-                  "type": "object",
-                  "properties": {
-                    "lunar": {
-                      "type": "string"
-                    },
-                    "solar": {
-                      "type": "string"
-                    },
-                    "neutral": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "lunar",
-                    "solar",
-                    "neutral"
-                  ]
-                },
-                "rune_types": {
-                  "type": "object",
-                  "properties": {
-                    "blood": {
-                      "type": "string"
-                    },
-                    "frost": {
-                      "type": "string"
-                    },
-                    "unholy": {
-                      "type": "string"
-                    },
-                    "death": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "blood",
-                    "frost",
-                    "unholy",
-                    "death"
-                  ]
-                },
-                "rune_slots": {
-                  "type": "object",
-                  "properties": {
-                    "blood_left": {
-                      "type": "string"
-                    },
-                    "blood_right": {
-                      "type": "string"
-                    },
-                    "frost_left": {
-                      "type": "string"
-                    },
-                    "frost_right": {
-                      "type": "string"
-                    },
-                    "unholy_left": {
-                      "type": "string"
-                    },
-                    "unholy_right": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "blood_left",
-                    "blood_right",
-                    "frost_left",
-                    "frost_right",
-                    "unholy_left",
-                    "unholy_right"
-                  ]
-                },
-                "rotation_types": {
-                  "type": "object",
-                  "properties": {
-                    "single_target": {
-                      "type": "string"
-                    },
-                    "aoe": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "single_target",
-                    "aoe"
-                  ]
-                },
-                "hotw_strategies": {
-                  "type": "object",
-                  "properties": {
-                    "caster": {
-                      "type": "string"
-                    },
-                    "cat": {
-                      "type": "string"
-                    },
-                    "hybrid": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "caster",
-                    "cat",
-                    "hybrid"
-                  ]
-                },
-                "amplification_types": {
-                  "type": "object",
-                  "properties": {
-                    "caster_buff": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    },
-                    "environment_buff": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    },
-                    "target_debuff": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "caster_buff",
-                    "environment_buff",
-                    "target_debuff"
-                  ]
-                },
-                "unit_labels": {
-                  "type": "object",
-                  "properties": {
-                    "self": {
-                      "type": "string"
-                    },
-                    "current_target": {
-                      "type": "string"
-                    },
-                    "previous_target": {
-                      "type": "string"
-                    },
-                    "next_target": {
-                      "type": "string"
-                    },
-                    "player": {
-                      "type": "string"
-                    },
-                    "target": {
-                      "type": "string"
-                    },
-                    "pet": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "self",
-                    "current_target",
-                    "previous_target",
-                    "next_target",
-                    "player",
-                    "target",
-                    "pet"
-                  ]
-                },
-                "placeholder_tooltip": {
-                  "type": "string"
-                },
-                "select_variable": {
-                  "type": "string"
-                },
-                "select_group": {
-                  "type": "string"
-                },
-                "no_variables_defined": {
-                  "type": "string"
-                },
-                "no_groups_defined": {
-                  "type": "string"
-                },
-                "buttons": {
-                  "type": "object",
-                  "properties": {
-                    "enable_action": {
-                      "type": "string"
-                    },
-                    "disable_action": {
-                      "type": "string"
-                    },
-                    "enable_disable": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "enable_action",
-                    "disable_action",
-                    "enable_disable"
-                  ]
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "action_id_sets",
-                "field_configs",
-                "eclipse_types",
-                "rune_types",
-                "rune_slots",
-                "rotation_types",
-                "hotw_strategies",
-                "amplification_types",
-                "unit_labels",
-                "placeholder_tooltip",
-                "select_variable",
-                "select_group",
-                "no_variables_defined",
-                "no_groups_defined",
-                "buttons"
-              ]
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "actionGroups",
-            "floatingActionBar",
-            "nameModal",
-            "prePullActions",
-            "priorityList",
-            "tabs",
-            "variables",
-            "variablePlaceholder",
-            "prepull_actions",
-            "priority_list",
-            "actions",
-            "values",
-            "operators",
-            "execute_phases",
-            "totem_types",
-            "submenus",
-            "item_swap_sets",
-            "helpers"
-          ]
-        },
-        "auto": {
-          "type": "object",
-          "properties": {
-            "description": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "description"
-          ]
-        },
-        "simple": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title"
-          ]
-        },
-        "cooldowns": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "tooltip": {
-              "type": "string"
-            },
-            "delete_tooltip": {
-              "type": "string"
-            },
-            "timings_placeholder": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "tooltip",
-            "delete_tooltip",
-            "timings_placeholder"
-          ]
-        },
-        "saved_rotations": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "label": {
-              "type": "string"
-            },
-            "name_label": {
-              "type": "string"
-            },
-            "save_button": {
-              "type": "string"
-            },
-            "delete": {
-              "type": "object",
-              "properties": {
-                "confirm": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "confirm",
-                "tooltip"
-              ]
-            },
-            "alerts": {
-              "type": "object",
-              "properties": {
-                "choose_name": {
-                  "type": "string"
-                },
-                "name_exists": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "choose_name",
-                "name_exists"
-              ]
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "label",
-            "name_label",
-            "save_button",
-            "delete",
-            "alerts"
-          ]
-        },
-        "options": {
-          "type": "object",
-          "properties": {
-            "druid": {
-              "type": "object",
-              "properties": {
-                "feral": {
-                  "type": "object",
-                  "properties": {
-                    "target_type": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "single_target": {
-                          "type": "string"
-                        },
-                        "aoe": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "single_target",
-                        "aoe"
-                      ]
-                    },
-                    "bear_weave": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    },
-                    "snek_weave": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    },
-                    "use_ns": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    },
-                    "manual_params": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    },
-                    "hotw_strategy": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        },
-                        "values": {
-                          "type": "object",
-                          "properties": {
-                            "passives_only": {
-                              "type": "string"
-                            },
-                            "enhanced_bear_weaving": {
-                              "type": "string"
-                            },
-                            "wrath_weaving": {
-                              "type": "string"
-                            }
-                          },
-                          "additionalProperties": false,
-                          "required": [
-                            "passives_only",
-                            "enhanced_bear_weaving",
-                            "wrath_weaving"
-                          ]
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip",
-                        "values"
-                      ]
-                    },
-                    "allow_aoe_berserk": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    },
-                    "roar_offset": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    },
-                    "rip_leeway": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    },
-                    "bite_during_rotation": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    },
-                    "bite_time": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    },
-                    "berserk_bite_time": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "target_type",
-                    "bear_weave",
-                    "snek_weave",
-                    "use_ns",
-                    "manual_params",
-                    "hotw_strategy",
-                    "allow_aoe_berserk",
-                    "roar_offset",
-                    "rip_leeway",
-                    "bite_during_rotation",
-                    "bite_time",
-                    "berserk_bite_time"
-                  ]
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "feral"
-              ]
-            },
-            "guardian": {
-              "type": "object",
-              "properties": {
-                "maintain_faerie_fire": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "maintain_demo_roar": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "demo_roar_refresh_leeway": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "pulverize_refresh_leeway": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "maintain_faerie_fire",
-                "maintain_demo_roar",
-                "demo_roar_refresh_leeway",
-                "pulverize_refresh_leeway"
-              ]
-            },
-            "rogue": {
-              "type": "object",
-              "properties": {
-                "apply_poisons_manually": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "subtlety": {
-                  "type": "object",
-                  "properties": {
-                    "honor_of_thieves_crit_rate": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "honor_of_thieves_crit_rate"
-                  ]
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "apply_poisons_manually",
-                "subtlety"
-              ]
-            },
-            "shaman": {
-              "type": "object",
-              "properties": {
-                "elemental": {
-                  "type": "object",
-                  "properties": {
-                    "thunderstorm_in_range": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "thunderstorm_in_range"
-                  ]
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "elemental"
-              ]
-            },
-            "warlock": {
-              "type": "object",
-              "properties": {
-                "affliction": {
-                  "type": "object",
-                  "properties": {
-                    "exhale_window": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "exhale_window"
-                  ]
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "affliction"
-              ]
-            },
-            "hunter": {
-              "type": "object",
-              "properties": {
-                "beast_mastery": {
-                  "type": "object",
-                  "properties": {
-                    "sting": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        },
-                        "values": {
-                          "type": "object",
-                          "properties": {
-                            "none": {
-                              "type": "string"
-                            },
-                            "serpent_sting": {
-                              "type": "string"
-                            }
-                          },
-                          "additionalProperties": false,
-                          "required": [
-                            "none",
-                            "serpent_sting"
-                          ]
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip",
-                        "values"
-                      ]
-                    },
-                    "trap_weave": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    },
-                    "multi_dot_serpent_sting": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "sting",
-                    "trap_weave",
-                    "multi_dot_serpent_sting"
-                  ]
-                },
-                "marksmanship": {
-                  "type": "object",
-                  "properties": {
-                    "sting": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        },
-                        "values": {
-                          "type": "object",
-                          "properties": {
-                            "none": {
-                              "type": "string"
-                            },
-                            "serpent_sting": {
-                              "type": "string"
-                            }
-                          },
-                          "additionalProperties": false,
-                          "required": [
-                            "none",
-                            "serpent_sting"
-                          ]
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip",
-                        "values"
-                      ]
-                    },
-                    "trap_weave": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    },
-                    "multi_dot_serpent_sting": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "sting",
-                    "trap_weave",
-                    "multi_dot_serpent_sting"
-                  ]
-                },
-                "survival": {
-                  "type": "object",
-                  "properties": {
-                    "multi_dot_serpent_sting": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "multi_dot_serpent_sting"
-                  ]
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "beast_mastery",
-                "marksmanship",
-                "survival"
-              ]
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "druid",
-            "guardian",
-            "rogue",
-            "shaman",
-            "warlock",
-            "hunter"
-          ]
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "title",
-        "common",
-        "apl",
-        "auto",
-        "simple",
-        "cooldowns",
-        "saved_rotations",
-        "options"
-      ]
-    },
-    "results_tab": {
-      "type": "object",
-      "properties": {
-        "title": {
-          "type": "string"
-        },
-        "details": {
-          "type": "object",
-          "properties": {
-            "no_results": {
-              "type": "string"
-            },
-            "view_in_separate_tab": {
-              "type": "string"
-            },
-            "sim_1_iteration": {
-              "type": "string"
-            },
-            "sim_1_death": {
-              "type": "string"
-            },
-            "all_targets": {
-              "type": "string"
-            },
-            "all_players": {
-              "type": "string"
-            },
-            "target_number": {
-              "type": "string"
-            },
-            "damage": {
-              "type": "object",
-              "properties": {
-                "dps_histogram": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "dps_histogram"
-              ]
-            },
-            "timeline": {
-              "type": "object",
-              "properties": {
-                "disclaimer": {
-                  "type": "string"
-                },
-                "note": {
-                  "type": "string"
-                },
-                "chart_types": {
-                  "type": "object",
-                  "properties": {
-                    "rotation": {
-                      "type": "string"
-                    },
-                    "dps": {
-                      "type": "string"
-                    },
-                    "threat": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "rotation",
-                    "dps",
-                    "threat"
-                  ]
-                },
-                "chart_options": {
-                  "type": "object",
-                  "properties": {
-                    "time_axis": {
-                      "type": "string"
-                    },
-                    "waiting_for_data": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "time_axis",
-                    "waiting_for_data"
-                  ]
-                },
-                "tooltips": {
-                  "type": "object",
-                  "properties": {
-                    "dps": {
-                      "type": "string"
-                    },
-                    "dtps": {
-                      "type": "string"
-                    },
-                    "amount": {
-                      "type": "string"
-                    },
-                    "player_damage": {
-                      "type": "string"
-                    },
-                    "player_damage_taken": {
-                      "type": "string"
-                    },
-                    "before": {
-                      "type": "string"
-                    },
-                    "after": {
-                      "type": "string"
-                    },
-                    "threat": {
-                      "type": "string"
-                    },
-                    "active_auras": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "dps",
-                    "dtps",
-                    "amount",
-                    "player_damage",
-                    "player_damage_taken",
-                    "before",
-                    "after",
-                    "threat",
-                    "active_auras"
-                  ]
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "disclaimer",
-                "note",
-                "chart_types",
-                "chart_options",
-                "tooltips"
-              ]
-            },
-            "logs": {
-              "type": "object",
-              "properties": {
-                "top_button": {
-                  "type": "string"
-                },
-                "time_column": {
-                  "type": "string"
-                },
-                "event_column": {
-                  "type": "string"
-                },
-                "show_debug": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "top_button",
-                "time_column",
-                "event_column",
-                "show_debug"
-              ]
-            },
-            "tabs": {
-              "type": "object",
-              "properties": {
-                "damage": {
-                  "type": "string"
-                },
-                "healing": {
-                  "type": "string"
-                },
-                "damage_taken": {
-                  "type": "string"
-                },
-                "buffs": {
-                  "type": "string"
-                },
-                "debuffs": {
-                  "type": "string"
-                },
-                "casts": {
-                  "type": "string"
-                },
-                "resources": {
-                  "type": "string"
-                },
-                "timeline": {
-                  "type": "string"
-                },
-                "replay": {
-                  "type": "string"
-                },
-                "log": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "damage",
-                "healing",
-                "damage_taken",
-                "buffs",
-                "debuffs",
-                "casts",
-                "resources",
-                "timeline",
-                "replay",
-                "log"
-              ]
-            },
-            "columns": {
-              "type": "object",
-              "properties": {
-                "damage_done": {
-                  "type": "string"
-                },
-                "casts": {
-                  "type": "string"
-                },
-                "avg_cast": {
-                  "type": "string"
-                },
-                "hits": {
-                  "type": "string"
-                },
-                "avg_hit": {
-                  "type": "string"
-                },
-                "crit_percent": {
-                  "type": "string"
-                },
-                "miss_percent": {
-                  "type": "string"
-                },
-                "dpet": {
-                  "type": "string"
-                },
-                "dps": {
-                  "type": "string"
-                },
-                "healing_done": {
-                  "type": "string"
-                },
-                "cpm": {
-                  "type": "string"
-                },
-                "cast_time": {
-                  "type": "string"
-                },
-                "hpm": {
-                  "type": "string"
-                },
-                "hpet": {
-                  "type": "string"
-                },
-                "amount": {
-                  "type": "string"
-                },
-                "dtps": {
-                  "type": "string"
-                },
-                "avg_heal": {
-                  "type": "string"
-                },
-                "hps": {
-                  "type": "string"
-                },
-                "damage_taken": {
-                  "type": "string"
-                },
-                "overhealing": {
-                  "type": "string"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "duration": {
-                  "type": "string"
-                },
-                "uptime": {
-                  "type": "string"
-                },
-                "procs": {
-                  "type": "string"
-                },
-                "ppm": {
-                  "type": "string"
-                },
-                "casts_per_minute": {
-                  "type": "string"
-                },
-                "mana_gain": {
-                  "type": "string"
-                },
-                "mana_cost": {
-                  "type": "string"
-                },
-                "rage_gain": {
-                  "type": "string"
-                },
-                "rage_cost": {
-                  "type": "string"
-                },
-                "energy_gain": {
-                  "type": "string"
-                },
-                "energy_cost": {
-                  "type": "string"
-                },
-                "focus_gain": {
-                  "type": "string"
-                },
-                "focus_cost": {
-                  "type": "string"
-                },
-                "runic_power_gain": {
-                  "type": "string"
-                },
-                "runic_power_cost": {
-                  "type": "string"
-                },
-                "chi_gain": {
-                  "type": "string"
-                },
-                "chi_cost": {
-                  "type": "string"
-                },
-                "holy_power_gain": {
-                  "type": "string"
-                },
-                "holy_power_cost": {
-                  "type": "string"
-                },
-                "shadow_orbs_gain": {
-                  "type": "string"
-                },
-                "shadow_orbs_cost": {
-                  "type": "string"
-                },
-                "combo_points_gain": {
-                  "type": "string"
-                },
-                "combo_points_cost": {
-                  "type": "string"
-                },
-                "maelstrom_gain": {
-                  "type": "string"
-                },
-                "maelstrom_cost": {
-                  "type": "string"
-                },
-                "demonic_fury_gain": {
-                  "type": "string"
-                },
-                "demonic_fury_cost": {
-                  "type": "string"
-                },
-                "burning_embers_gain": {
-                  "type": "string"
-                },
-                "burning_embers_cost": {
-                  "type": "string"
-                },
-                "gain": {
-                  "type": "string"
-                },
-                "gain_per_second": {
-                  "type": "string"
-                },
-                "avg_gain": {
-                  "type": "string"
-                },
-                "wasted_gain": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "damage_done",
-                "casts",
-                "avg_cast",
-                "hits",
-                "avg_hit",
-                "crit_percent",
-                "miss_percent",
-                "dpet",
-                "dps",
-                "healing_done",
-                "cpm",
-                "cast_time",
-                "hpm",
-                "hpet",
-                "amount",
-                "dtps",
-                "avg_heal",
-                "hps",
-                "damage_taken",
-                "overhealing",
-                "name",
-                "duration",
-                "uptime",
-                "procs",
-                "ppm",
-                "casts_per_minute",
-                "mana_gain",
-                "mana_cost",
-                "rage_gain",
-                "rage_cost",
-                "energy_gain",
-                "energy_cost",
-                "focus_gain",
-                "focus_cost",
-                "runic_power_gain",
-                "runic_power_cost",
-                "chi_gain",
-                "chi_cost",
-                "holy_power_gain",
-                "holy_power_cost",
-                "shadow_orbs_gain",
-                "shadow_orbs_cost",
-                "combo_points_gain",
-                "combo_points_cost",
-                "maelstrom_gain",
-                "maelstrom_cost",
-                "demonic_fury_gain",
-                "demonic_fury_cost",
-                "burning_embers_gain",
-                "burning_embers_cost",
-                "gain",
-                "gain_per_second",
-                "avg_gain",
-                "wasted_gain"
-              ]
-            },
-            "tooltips": {
-              "type": "object",
-              "properties": {
-                "damage_avg_cast": {
-                  "type": "string"
-                },
-                "player_damage": {
-                  "type": "string"
-                },
-                "player_damage_taken": {
-                  "type": "string"
-                },
-                "damage_taken_per_encounter": {
-                  "type": "string"
-                },
-                "healing_per_encounter": {
-                  "type": "string"
-                },
-                "threat_per_encounter": {
-                  "type": "string"
-                },
-                "damage_taken": {
-                  "type": "string"
-                },
-                "damage_per_encounter": {
-                  "type": "string"
-                },
-                "damage_avg_cast_tooltip": {
-                  "type": "string"
-                },
-                "healing_avg_cast_tooltip": {
-                  "type": "string"
-                },
-                "healing_avg_hit_tooltip": {
-                  "type": "string"
-                },
-                "healing_hits_tooltip": {
-                  "type": "string"
-                },
-                "hit_miss_percent_tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "damage_avg_cast",
-                "player_damage",
-                "player_damage_taken",
-                "damage_taken_per_encounter",
-                "healing_per_encounter",
-                "threat_per_encounter",
-                "damage_taken",
-                "damage_per_encounter",
-                "damage_avg_cast_tooltip",
-                "healing_avg_cast_tooltip",
-                "healing_avg_hit_tooltip",
-                "healing_hits_tooltip",
-                "hit_miss_percent_tooltip"
-              ]
-            },
-            "attack_types": {
-              "type": "object",
-              "properties": {
-                "hit": {
-                  "type": "string"
-                },
-                "critical_hit": {
-                  "type": "string"
-                },
-                "tick": {
-                  "type": "string"
-                },
-                "critical_tick": {
-                  "type": "string"
-                },
-                "glancing_blow": {
-                  "type": "string"
-                },
-                "blocked_glancing_blow": {
-                  "type": "string"
-                },
-                "blocked_hit": {
-                  "type": "string"
-                },
-                "blocked_critical_hit": {
-                  "type": "string"
-                },
-                "miss": {
-                  "type": "string"
-                },
-                "parry": {
-                  "type": "string"
-                },
-                "dodge": {
-                  "type": "string"
-                },
-                "threat": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "hit",
-                "critical_hit",
-                "tick",
-                "critical_tick",
-                "glancing_blow",
-                "blocked_glancing_blow",
-                "blocked_hit",
-                "blocked_critical_hit",
-                "miss",
-                "parry",
-                "dodge",
-                "threat"
-              ]
-            },
-            "tooltip_table": {
-              "type": "object",
-              "properties": {
-                "type": {
-                  "type": "string"
-                },
-                "count": {
-                  "type": "string"
-                },
-                "average": {
-                  "type": "string"
-                },
-                "amount": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "type",
-                "count",
-                "average",
-                "amount"
-              ]
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "no_results",
-            "view_in_separate_tab",
-            "sim_1_iteration",
-            "sim_1_death",
-            "all_targets",
-            "all_players",
-            "target_number",
-            "damage",
-            "timeline",
-            "logs",
-            "tabs",
-            "columns",
-            "tooltips",
-            "attack_types",
-            "tooltip_table"
-          ]
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "title",
-        "details"
-      ]
-    },
-    "import": {
-      "type": "object",
-      "properties": {
-        "title": {
-          "type": "string"
-        },
-        "json": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "instructions": {
-              "type": "string"
-            },
-            "upload_button": {
-              "type": "string"
-            },
-            "import_button": {
-              "type": "string"
-            },
-            "error_invalid_json": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "description",
-            "instructions",
-            "upload_button",
-            "import_button",
-            "error_invalid_json"
-          ]
-        },
-        "wowhead": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "gear_planner_link": {
-              "type": "string"
-            },
-            "feature_description": {
-              "type": "string"
-            },
-            "instructions": {
-              "type": "string"
-            },
-            "upload_button": {
-              "type": "string"
-            },
-            "import_button": {
-              "type": "string"
-            },
-            "tinker_warning": {
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "message": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "title",
-                "message"
-              ]
-            },
-            "error_invalid_url": {
-              "type": "string"
-            },
-            "error_cannot_parse_class": {
-              "type": "string"
-            },
-            "error_cannot_parse_race": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "description",
-            "gear_planner_link",
-            "feature_description",
-            "instructions",
-            "upload_button",
-            "import_button",
-            "tinker_warning",
-            "error_invalid_url",
-            "error_cannot_parse_class",
-            "error_cannot_parse_race"
-          ]
-        },
-        "addon": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "addon_link": {
-              "type": "string"
-            },
-            "feature_description": {
-              "type": "string"
-            },
-            "instructions": {
-              "type": "string"
-            },
-            "upload_button": {
-              "type": "string"
-            },
-            "import_button": {
-              "type": "string"
-            },
-            "reforge_warning": {
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "message": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "title",
-                "message"
-              ]
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "description",
-            "addon_link",
-            "feature_description",
-            "instructions",
-            "upload_button",
-            "import_button",
-            "reforge_warning"
-          ]
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "title",
-        "json",
-        "wowhead",
-        "addon"
-      ]
-    },
-    "export": {
-      "type": "object",
-      "properties": {
-        "title": {
-          "type": "string"
-        },
-        "link": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "instructions": {
-              "type": "string"
-            },
-            "copy_button": {
-              "type": "string"
-            },
-            "copy_tooltip": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "description",
-            "instructions",
-            "copy_button",
-            "copy_tooltip"
-          ]
-        },
-        "json": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "instructions": {
-              "type": "string"
-            },
-            "copy_button": {
-              "type": "string"
-            },
-            "copy_tooltip": {
-              "type": "string"
-            },
-            "download_button": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "description",
-            "instructions",
-            "copy_button",
-            "copy_tooltip",
-            "download_button"
-          ]
-        },
-        "wowhead": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "instructions": {
-              "type": "string"
-            },
-            "copy_button": {
-              "type": "string"
-            },
-            "copy_tooltip": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "description",
-            "instructions",
-            "copy_button",
-            "copy_tooltip"
-          ]
-        },
-        "pawn_ep": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "instructions": {
-              "type": "string"
-            },
-            "copy_button": {
-              "type": "string"
-            },
-            "copy_tooltip": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "description",
-            "instructions",
-            "copy_button",
-            "copy_tooltip"
-          ]
-        },
-        "cli": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "instructions": {
-              "type": "string"
-            },
-            "copy_button": {
-              "type": "string"
-            },
-            "copy_tooltip": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "description",
-            "instructions",
-            "copy_button",
-            "copy_tooltip"
-          ]
-        },
-        "categories": {
-          "type": "object",
-          "properties": {
-            "gear": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "talents": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "rotation": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "consumes": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "external": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "miscellaneous": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "encounter": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "gear",
-            "talents",
-            "rotation",
-            "consumes",
-            "external",
-            "miscellaneous",
-            "encounter"
-          ]
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "title",
-        "link",
-        "json",
-        "wowhead",
-        "pawn_ep",
-        "cli",
-        "categories"
-      ]
-    },
-    "info": {
-      "type": "object",
-      "properties": {
-        "known_issues": {
-          "type": "string"
-        },
-        "bug_report": {
-          "type": "string"
-        },
-        "sim_options": {
-          "type": "string"
-        },
-        "discord": {
-          "type": "string"
-        },
-        "patreon": {
-          "type": "string"
-        },
-        "github": {
-          "type": "string"
-        },
-        "status": {
-          "type": "object",
-          "properties": {
-            "unlaunched": {
-              "type": "string"
-            },
-            "alpha": {
-              "type": "string"
-            },
-            "beta": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "unlaunched",
-            "alpha",
-            "beta"
-          ]
-        },
-        "options": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "fixed_rng_seed": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                },
-                "last_used": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip",
-                "last_used"
-              ]
-            },
-            "language": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label",
-                "tooltip"
-              ]
-            },
-            "feature_toggles": {
-              "type": "object",
-              "properties": {
-                "show_threat_metrics": {
-                  "type": "string"
-                },
-                "show_experimental": {
-                  "type": "string"
-                },
-                "show_quick_swap": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "show_threat_metrics",
-                "show_experimental",
-                "show_quick_swap"
-              ]
-            },
-            "use_multiple_cpu_cores": {
-              "type": "object",
-              "properties": {
-                "label": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "label"
-              ]
-            },
-            "restore_defaults": {
-              "type": "object",
-              "properties": {
-                "button": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                },
-                "success_message": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "button",
-                "tooltip",
-                "success_message"
-              ]
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "fixed_rng_seed",
-            "language",
-            "feature_toggles",
-            "use_multiple_cpu_cores",
-            "restore_defaults"
-          ]
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "known_issues",
-        "bug_report",
-        "sim_options",
-        "discord",
-        "patreon",
-        "github",
-        "status",
-        "options"
-      ]
-    },
-    "sidebar": {
-      "type": "object",
-      "properties": {
-        "iterations": {
-          "type": "string"
-        },
-        "warnings": {
-          "type": "object",
-          "properties": {
-            "meta_gem_disabled": {
-              "type": "string"
-            },
-            "profession_requirement": {
-              "type": "string"
-            },
-            "too_many_jc_gems": {
-              "type": "string"
-            },
-            "unspent_talent_points": {
-              "type": "string"
-            },
-            "armor_specialization": {
-              "type": "string"
-            },
-            "dual_wield_2h_without_titans_grip": {
-              "type": "string"
-            },
-            "shaman_fele_autocast": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "meta_gem_disabled",
-            "profession_requirement",
-            "too_many_jc_gems",
-            "unspent_talent_points",
-            "armor_specialization",
-            "dual_wield_2h_without_titans_grip",
-            "shaman_fele_autocast"
-          ]
-        },
-        "buttons": {
-          "type": "object",
-          "properties": {
-            "simulate": {
-              "type": "string"
-            },
-            "stat_weights": {
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "modal": {
-                  "type": "object",
-                  "properties": {
-                    "title": {
-                      "type": "string"
-                    },
-                    "ep": {
-                      "type": "string"
-                    },
-                    "weights": {
-                      "type": "string"
-                    },
-                    "show_all_stats": {
-                      "type": "string"
-                    },
-                    "dps_tps_reference": {
-                      "type": "string"
-                    },
-                    "healing_reference": {
-                      "type": "string"
-                    },
-                    "mitigation_reference": {
-                      "type": "string"
-                    },
-                    "reference_description": {
-                      "type": "string"
-                    },
-                    "current_ep_description": {
-                      "type": "string"
-                    },
-                    "copy_icon_description": {
-                      "type": "string"
-                    },
-                    "stat": {
-                      "type": "string"
-                    },
-                    "update": {
-                      "type": "string"
-                    },
-                    "ep_ratio": {
-                      "type": "string"
-                    },
-                    "update_ep": {
-                      "type": "string"
-                    },
-                    "calculate": {
-                      "type": "string"
-                    },
-                    "compute_weighted_ep": {
-                      "type": "string"
-                    },
-                    "dps_weight": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    },
-                    "dps_ep": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    },
-                    "hps_weight": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    },
-                    "hps_ep": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    },
-                    "tps_weight": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    },
-                    "tps_ep": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    },
-                    "dtps_weight": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    },
-                    "dtps_ep": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    },
-                    "tmi_weight": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    },
-                    "tmi_ep": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    },
-                    "death_weight": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    },
-                    "death_ep": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    },
-                    "current_ep": {
-                      "type": "object",
-                      "properties": {
-                        "label": {
-                          "type": "string"
-                        },
-                        "tooltip": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "label",
-                        "tooltip"
-                      ]
-                    },
-                    "not_applicable": {
-                      "type": "string"
-                    },
-                    "column_headers": {
-                      "type": "object",
-                      "properties": {
-                        "stat": {
-                          "type": "string"
-                        },
-                        "update": {
-                          "type": "string"
-                        },
-                        "ep_ratio": {
-                          "type": "string"
-                        },
-                        "update_ep_button": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "stat",
-                        "update",
-                        "ep_ratio",
-                        "update_ep_button"
-                      ]
-                    },
-                    "tooltips": {
-                      "type": "object",
-                      "properties": {
-                        "normalized_by": {
-                          "type": "string"
-                        },
-                        "copy_to_current_ep": {
-                          "type": "string"
-                        },
-                        "restore_default_ep": {
-                          "type": "string"
-                        },
-                        "compute_weighted_ep": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "normalized_by",
-                        "copy_to_current_ep",
-                        "restore_default_ep",
-                        "compute_weighted_ep"
-                      ]
-                    },
-                    "progress": {
-                      "type": "object",
-                      "properties": {
-                        "simulations_complete": {
-                          "type": "string"
-                        },
-                        "iterations_complete": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "simulations_complete",
-                        "iterations_complete"
-                      ]
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "title",
-                    "ep",
-                    "weights",
-                    "show_all_stats",
-                    "dps_tps_reference",
-                    "healing_reference",
-                    "mitigation_reference",
-                    "reference_description",
-                    "current_ep_description",
-                    "copy_icon_description",
-                    "stat",
-                    "update",
-                    "ep_ratio",
-                    "update_ep",
-                    "calculate",
-                    "compute_weighted_ep",
-                    "dps_weight",
-                    "dps_ep",
-                    "hps_weight",
-                    "hps_ep",
-                    "tps_weight",
-                    "tps_ep",
-                    "dtps_weight",
-                    "dtps_ep",
-                    "tmi_weight",
-                    "tmi_ep",
-                    "death_weight",
-                    "death_ep",
-                    "current_ep",
-                    "not_applicable",
-                    "column_headers",
-                    "tooltips",
-                    "progress"
-                  ]
-                },
-                "saved_ep_weights": {
-                  "type": "object",
-                  "properties": {
-                    "title": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "title"
-                  ]
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "title",
-                "modal",
-                "saved_ep_weights"
-              ]
-            },
-            "suggest_reforges": {
-              "type": "object",
-              "properties": {
-                "title": {
-                  "type": "string"
-                },
-                "tooltip": {
-                  "type": "string"
-                },
-                "use_soft_cap_breakpoints": {
-                  "type": "string"
-                },
-                "force_stat_proc": {
-                  "type": "string"
-                },
-                "any": {
-                  "type": "string"
-                },
-                "optimize_gems_tooltip": {
-                  "type": "string"
-                },
-                "freeze_item_slots_tooltip": {
-                  "type": "string"
-                },
-                "edit_stat_caps": {
-                  "type": "string"
-                },
-                "stat_caps_tooltip": {
-                  "type": "string"
-                },
-                "reset_to_defaults": {
-                  "type": "string"
-                },
-                "stat": {
-                  "type": "string"
-                },
-                "select_preset": {
-                  "type": "string"
-                },
-                "breakpoint_limit": {
-                  "type": "string"
-                },
-                "breakpoint_limit_tooltip": {
-                  "type": "string"
-                },
-                "no_limit_set": {
-                  "type": "string"
-                },
-                "breakpoints_implemented": {
-                  "type": "string"
-                },
-                "post_cap_ep": {
-                  "type": "string"
-                },
-                "reforge_optimization_failed": {
-                  "type": "string"
-                },
-                "reforge_optimization_cancelled": {
-                  "type": "string"
-                },
-                "use_custom": {
-                  "type": "string"
-                },
-                "enable_modification": {
-                  "type": "string"
-                },
-                "modify_in_editor": {
-                  "type": "string"
-                },
-                "hard_cap_info": {
-                  "type": "string"
-                },
-                "edit_weights": {
-                  "type": "string"
-                },
-                "include_gems": {
-                  "type": "string"
-                },
-                "freeze_item_slots": {
-                  "type": "string"
-                },
-                "include_eotbp_socket": {
-                  "type": "string"
-                },
-                "include_eotbp_socket_tooltip": {
-                  "type": "string"
-                },
-                "limit_execution_time": {
-                  "type": "string"
-                },
-                "limit_execution_time_tooltip": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "title",
-                "tooltip",
-                "use_soft_cap_breakpoints",
-                "force_stat_proc",
-                "any",
-                "optimize_gems_tooltip",
-                "freeze_item_slots_tooltip",
-                "edit_stat_caps",
-                "stat_caps_tooltip",
-                "reset_to_defaults",
-                "stat",
-                "select_preset",
-                "breakpoint_limit",
-                "breakpoint_limit_tooltip",
-                "no_limit_set",
-                "breakpoints_implemented",
-                "post_cap_ep",
-                "reforge_optimization_failed",
-                "reforge_optimization_cancelled",
-                "use_custom",
-                "enable_modification",
-                "modify_in_editor",
-                "hard_cap_info",
-                "edit_weights",
-                "include_gems",
-                "freeze_item_slots",
-                "include_eotbp_socket",
-                "include_eotbp_socket_tooltip",
-                "limit_execution_time",
-                "limit_execution_time_tooltip"
-              ]
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "simulate",
-            "stat_weights",
-            "suggest_reforges"
-          ]
-        },
-        "header": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "phase": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "phase"
-          ]
-        },
-        "results": {
-          "type": "object",
-          "properties": {
-            "progress": {
-              "type": "object",
-              "properties": {
-                "presim_running": {
-                  "type": "string"
-                },
-                "iterations_complete": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "presim_running",
-                "iterations_complete"
-              ]
-            },
-            "reference": {
-              "type": "object",
-              "properties": {
-                "save_as_reference": {
-                  "type": "string"
-                },
-                "use_as_reference": {
-                  "type": "string"
-                },
-                "swap": {
-                  "type": "string"
-                },
-                "swap_reference_with_current": {
-                  "type": "string"
-                },
-                "cancel": {
-                  "type": "string"
-                },
-                "remove_reference": {
-                  "type": "string"
-                },
-                "vs_ref": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "save_as_reference",
-                "use_as_reference",
-                "swap",
-                "swap_reference_with_current",
-                "cancel",
-                "remove_reference",
-                "vs_ref"
-              ]
-            },
-            "metrics": {
-              "type": "object",
-              "properties": {
-                "dps": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "hps": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "tps": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "dtps": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "tmi": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        },
-                        "description": {
-                          "type": "string"
-                        },
-                        "note": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "title",
-                        "description",
-                        "note"
-                      ]
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "cod": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "object",
-                      "properties": {
-                        "title": {
-                          "type": "string"
-                        },
-                        "description": {
-                          "type": "string"
-                        },
-                        "note": {
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "required": [
-                        "title",
-                        "description",
-                        "note"
-                      ]
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "dur": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "tto": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                },
-                "oom": {
-                  "type": "object",
-                  "properties": {
-                    "label": {
-                      "type": "string"
-                    },
-                    "tooltip": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": [
-                    "label",
-                    "tooltip"
-                  ]
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "dps",
-                "hps",
-                "tps",
-                "dtps",
-                "tmi",
-                "cod",
-                "dur",
-                "tto",
-                "oom"
-              ]
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "progress",
-            "reference",
-            "metrics"
-          ]
-        },
-        "character_stats": {
-          "type": "object",
-          "properties": {
-            "title": {
-              "type": "string"
-            },
-            "melee_crit_cap": {
-              "type": "string"
-            },
-            "tooltip": {
-              "type": "object",
-              "properties": {
-                "base": {
-                  "type": "string"
-                },
-                "gear": {
-                  "type": "string"
-                },
-                "talents": {
-                  "type": "string"
-                },
-                "buffs": {
-                  "type": "string"
-                },
-                "consumes": {
-                  "type": "string"
-                },
-                "bonus": {
-                  "type": "string"
-                },
-                "total": {
-                  "type": "string"
-                },
-                "glancing": {
-                  "type": "string"
-                },
-                "suppression": {
-                  "type": "string"
-                },
-                "to_hit_cap": {
-                  "type": "string"
-                },
-                "to_exp_cap": {
-                  "type": "string"
-                },
-                "spec_offsets": {
-                  "type": "string"
-                },
-                "final_crit_cap": {
-                  "type": "string"
-                },
-                "can_raise_by": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "base",
-                "gear",
-                "talents",
-                "buffs",
-                "consumes",
-                "bonus",
-                "total",
-                "glancing",
-                "suppression",
-                "to_hit_cap",
-                "to_exp_cap",
-                "spec_offsets",
-                "final_crit_cap",
-                "can_raise_by"
-              ]
-            },
-            "attack_table": {
-              "type": "object",
-              "properties": {
-                "glancing": {
-                  "type": "string"
-                },
-                "suppression": {
-                  "type": "string"
-                },
-                "to_hit_cap": {
-                  "type": "string"
-                },
-                "to_exp_cap": {
-                  "type": "string"
-                },
-                "spec_offsets": {
-                  "type": "string"
-                },
-                "final_crit_cap": {
-                  "type": "string"
-                },
-                "can_raise_by": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "glancing",
-                "suppression",
-                "to_hit_cap",
-                "to_exp_cap",
-                "spec_offsets",
-                "final_crit_cap",
-                "can_raise_by"
-              ]
-            },
-            "crit_cap": {
-              "type": "object",
-              "properties": {
-                "exact": {
-                  "type": "string"
-                },
-                "over_by": {
-                  "type": "string"
-                },
-                "under_by": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false,
-              "required": [
-                "exact",
-                "over_by",
-                "under_by"
-              ]
-            },
-            "bonus_prefix": {
-              "type": "string"
-            },
-            "points_suffix": {
-              "type": "string"
-            },
-            "percent_suffix": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "title",
-            "melee_crit_cap",
-            "tooltip",
-            "attack_table",
-            "crit_cap",
-            "bonus_prefix",
-            "points_suffix",
-            "percent_suffix"
-          ]
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "iterations",
-        "warnings",
-        "buttons",
-        "header",
-        "results",
-        "character_stats"
-      ]
-    },
-    "combat_replay": {
-      "type": "object",
-      "properties": {
-        "empty_title": { "type": "string" },
-        "empty_desc": { "type": "string" },
-        "default_player": { "type": "string" },
-        "training_dummy": { "type": "string" },
-        "seek_back": { "type": "string" },
-        "seek_fwd": { "type": "string" }
-      },
-      "additionalProperties": false,
-      "required": [
-        "empty_title",
-        "empty_desc",
-        "default_player",
-        "training_dummy",
-        "seek_back",
-        "seek_fwd"
-      ]
-    }
-  },
-  "additionalProperties": false,
-  "required": [
-    "landing",
-    "common",
-    "sim",
-    "gear_tab",
-    "settings_tab",
-    "talents_tab",
-    "bulk_tab",
-    "rotation_tab",
-    "results_tab",
-    "combat_replay",
-    "import",
-    "export",
-    "info",
-    "sidebar"
-  ],
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Generated Schema",
-  "description": "Auto-generated JSON Schema",
-  "definitions": {}
+	"type": "object",
+	"properties": {
+		"landing": {
+			"type": "object",
+			"properties": {
+				"navigation": {
+					"type": "object",
+					"properties": {
+						"home": {
+							"type": "string"
+						},
+						"simulations": {
+							"type": "string"
+						},
+						"about": {
+							"type": "string"
+						},
+						"toggle": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["home", "simulations", "about", "toggle"]
+				},
+				"simulations": {
+					"type": "object",
+					"properties": {
+						"full_raid": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["full_raid"]
+				},
+				"home": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"description": {
+							"type": "string"
+						},
+						"welcomeDescription": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title", "description", "welcomeDescription"]
+				},
+				"header": {
+					"type": "object",
+					"properties": {
+						"wowsims": {
+							"type": "string"
+						},
+						"expansion": {
+							"type": "string"
+						},
+						"supportDevs": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["wowsims", "expansion", "supportDevs"]
+				}
+			},
+			"additionalProperties": false,
+			"required": ["navigation", "simulations", "home", "header"]
+		},
+		"common": {
+			"type": "object",
+			"properties": {
+				"none": {
+					"type": "string"
+				},
+				"custom": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"search": {
+					"type": "string"
+				},
+				"filter": {
+					"type": "string"
+				},
+				"elapsed_time": {
+					"type": "string"
+				},
+				"phases": {
+					"type": "object",
+					"properties": {
+						"1": {
+							"type": "string"
+						},
+						"2": {
+							"type": "string"
+						},
+						"3": {
+							"type": "string"
+						},
+						"4": {
+							"type": "string"
+						},
+						"5": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["1", "2", "3", "4", "5"]
+				},
+				"tanks": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"main_tank": {
+							"type": "string"
+						},
+						"tank_2": {
+							"type": "string"
+						},
+						"tank_3": {
+							"type": "string"
+						},
+						"tank_4": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title", "main_tank", "tank_2", "tank_3", "tank_4"]
+				},
+				"status": {
+					"type": "object",
+					"properties": {
+						"unlaunched": {
+							"type": "string"
+						},
+						"alpha": {
+							"type": "string"
+						},
+						"beta": {
+							"type": "string"
+						},
+						"launched": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["unlaunched", "alpha", "beta", "launched"]
+				},
+				"mob_types": {
+					"type": "object",
+					"properties": {
+						"unknown": {
+							"type": "string"
+						},
+						"beast": {
+							"type": "string"
+						},
+						"demon": {
+							"type": "string"
+						},
+						"dragonkin": {
+							"type": "string"
+						},
+						"elemental": {
+							"type": "string"
+						},
+						"giant": {
+							"type": "string"
+						},
+						"humanoid": {
+							"type": "string"
+						},
+						"mechanical": {
+							"type": "string"
+						},
+						"undead": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["unknown", "beast", "demon", "dragonkin", "elemental", "giant", "humanoid", "mechanical", "undead"]
+				},
+				"sources": {
+					"type": "object",
+					"properties": {
+						"unknown": {
+							"type": "string"
+						},
+						"crafting": {
+							"type": "string"
+						},
+						"quest": {
+							"type": "string"
+						},
+						"sold_by": {
+							"type": "string"
+						},
+						"reputation": {
+							"type": "string"
+						},
+						"pvp": {
+							"type": "string"
+						},
+						"dungeon": {
+							"type": "string"
+						},
+						"dungeon_h": {
+							"type": "string"
+						},
+						"raid": {
+							"type": "string"
+						},
+						"raid_h": {
+							"type": "string"
+						},
+						"raid_rf": {
+							"type": "string"
+						},
+						"raid_flex": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"unknown",
+						"crafting",
+						"quest",
+						"sold_by",
+						"reputation",
+						"pvp",
+						"dungeon",
+						"dungeon_h",
+						"raid",
+						"raid_h",
+						"raid_rf",
+						"raid_flex"
+					]
+				},
+				"raids": {
+					"type": "object",
+					"properties": {
+						"unknown": {
+							"type": "string"
+						},
+						"mogushan_vaults": {
+							"type": "string"
+						},
+						"heart_of_fear": {
+							"type": "string"
+						},
+						"terrace_of_endless_spring": {
+							"type": "string"
+						},
+						"throne_of_thunder": {
+							"type": "string"
+						},
+						"siege_of_orgrimmar": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["unknown", "mogushan_vaults", "heart_of_fear", "terrace_of_endless_spring", "throne_of_thunder", "siege_of_orgrimmar"]
+				},
+				"armor_types": {
+					"type": "object",
+					"properties": {
+						"unknown": {
+							"type": "string"
+						},
+						"cloth": {
+							"type": "string"
+						},
+						"leather": {
+							"type": "string"
+						},
+						"mail": {
+							"type": "string"
+						},
+						"plate": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["unknown", "cloth", "leather", "mail", "plate"]
+				},
+				"weapon_types": {
+					"type": "object",
+					"properties": {
+						"unknown": {
+							"type": "string"
+						},
+						"axe": {
+							"type": "string"
+						},
+						"dagger": {
+							"type": "string"
+						},
+						"fist": {
+							"type": "string"
+						},
+						"mace": {
+							"type": "string"
+						},
+						"off_hand": {
+							"type": "string"
+						},
+						"polearm": {
+							"type": "string"
+						},
+						"shield": {
+							"type": "string"
+						},
+						"staff": {
+							"type": "string"
+						},
+						"sword": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["unknown", "axe", "dagger", "fist", "mace", "off_hand", "polearm", "shield", "staff", "sword"]
+				},
+				"ranged_weapon_types": {
+					"type": "object",
+					"properties": {
+						"unknown": {
+							"type": "string"
+						},
+						"bow": {
+							"type": "string"
+						},
+						"crossbow": {
+							"type": "string"
+						},
+						"gun": {
+							"type": "string"
+						},
+						"thrown": {
+							"type": "string"
+						},
+						"wand": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["unknown", "bow", "crossbow", "gun", "thrown", "wand"]
+				},
+				"spell_schools": {
+					"type": "object",
+					"properties": {
+						"physical": {
+							"type": "string"
+						},
+						"arcane": {
+							"type": "string"
+						},
+						"fire": {
+							"type": "string"
+						},
+						"frost": {
+							"type": "string"
+						},
+						"holy": {
+							"type": "string"
+						},
+						"nature": {
+							"type": "string"
+						},
+						"shadow": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["physical", "arcane", "fire", "frost", "holy", "nature", "shadow"]
+				},
+				"resource_types": {
+					"type": "object",
+					"properties": {
+						"health": {
+							"type": "string"
+						},
+						"mana": {
+							"type": "string"
+						},
+						"energy": {
+							"type": "string"
+						},
+						"rage": {
+							"type": "string"
+						},
+						"focus": {
+							"type": "string"
+						},
+						"runic_power": {
+							"type": "string"
+						},
+						"chi": {
+							"type": "string"
+						},
+						"holy_power": {
+							"type": "string"
+						},
+						"shadow_orbs": {
+							"type": "string"
+						},
+						"combo_points": {
+							"type": "string"
+						},
+						"maelstrom": {
+							"type": "string"
+						},
+						"demonic_fury": {
+							"type": "string"
+						},
+						"burning_embers": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"health",
+						"mana",
+						"energy",
+						"rage",
+						"focus",
+						"runic_power",
+						"chi",
+						"holy_power",
+						"shadow_orbs",
+						"combo_points",
+						"maelstrom",
+						"demonic_fury",
+						"burning_embers"
+					]
+				},
+				"stats": {
+					"type": "object",
+					"properties": {
+						"strength": {
+							"type": "string"
+						},
+						"agility": {
+							"type": "string"
+						},
+						"stamina": {
+							"type": "string"
+						},
+						"intellect": {
+							"type": "string"
+						},
+						"spirit": {
+							"type": "string"
+						},
+						"hit": {
+							"type": "string"
+						},
+						"crit": {
+							"type": "string"
+						},
+						"haste": {
+							"type": "string"
+						},
+						"expertise": {
+							"type": "string"
+						},
+						"dodge": {
+							"type": "string"
+						},
+						"parry": {
+							"type": "string"
+						},
+						"mastery": {
+							"type": "string"
+						},
+						"attack_power": {
+							"type": "string"
+						},
+						"ranged_attack_power": {
+							"type": "string"
+						},
+						"spell_power": {
+							"type": "string"
+						},
+						"pvp_resilience": {
+							"type": "string"
+						},
+						"pvp_power": {
+							"type": "string"
+						},
+						"armor": {
+							"type": "string"
+						},
+						"bonus_armor": {
+							"type": "string"
+						},
+						"health": {
+							"type": "string"
+						},
+						"mana": {
+							"type": "string"
+						},
+						"mp5": {
+							"type": "string"
+						},
+						"main_hand_dps": {
+							"type": "string"
+						},
+						"off_hand_dps": {
+							"type": "string"
+						},
+						"ranged_dps": {
+							"type": "string"
+						},
+						"block": {
+							"type": "string"
+						},
+						"melee_speed_multiplier": {
+							"type": "string"
+						},
+						"ranged_speed_multiplier": {
+							"type": "string"
+						},
+						"cast_speed_multiplier": {
+							"type": "string"
+						},
+						"spell_hit": {
+							"type": "string"
+						},
+						"spell_crit": {
+							"type": "string"
+						},
+						"spell_haste": {
+							"type": "string"
+						},
+						"melee_hit": {
+							"type": "string"
+						},
+						"melee_crit": {
+							"type": "string"
+						},
+						"melee_haste": {
+							"type": "string"
+						},
+						"ranged_haste": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"strength",
+						"agility",
+						"stamina",
+						"intellect",
+						"spirit",
+						"hit",
+						"crit",
+						"haste",
+						"expertise",
+						"dodge",
+						"parry",
+						"mastery",
+						"attack_power",
+						"ranged_attack_power",
+						"spell_power",
+						"pvp_resilience",
+						"pvp_power",
+						"armor",
+						"bonus_armor",
+						"health",
+						"mana",
+						"mp5",
+						"main_hand_dps",
+						"off_hand_dps",
+						"ranged_dps",
+						"block",
+						"melee_speed_multiplier",
+						"ranged_speed_multiplier",
+						"cast_speed_multiplier",
+						"spell_hit",
+						"spell_crit",
+						"spell_haste",
+						"melee_hit",
+						"melee_crit",
+						"melee_haste",
+						"ranged_haste"
+					]
+				},
+				"mastery_spell_names": {
+					"type": "object",
+					"properties": {
+						"unknown": {
+							"type": "string"
+						},
+						"potent_poisons": {
+							"type": "string"
+						},
+						"main_gauche": {
+							"type": "string"
+						},
+						"executioner": {
+							"type": "string"
+						},
+						"blood_shield": {
+							"type": "string"
+						},
+						"frozen_heart": {
+							"type": "string"
+						},
+						"dreadblade": {
+							"type": "string"
+						},
+						"total_eclipse": {
+							"type": "string"
+						},
+						"razor_claws": {
+							"type": "string"
+						},
+						"natures_guardian": {
+							"type": "string"
+						},
+						"harmony": {
+							"type": "string"
+						},
+						"illuminated_healing": {
+							"type": "string"
+						},
+						"divine_bulwark": {
+							"type": "string"
+						},
+						"hand_of_light": {
+							"type": "string"
+						},
+						"elemental_overload": {
+							"type": "string"
+						},
+						"enhanced_elements": {
+							"type": "string"
+						},
+						"deep_healing": {
+							"type": "string"
+						},
+						"master_of_beasts": {
+							"type": "string"
+						},
+						"wild_quiver": {
+							"type": "string"
+						},
+						"essence_of_the_viper": {
+							"type": "string"
+						},
+						"strikes_of_opportunity": {
+							"type": "string"
+						},
+						"unshackled_fury": {
+							"type": "string"
+						},
+						"critical_block": {
+							"type": "string"
+						},
+						"mana_adept": {
+							"type": "string"
+						},
+						"ignite": {
+							"type": "string"
+						},
+						"icicles": {
+							"type": "string"
+						},
+						"shield_discipline": {
+							"type": "string"
+						},
+						"echo_of_light": {
+							"type": "string"
+						},
+						"shadow_orb_power": {
+							"type": "string"
+						},
+						"potent_afflictions": {
+							"type": "string"
+						},
+						"master_demonologist": {
+							"type": "string"
+						},
+						"emberstorm": {
+							"type": "string"
+						},
+						"elusive_brawler": {
+							"type": "string"
+						},
+						"gift_of_the_serpent": {
+							"type": "string"
+						},
+						"bottled_fury": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"unknown",
+						"potent_poisons",
+						"main_gauche",
+						"executioner",
+						"blood_shield",
+						"frozen_heart",
+						"dreadblade",
+						"total_eclipse",
+						"razor_claws",
+						"natures_guardian",
+						"harmony",
+						"illuminated_healing",
+						"divine_bulwark",
+						"hand_of_light",
+						"elemental_overload",
+						"enhanced_elements",
+						"deep_healing",
+						"master_of_beasts",
+						"wild_quiver",
+						"essence_of_the_viper",
+						"strikes_of_opportunity",
+						"unshackled_fury",
+						"critical_block",
+						"mana_adept",
+						"ignite",
+						"icicles",
+						"shield_discipline",
+						"echo_of_light",
+						"shadow_orb_power",
+						"potent_afflictions",
+						"master_demonologist",
+						"emberstorm",
+						"elusive_brawler",
+						"gift_of_the_serpent",
+						"bottled_fury"
+					]
+				},
+				"currency": {
+					"type": "object",
+					"properties": {
+						"valorPoints": {
+							"type": "string"
+						},
+						"justicePoints": {
+							"type": "string"
+						},
+						"honorPoints": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["valorPoints", "justicePoints", "honorPoints"]
+				},
+				"copy_button": {
+					"type": "object",
+					"properties": {
+						"default_text": {
+							"type": "string"
+						},
+						"copied": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["default_text", "copied"]
+				},
+				"list_picker": {
+					"type": "object",
+					"properties": {
+						"new_item": {
+							"type": "string"
+						},
+						"delete_item": {
+							"type": "string"
+						},
+						"copy_to_new": {
+							"type": "string"
+						},
+						"move_drag_drop": {
+							"type": "string"
+						},
+						"warnings": {
+							"type": "string"
+						},
+						"additional_information": {
+							"type": "string"
+						},
+						"action_has_warnings": {
+							"type": "string"
+						},
+						"action_has_errors": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"new_item",
+						"delete_item",
+						"copy_to_new",
+						"move_drag_drop",
+						"warnings",
+						"additional_information",
+						"action_has_warnings",
+						"action_has_errors"
+					]
+				},
+				"preset": {
+					"type": "object",
+					"properties": {
+						"ep_weights": {
+							"type": "string"
+						},
+						"gear": {
+							"type": "string"
+						},
+						"talents": {
+							"type": "string"
+						},
+						"rotation": {
+							"type": "string"
+						},
+						"encounter": {
+							"type": "string"
+						},
+						"settings": {
+							"type": "string"
+						},
+						"description": {
+							"type": "string"
+						},
+						"stat_weights": {
+							"type": "string"
+						},
+						"class_spec_options": {
+							"type": "string"
+						},
+						"consumables": {
+							"type": "string"
+						},
+						"other_settings": {
+							"type": "string"
+						},
+						"buffs": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"ep_weights",
+						"gear",
+						"talents",
+						"rotation",
+						"encounter",
+						"settings",
+						"description",
+						"stat_weights",
+						"class_spec_options",
+						"consumables",
+						"other_settings",
+						"buffs"
+					]
+				}
+			},
+			"additionalProperties": false,
+			"required": [
+				"none",
+				"custom",
+				"name",
+				"search",
+				"filter",
+				"elapsed_time",
+				"phases",
+				"tanks",
+				"status",
+				"mob_types",
+				"sources",
+				"raids",
+				"armor_types",
+				"weapon_types",
+				"ranged_weapon_types",
+				"spell_schools",
+				"resource_types",
+				"stats",
+				"mastery_spell_names",
+				"currency",
+				"copy_button",
+				"list_picker",
+				"preset"
+			]
+		},
+		"sim": {
+			"type": "object",
+			"properties": {
+				"title": {
+					"type": "string"
+				},
+				"description": {
+					"type": "string"
+				},
+				"basic_bis_disclaimer": {
+					"type": "string"
+				},
+				"healing_sim_disclaimer": {
+					"type": "string"
+				},
+				"notice_local_download": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"message": {
+							"type": "string"
+						},
+						"download_button": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title", "message", "download_button"]
+				},
+				"crash_modal": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"header": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title", "header"]
+				},
+				"unlaunched": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"contribute_message": {
+							"type": "string"
+						},
+						"discord_message": {
+							"type": "string"
+						},
+						"healing_message": {
+							"type": "string"
+						},
+						"qe_live_message": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title", "contribute_message", "discord_message", "healing_message", "qe_live_message"]
+				},
+				"notifications": {
+					"type": "object",
+					"properties": {
+						"raid_sim_cancelled": {
+							"type": "string"
+						},
+						"simulation_failed": {
+							"type": "string"
+						},
+						"failed_to_file_report": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["raid_sim_cancelled", "simulation_failed", "failed_to_file_report"]
+				},
+				"crash_report": {
+					"type": "object",
+					"properties": {
+						"confirm_title": {
+							"type": "string"
+						},
+						"confirm_message": {
+							"type": "string"
+						},
+						"report_title": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["confirm_title", "confirm_message", "report_title"]
+				}
+			},
+			"additionalProperties": false,
+			"required": [
+				"title",
+				"description",
+				"basic_bis_disclaimer",
+				"healing_sim_disclaimer",
+				"notice_local_download",
+				"crash_modal",
+				"unlaunched",
+				"notifications",
+				"crash_report"
+			]
+		},
+		"gear_tab": {
+			"type": "object",
+			"properties": {
+				"title": {
+					"type": "string"
+				},
+				"gem_summary": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"reset_gems": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title", "reset_gems"]
+				},
+				"reforge_summary": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"reset_reforges": {
+							"type": "string"
+						},
+						"copy_to_reforge_lite": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title", "reset_reforges", "copy_to_reforge_lite"]
+				},
+				"reforge_success": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"removed_reforge": {
+							"type": "string"
+						},
+						"no_changes": {
+							"type": "string"
+						},
+						"copy_to_reforge_lite": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title", "removed_reforge", "no_changes", "copy_to_reforge_lite"]
+				},
+				"gear_sets": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"gear_set": {
+							"type": "string"
+						},
+						"gear_set_name": {
+							"type": "string"
+						},
+						"save_gear_set": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title", "gear_set", "gear_set_name", "save_gear_set"]
+				},
+				"gear_picker": {
+					"type": "object",
+					"properties": {
+						"tabs": {
+							"type": "object",
+							"properties": {
+								"items": {
+									"type": "string"
+								},
+								"random_suffix": {
+									"type": "string"
+								},
+								"enchants": {
+									"type": "string"
+								},
+								"tinkers": {
+									"type": "string"
+								},
+								"reforging": {
+									"type": "string"
+								},
+								"upgrades": {
+									"type": "string"
+								},
+								"gem1": {
+									"type": "string"
+								},
+								"gem2": {
+									"type": "string"
+								},
+								"gem3": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["items", "random_suffix", "enchants", "tinkers", "reforging", "upgrades", "gem1", "gem2", "gem3"]
+						},
+						"remove_buttons": {
+							"type": "object",
+							"properties": {
+								"remove_enchant": {
+									"type": "string"
+								},
+								"remove_tinkers": {
+									"type": "string"
+								},
+								"remove_reforge": {
+									"type": "string"
+								},
+								"remove_random_suffix": {
+									"type": "string"
+								},
+								"remove_upgrade": {
+									"type": "string"
+								},
+								"remove_gem": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["remove_enchant", "remove_tinkers", "remove_reforge", "remove_random_suffix", "remove_upgrade", "remove_gem"]
+						},
+						"filters": {
+							"type": "object",
+							"properties": {
+								"title": {
+									"type": "string"
+								},
+								"general": {
+									"type": "string"
+								},
+								"min_ilvl": {
+									"type": "string"
+								},
+								"max_ilvl": {
+									"type": "string"
+								},
+								"faction_restrictions": {
+									"type": "string"
+								},
+								"source": {
+									"type": "string"
+								},
+								"raids": {
+									"type": "string"
+								},
+								"faction_labels": {
+									"type": "object",
+									"properties": {
+										"none": {
+											"type": "string"
+										},
+										"alliance_only": {
+											"type": "string"
+										},
+										"horde_only": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["none", "alliance_only", "horde_only"]
+								}
+							},
+							"additionalProperties": false,
+							"required": ["title", "general", "min_ilvl", "max_ilvl", "faction_restrictions", "source", "raids", "faction_labels"]
+						},
+						"quick_popovers": {
+							"type": "object",
+							"properties": {
+								"favorite_gems": {
+									"type": "object",
+									"properties": {
+										"title": {
+											"type": "string"
+										},
+										"empty_message": {
+											"type": "string"
+										},
+										"open_gems": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["title", "empty_message", "open_gems"]
+								},
+								"favorite_enchants": {
+									"type": "object",
+									"properties": {
+										"title": {
+											"type": "string"
+										},
+										"empty_message": {
+											"type": "string"
+										},
+										"open_enchants": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["title", "empty_message", "open_enchants"]
+								}
+							},
+							"additionalProperties": false,
+							"required": ["favorite_gems", "favorite_enchants"]
+						},
+						"missing_gear_message": {
+							"type": "object",
+							"properties": {
+								"title": {
+									"type": "string"
+								},
+								"description": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["title", "description"]
+						},
+						"cooldowns": {
+							"type": "object",
+							"properties": {
+								"title": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["title", "tooltip"]
+						},
+						"ep_tooltip": {
+							"type": "string"
+						},
+						"filters_button": {
+							"type": "string"
+						},
+						"unequip_item": {
+							"type": "string"
+						},
+						"table_headers": {
+							"type": "object",
+							"properties": {
+								"ilvl": {
+									"type": "string"
+								},
+								"item": {
+									"type": "string"
+								},
+								"source": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["ilvl", "item", "source"]
+						},
+						"show_ep": {
+							"type": "string"
+						},
+						"armor_type": {
+							"type": "string"
+						},
+						"weapon_type": {
+							"type": "string"
+						},
+						"weapon_speed": {
+							"type": "string"
+						},
+						"min_mh_speed": {
+							"type": "string"
+						},
+						"max_mh_speed": {
+							"type": "string"
+						},
+						"min_oh_speed": {
+							"type": "string"
+						},
+						"max_oh_speed": {
+							"type": "string"
+						},
+						"ranged_weapon_type": {
+							"type": "string"
+						},
+						"ranged_weapon_speed": {
+							"type": "string"
+						},
+						"min_ranged_speed": {
+							"type": "string"
+						},
+						"max_ranged_speed": {
+							"type": "string"
+						},
+						"reforge_text": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"tabs",
+						"remove_buttons",
+						"filters",
+						"quick_popovers",
+						"missing_gear_message",
+						"cooldowns",
+						"ep_tooltip",
+						"filters_button",
+						"unequip_item",
+						"table_headers",
+						"show_ep",
+						"armor_type",
+						"weapon_type",
+						"weapon_speed",
+						"min_mh_speed",
+						"max_mh_speed",
+						"min_oh_speed",
+						"max_oh_speed",
+						"ranged_weapon_type",
+						"ranged_weapon_speed",
+						"min_ranged_speed",
+						"max_ranged_speed",
+						"reforge_text"
+					]
+				},
+				"preset_configurations": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"tooltip": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title", "tooltip"]
+				},
+				"upgrade_summary": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"upgrade_all_items": {
+							"type": "string"
+						},
+						"reset_upgrades": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title", "upgrade_all_items", "reset_upgrades"]
+				}
+			},
+			"additionalProperties": false,
+			"required": ["title", "gem_summary", "reforge_summary", "reforge_success", "gear_sets", "gear_picker", "preset_configurations", "upgrade_summary"]
+		},
+		"settings_tab": {
+			"type": "object",
+			"properties": {
+				"title": {
+					"type": "string"
+				},
+				"raid_buffs": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"tooltip": {
+							"type": "string"
+						},
+						"description": {
+							"type": "string"
+						},
+						"misc": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"stats": {
+							"type": "string"
+						},
+						"attack_power": {
+							"type": "string"
+						},
+						"attack_speed": {
+							"type": "string"
+						},
+						"spell_power": {
+							"type": "string"
+						},
+						"spell_haste": {
+							"type": "string"
+						},
+						"crit_percent": {
+							"type": "string"
+						},
+						"mastery": {
+							"type": "string"
+						},
+						"stamina": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"title",
+						"tooltip",
+						"description",
+						"misc",
+						"stats",
+						"attack_power",
+						"attack_speed",
+						"spell_power",
+						"spell_haste",
+						"crit_percent",
+						"mastery",
+						"stamina"
+					]
+				},
+				"external_damage_cooldowns": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"tooltip": {
+							"type": "string"
+						},
+						"bloodlust": {
+							"type": "string"
+						},
+						"skull_banner": {
+							"type": "string"
+						},
+						"stormlash_totem": {
+							"type": "string"
+						},
+						"tricks_of_the_trade": {
+							"type": "string"
+						},
+						"unholy_frenzy": {
+							"type": "string"
+						},
+						"shattering_throw": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title", "tooltip", "bloodlust", "skull_banner", "stormlash_totem", "tricks_of_the_trade", "unholy_frenzy", "shattering_throw"]
+				},
+				"external_defensive_cooldowns": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"tooltip": {
+							"type": "string"
+						},
+						"vigilance": {
+							"type": "string"
+						},
+						"devotion_aura": {
+							"type": "string"
+						},
+						"pain_suppression": {
+							"type": "string"
+						},
+						"rallying_cry": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title", "tooltip", "vigilance", "devotion_aura", "pain_suppression", "rallying_cry"]
+				},
+				"debuffs": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"tooltip": {
+							"type": "string"
+						},
+						"misc": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"armor_reduction": {
+							"type": "string"
+						},
+						"phys_dmg_reduction": {
+							"type": "string"
+						},
+						"cast_speed": {
+							"type": "string"
+						},
+						"phys_dmg": {
+							"type": "string"
+						},
+						"spell_dmg": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title", "tooltip", "misc", "armor_reduction", "phys_dmg_reduction", "cast_speed", "phys_dmg", "spell_dmg"]
+				},
+				"other": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"challenge_mode": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"input_delay": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"channel_clip_delay": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"in_front_of_target": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"distance_from_target": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"tank_assignment": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"incoming_hps": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"healing_cadence": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"healing_cadence_variation": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"absorb_frac": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"burst_window": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"hp_percent_for_defensives": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"pet_uptime": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"glaive_toss_chance": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"detonate_seed": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"stance_snapshot": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"assume_bleed_active": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"cannot_shred_target": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"okf_uptime": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"sync_type": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								},
+								"values": {
+									"type": "object",
+									"properties": {
+										"automatic": {
+											"type": "string"
+										},
+										"none": {
+											"type": "string"
+										},
+										"perfect_sync": {
+											"type": "string"
+										},
+										"delayed_offhand": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["automatic", "none", "perfect_sync", "delayed_offhand"]
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip", "values"]
+						},
+						"show_1h_weapons": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"show_2h_weapons": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"show_matching_gems": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"show_ep_values": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"phase_selector": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"enable_item_swap": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"item_swap": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"assume_prepull_mastery_elixir": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"blessings": {
+							"type": "object",
+							"properties": {
+								"title": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["title", "tooltip"]
+						},
+						"shaman_disable_immolate": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"shaman_disable_immolate_duration": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"title",
+						"challenge_mode",
+						"input_delay",
+						"channel_clip_delay",
+						"in_front_of_target",
+						"distance_from_target",
+						"tank_assignment",
+						"incoming_hps",
+						"healing_cadence",
+						"healing_cadence_variation",
+						"absorb_frac",
+						"burst_window",
+						"hp_percent_for_defensives",
+						"pet_uptime",
+						"glaive_toss_chance",
+						"detonate_seed",
+						"stance_snapshot",
+						"assume_bleed_active",
+						"cannot_shred_target",
+						"okf_uptime",
+						"sync_type",
+						"show_1h_weapons",
+						"show_2h_weapons",
+						"show_matching_gems",
+						"show_ep_values",
+						"phase_selector",
+						"enable_item_swap",
+						"item_swap",
+						"assume_prepull_mastery_elixir",
+						"blessings",
+						"shaman_disable_immolate",
+						"shaman_disable_immolate_duration"
+					]
+				},
+				"consumables": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"potions": {
+							"type": "object",
+							"properties": {
+								"title": {
+									"type": "string"
+								},
+								"prepop": {
+									"type": "string"
+								},
+								"combat": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["title", "prepop", "combat"]
+						},
+						"elixirs": {
+							"type": "object",
+							"properties": {
+								"title": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["title"]
+						},
+						"food": {
+							"type": "object",
+							"properties": {
+								"title": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["title"]
+						},
+						"engineering": {
+							"type": "object",
+							"properties": {
+								"title": {
+									"type": "string"
+								},
+								"explosives": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["title", "explosives"]
+						},
+						"pet": {
+							"type": "object",
+							"properties": {
+								"title": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["title"]
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title", "potions", "elixirs", "food", "engineering", "pet"]
+				},
+				"encounter": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"target_inputs": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"frenzy_time": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"spiritual_grasp_frequency": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"jalak_death_time": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"taunt_swap_for_triple_puncture": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"movement_interval": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"reaction_time": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"yards": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"adds_respawn_time": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"adds_lifetime": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"adds_spawn_delay": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"label",
+								"frenzy_time",
+								"spiritual_grasp_frequency",
+								"jalak_death_time",
+								"taunt_swap_for_triple_puncture",
+								"movement_interval",
+								"reaction_time",
+								"yards",
+								"adds_respawn_time",
+								"adds_lifetime",
+								"adds_spawn_delay"
+							]
+						},
+						"duration": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"duration_variation": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"execute_duration_20": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"execute_duration_25": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"execute_duration_35": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"execute_duration_45": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"duration_below_high_hp": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"encounter_preset": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"advanced": {
+							"type": "string"
+						},
+						"use_health": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"target": {
+							"type": "string"
+						},
+						"num_allies": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"min_base_damage": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"npc": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"ai": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"level": {
+							"type": "string"
+						},
+						"mob_type": {
+							"type": "string"
+						},
+						"tanked_by": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"swing_speed": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"dual_wield": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"dual_wield_penalty": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"parry_haste": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"spell_school": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"damage_spread": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"suppress_dodge": {
+							"type": "string"
+						},
+						"second_tank_index": {
+							"type": "string"
+						},
+						"disabled_at_start": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"title",
+						"target_inputs",
+						"duration",
+						"duration_variation",
+						"execute_duration_20",
+						"execute_duration_25",
+						"execute_duration_35",
+						"execute_duration_45",
+						"duration_below_high_hp",
+						"encounter_preset",
+						"advanced",
+						"use_health",
+						"target",
+						"num_allies",
+						"min_base_damage",
+						"npc",
+						"ai",
+						"level",
+						"mob_type",
+						"tanked_by",
+						"swing_speed",
+						"dual_wield",
+						"dual_wield_penalty",
+						"parry_haste",
+						"spell_school",
+						"damage_spread",
+						"suppress_dodge",
+						"second_tank_index",
+						"disabled_at_start"
+					]
+				},
+				"player": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"race": {
+							"type": "string"
+						},
+						"profession_1": {
+							"type": "string"
+						},
+						"profession_2": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title", "race", "profession_1", "profession_2"]
+				},
+				"saved_encounters": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"encounter": {
+							"type": "string"
+						},
+						"encounter_name": {
+							"type": "string"
+						},
+						"save_encounter": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title", "encounter", "encounter_name", "save_encounter"]
+				},
+				"saved_settings": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"settings": {
+							"type": "string"
+						},
+						"settings_name": {
+							"type": "string"
+						},
+						"save_settings": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title", "settings", "settings_name", "save_settings"]
+				},
+				"external_buffs": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"tooltip": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title", "tooltip"]
+				}
+			},
+			"additionalProperties": false,
+			"required": [
+				"title",
+				"raid_buffs",
+				"external_damage_cooldowns",
+				"external_defensive_cooldowns",
+				"debuffs",
+				"other",
+				"consumables",
+				"encounter",
+				"player",
+				"saved_encounters",
+				"saved_settings",
+				"external_buffs"
+			]
+		},
+		"talents_tab": {
+			"type": "object",
+			"properties": {
+				"title": {
+					"type": "string"
+				},
+				"copy_button": {
+					"type": "object",
+					"properties": {
+						"label": {
+							"type": "string"
+						},
+						"tooltip": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["label", "tooltip"]
+				},
+				"reset_button": {
+					"type": "object",
+					"properties": {
+						"tooltip": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["tooltip"]
+				},
+				"glyphs": {
+					"type": "object",
+					"properties": {
+						"major": {
+							"type": "string"
+						},
+						"minor": {
+							"type": "string"
+						},
+						"modal": {
+							"type": "object",
+							"properties": {
+								"title": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["title"]
+						},
+						"empty": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["major", "minor", "modal", "empty"]
+				},
+				"saved_talents": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"label": {
+							"type": "string"
+						},
+						"name_label": {
+							"type": "string"
+						},
+						"save_button": {
+							"type": "string"
+						},
+						"delete": {
+							"type": "object",
+							"properties": {
+								"confirm": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["confirm", "tooltip"]
+						},
+						"alerts": {
+							"type": "object",
+							"properties": {
+								"choose_name": {
+									"type": "string"
+								},
+								"name_exists": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["choose_name", "name_exists"]
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title", "label", "name_label", "save_button", "delete", "alerts"]
+				}
+			},
+			"additionalProperties": false,
+			"required": ["title", "copy_button", "reset_button", "glyphs", "saved_talents"]
+		},
+		"bulk_tab": {
+			"type": "object",
+			"properties": {
+				"title": {
+					"type": "string"
+				},
+				"description": {
+					"type": "string"
+				},
+				"download_local": {
+					"type": "string"
+				},
+				"tabs": {
+					"type": "object",
+					"properties": {
+						"setup": {
+							"type": "string"
+						},
+						"results": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["setup", "results"]
+				},
+				"actions": {
+					"type": "object",
+					"properties": {
+						"import_bags": {
+							"type": "string"
+						},
+						"import_favorites": {
+							"type": "string"
+						},
+						"clear_items": {
+							"type": "string"
+						},
+						"simulate_batch": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["import_bags", "import_favorites", "clear_items", "simulate_batch"]
+				},
+				"search": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"name_label": {
+							"type": "string"
+						},
+						"clear_search": {
+							"type": "string"
+						},
+						"min_ilvl": {
+							"type": "string"
+						},
+						"max_ilvl": {
+							"type": "string"
+						},
+						"no_results": {
+							"type": "string"
+						},
+						"showing_results": {
+							"type": "string"
+						},
+						"item_added": {
+							"type": "string"
+						},
+						"item_removed": {
+							"type": "string"
+						},
+						"item_unique": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"title",
+						"name_label",
+						"clear_search",
+						"min_ilvl",
+						"max_ilvl",
+						"no_results",
+						"showing_results",
+						"item_added",
+						"item_removed",
+						"item_unique"
+					]
+				},
+				"settings": {
+					"type": "object",
+					"properties": {
+						"combinations_count": {
+							"type": "string"
+						},
+						"combination_singular": {
+							"type": "string"
+						},
+						"iterations": {
+							"type": "string"
+						},
+						"fallback_gems": {
+							"type": "string"
+						},
+						"inherit_upgrades": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"freeze_ring": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"freeze_trinket": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"combinations_count",
+						"combination_singular",
+						"iterations",
+						"fallback_gems",
+						"inherit_upgrades",
+						"freeze_ring",
+						"freeze_trinket"
+					]
+				},
+				"progress": {
+					"type": "object",
+					"properties": {
+						"total_combinations": {
+							"type": "string"
+						},
+						"reforging_rounds": {
+							"type": "string"
+						},
+						"baseline_round": {
+							"type": "string"
+						},
+						"refining_rounds": {
+							"type": "string"
+						},
+						"iterations_complete": {
+							"type": "string"
+						},
+						"seconds_remaining": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["total_combinations", "reforging_rounds", "baseline_round", "refining_rounds", "iterations_complete", "seconds_remaining"]
+				},
+				"notifications": {
+					"type": "object",
+					"properties": {
+						"bulk_sim_cancelled": {
+							"type": "string"
+						},
+						"failed_to_remove_item": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["bulk_sim_cancelled", "failed_to_remove_item"]
+				},
+				"warning": {
+					"type": "object",
+					"properties": {
+						"iterations_limit": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["iterations_limit"]
+				},
+				"picker": {
+					"type": "object",
+					"properties": {
+						"no_items": {
+							"type": "string"
+						},
+						"remove_tooltip": {
+							"type": "string"
+						},
+						"failed_update": {
+							"type": "string"
+						},
+						"failed_remove": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["no_items", "remove_tooltip", "failed_update", "failed_remove"]
+				},
+				"results": {
+					"type": "object",
+					"properties": {
+						"run_simulation": {
+							"type": "string"
+						},
+						"equip_button": {
+							"type": "string"
+						},
+						"gear_equipped": {
+							"type": "string"
+						},
+						"current_gear": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["run_simulation", "equip_button", "gear_equipped", "current_gear"]
+				},
+				"gem_selector": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title"]
+				},
+				"import_modal": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"description_line1": {
+							"type": "string"
+						},
+						"description_line2": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title", "description_line1", "description_line2"]
+				}
+			},
+			"additionalProperties": false,
+			"required": [
+				"title",
+				"description",
+				"download_local",
+				"tabs",
+				"actions",
+				"search",
+				"settings",
+				"progress",
+				"notifications",
+				"warning",
+				"picker",
+				"results",
+				"gem_selector",
+				"import_modal"
+			]
+		},
+		"rotation_tab": {
+			"type": "object",
+			"properties": {
+				"title": {
+					"type": "string"
+				},
+				"common": {
+					"type": "object",
+					"properties": {
+						"rotation_type": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"auto": {
+									"type": "string"
+								},
+								"simple": {
+									"type": "string"
+								},
+								"apl": {
+									"type": "string"
+								},
+								"single_target": {
+									"type": "string"
+								},
+								"aoe": {
+									"type": "string"
+								},
+								"custom": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "auto", "simple", "apl", "single_target", "aoe", "custom"]
+						}
+					},
+					"additionalProperties": false,
+					"required": ["rotation_type"]
+				},
+				"apl": {
+					"type": "object",
+					"properties": {
+						"actionGroups": {
+							"type": "object",
+							"properties": {
+								"attributes": {
+									"type": "object",
+									"properties": {
+										"actions": {
+											"type": "string"
+										},
+										"name": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["actions", "name"]
+								},
+								"header": {
+									"type": "string"
+								},
+								"name": {
+									"type": "string"
+								},
+								"newGroupName": {
+									"type": "string"
+								},
+								"tooltips": {
+									"type": "object",
+									"properties": {
+										"actions": {
+											"type": "string"
+										},
+										"name": {
+											"type": "string"
+										},
+										"overview": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["actions", "name", "overview"]
+								}
+							},
+							"additionalProperties": false,
+							"required": ["attributes", "header", "name", "newGroupName", "tooltips"]
+						},
+						"floatingActionBar": {
+							"type": "object",
+							"properties": {
+								"new": {
+									"type": "string"
+								},
+								"reset": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["new", "reset"]
+						},
+						"nameModal": {
+							"type": "object",
+							"properties": {
+								"create": {
+									"type": "string"
+								},
+								"nameConflict": {
+									"type": "string"
+								},
+								"extract": {
+									"type": "string"
+								},
+								"rename": {
+									"type": "string"
+								},
+								"renameConfirm": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["create", "nameConflict", "extract", "rename", "renameConfirm"]
+						},
+						"prePullActions": {
+							"type": "object",
+							"properties": {
+								"header": {
+									"type": "string"
+								},
+								"name": {
+									"type": "string"
+								},
+								"tooltips": {
+									"type": "object",
+									"properties": {
+										"overview": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["overview"]
+								}
+							},
+							"additionalProperties": false,
+							"required": ["header", "name", "tooltips"]
+						},
+						"priorityList": {
+							"type": "object",
+							"properties": {
+								"header": {
+									"type": "string"
+								},
+								"name": {
+									"type": "string"
+								},
+								"tooltips": {
+									"type": "object",
+									"properties": {
+										"overview": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["overview"]
+								}
+							},
+							"additionalProperties": false,
+							"required": ["header", "name", "tooltips"]
+						},
+						"tabs": {
+							"type": "object",
+							"properties": {
+								"actionGroups": {
+									"type": "string"
+								},
+								"priorityList": {
+									"type": "string"
+								},
+								"variables": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["actionGroups", "priorityList", "variables"]
+						},
+						"variables": {
+							"type": "object",
+							"properties": {
+								"attributes": {
+									"type": "object",
+									"properties": {
+										"name": {
+											"type": "string"
+										},
+										"nameTooltip": {
+											"type": "string"
+										},
+										"value": {
+											"type": "string"
+										},
+										"valueTooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["name", "nameTooltip", "value", "valueTooltip"]
+								},
+								"enterVariableName": {
+									"type": "string"
+								},
+								"extractToVariable": {
+									"type": "string"
+								},
+								"header": {
+									"type": "string"
+								},
+								"name": {
+									"type": "string"
+								},
+								"newVariableName": {
+									"type": "string"
+								},
+								"tooltips": {
+									"type": "object",
+									"properties": {
+										"name": {
+											"type": "string"
+										},
+										"overview": {
+											"type": "string"
+										},
+										"value": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["name", "overview", "value"]
+								}
+							},
+							"additionalProperties": false,
+							"required": ["attributes", "enterVariableName", "extractToVariable", "header", "name", "newVariableName", "tooltips"]
+						},
+						"variablePlaceholder": {
+							"type": "object",
+							"properties": {
+								"name": {
+									"type": "string"
+								},
+								"nameLabel": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["name", "nameLabel"]
+						},
+						"prepull_actions": {
+							"type": "object",
+							"properties": {
+								"title": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								},
+								"item_label": {
+									"type": "string"
+								},
+								"do_at": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"new_action": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["title", "tooltip", "item_label", "do_at", "new_action"]
+						},
+						"priority_list": {
+							"type": "object",
+							"properties": {
+								"title": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								},
+								"item_label": {
+									"type": "string"
+								},
+								"if_label": {
+									"type": "string"
+								},
+								"new_action": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["title", "tooltip", "item_label", "if_label", "new_action"]
+						},
+						"actions": {
+							"type": "object",
+							"properties": {
+								"cast": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"cancel_cast": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"cast_at_player": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"multi_dot": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										},
+										"max_dots": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										},
+										"overlap": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip", "max_dots", "overlap"]
+								},
+								"strict_multi_dot": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										},
+										"max_dots": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										},
+										"overlap": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip", "max_dots", "overlap"]
+								},
+								"multi_shield": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										},
+										"max_shields": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										},
+										"overlap": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip", "max_shields", "overlap"]
+								},
+								"channel": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										},
+										"full_description": {
+											"type": "string"
+										},
+										"interrupt_if": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										},
+										"recast": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip", "full_description", "interrupt_if", "recast"]
+								},
+								"cast_all_stat_buff_cooldowns": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										},
+										"full_description": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip", "full_description"]
+								},
+								"autocast_other_cooldowns": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										},
+										"full_description": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip", "full_description"]
+								},
+								"wait": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"wait_until": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"scheduled_action": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										},
+										"do_at": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip", "do_at"]
+								},
+								"do_at": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"sequence": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										},
+										"full_description": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip", "full_description"]
+								},
+								"reset_sequence": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										},
+										"full_description": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip", "full_description"]
+								},
+								"strict_sequence": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										},
+										"full_description": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip", "full_description"]
+								},
+								"change_target": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"activate_aura": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"activate_aura_with_stacks": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										},
+										"stacks": {
+											"type": "string"
+										},
+										"stacks_tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip", "stacks", "stacks_tooltip"]
+								},
+								"activate_all_stat_buff_proc_auras": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"cancel_aura": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"trigger_icd": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"damage_amplification": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										},
+										"amount": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label"]
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip", "amount"]
+								},
+								"item_swap": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"move": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										},
+										"to_range": {
+											"type": "string"
+										},
+										"to_range_tooltip": {
+											"type": "string"
+										},
+										"move_duration": {
+											"type": "string"
+										},
+										"duration": {
+											"type": "string"
+										},
+										"duration_tooltip": {
+											"type": "string"
+										},
+										"move_duration_tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"label",
+										"tooltip",
+										"to_range",
+										"to_range_tooltip",
+										"move_duration",
+										"duration",
+										"duration_tooltip",
+										"move_duration_tooltip"
+									]
+								},
+								"custom_rotation": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"optimal_rotation_action": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										},
+										"wrath_weave": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip", "wrath_weave"]
+								},
+								"guardian_hotw_dps_rotation": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"warlock_next_exhale_target": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"cast",
+								"cancel_cast",
+								"cast_at_player",
+								"multi_dot",
+								"strict_multi_dot",
+								"multi_shield",
+								"channel",
+								"cast_all_stat_buff_cooldowns",
+								"autocast_other_cooldowns",
+								"wait",
+								"wait_until",
+								"scheduled_action",
+								"do_at",
+								"sequence",
+								"reset_sequence",
+								"strict_sequence",
+								"change_target",
+								"activate_aura",
+								"activate_aura_with_stacks",
+								"activate_all_stat_buff_proc_auras",
+								"cancel_aura",
+								"trigger_icd",
+								"damage_amplification",
+								"item_swap",
+								"move",
+								"custom_rotation",
+								"optimal_rotation_action",
+								"guardian_hotw_dps_rotation",
+								"warlock_next_exhale_target"
+							]
+						},
+						"values": {
+							"type": "object",
+							"properties": {
+								"item_label": {
+									"type": "string"
+								},
+								"no_condition": {
+									"type": "string"
+								},
+								"none": {
+									"type": "string"
+								},
+								"const": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										},
+										"full_description": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip", "full_description"]
+								},
+								"compare": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"math": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"max": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"min": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"all_of": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"any_of": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"not": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"current_time": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"current_time_percent": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"remaining_time": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"remaining_time_percent": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"is_execute_phase": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"num_targets": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"spell_is_casting": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"spell_time_to_ready": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"in_front_of_target": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"boss_cast": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"boss_cast_time_to_ready": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"boss_current_target": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"unit_is_moving": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"distance_to_unit": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"current_health": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"current_health_percent": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"max_health": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"current_mana": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"current_mana_percent": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"current_rage": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"max_rage": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"current_focus": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"max_focus": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"focus_regen_per_second": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"estimated_time_to_target_focus": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"current_energy": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"max_energy": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"energy_regen_per_second": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"estimated_time_to_target_energy": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"current_combo_points": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"max_combo_points": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"current_chi": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"max_chi": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"current_runic_power": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"max_runic_power": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"solar_energy": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"lunar_energy": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"current_eclipse_phase": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"generic_resource": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"num_runes": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"num_non_death_runes": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"rune_is_ready": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"rune_is_death": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"rune_cooldown": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"next_rune_cooldown": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"rune_slot_cooldown": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"full_rune_cooldown": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"gcd_is_ready": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"gcd_time_to_ready": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"time_to_next_auto": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"remaining_cast_time": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"spell_known": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"current_cost": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"can_cast": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										},
+										"full_description": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip", "full_description"]
+								},
+								"is_ready": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"time_to_ready": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"cast_time": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"travel_time": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"cpm": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"is_casting": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"is_channeling": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"channeled_ticks": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"number_of_charges": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"time_to_next_charge": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"gcd_hasted_duration": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"full_cooldown": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"channel_clip_delay": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"input_delay": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"spell_in_flight": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"aura_known": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"aura_active": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"aura_active_with_reaction_time": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"aura_inactive": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"aura_inactive_with_reaction_time": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"aura_remaining_time": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"aura_num_stacks": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"aura_should_refresh": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										},
+										"full_description": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip", "full_description"]
+								},
+								"all_trinket_stat_procs_active": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										},
+										"full_description": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip", "full_description"]
+								},
+								"any_trinket_stat_procs_active": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										},
+										"full_description": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip", "full_description"]
+								},
+								"any_trinket_stat_procs_available": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"trinket_procs_min_remaining_time": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"trinket_procs_max_remaining_icd": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"num_equipped_stat_proc_trinkets": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"num_stat_buff_cooldowns": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										},
+										"full_description": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip", "full_description"]
+								},
+								"any_stat_buff_cooldowns_active": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										},
+										"full_description": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip", "full_description"]
+								},
+								"any_stat_buff_cooldowns_min_duration": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"dot_is_active": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"dot_is_active_on_all_targets": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"dot_remaining_time": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"dot_lowest_remaining_time": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"dot_tick_frequency": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"dot_time_to_next_tick": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"dot_percent_increase": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"sequence_is_complete": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"sequence_is_ready": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"sequence_time_to_ready": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"totem_remaining_time": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"shaman_fire_elemental_duration": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"cat_excess_energy": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"cat_new_savage_roar_duration": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"warlock_hand_of_guldan_in_flight": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"warlock_haunt_in_flight": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"affliction_current_snapshot": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"affliction_exhale_window": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"mage_current_combustion_dot_estimate": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"brewmaster_monk_current_stagger_percent": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"protection_paladin_damage_taken_last_global": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"aura_remaining_icd": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"aura_icd_is_ready": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"aura_icd_is_ready_with_reaction_time": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"overlap": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"item_label",
+								"no_condition",
+								"none",
+								"const",
+								"compare",
+								"math",
+								"max",
+								"min",
+								"all_of",
+								"any_of",
+								"not",
+								"current_time",
+								"current_time_percent",
+								"remaining_time",
+								"remaining_time_percent",
+								"is_execute_phase",
+								"num_targets",
+								"spell_is_casting",
+								"spell_time_to_ready",
+								"in_front_of_target",
+								"boss_cast",
+								"boss_cast_time_to_ready",
+								"boss_current_target",
+								"unit_is_moving",
+								"distance_to_unit",
+								"current_health",
+								"current_health_percent",
+								"max_health",
+								"current_mana",
+								"current_mana_percent",
+								"current_rage",
+								"max_rage",
+								"current_focus",
+								"max_focus",
+								"focus_regen_per_second",
+								"estimated_time_to_target_focus",
+								"current_energy",
+								"max_energy",
+								"energy_regen_per_second",
+								"estimated_time_to_target_energy",
+								"current_combo_points",
+								"max_combo_points",
+								"current_chi",
+								"max_chi",
+								"current_runic_power",
+								"max_runic_power",
+								"solar_energy",
+								"lunar_energy",
+								"current_eclipse_phase",
+								"generic_resource",
+								"num_runes",
+								"num_non_death_runes",
+								"rune_is_ready",
+								"rune_is_death",
+								"rune_cooldown",
+								"next_rune_cooldown",
+								"rune_slot_cooldown",
+								"full_rune_cooldown",
+								"gcd_is_ready",
+								"gcd_time_to_ready",
+								"time_to_next_auto",
+								"remaining_cast_time",
+								"spell_known",
+								"current_cost",
+								"can_cast",
+								"is_ready",
+								"time_to_ready",
+								"cast_time",
+								"travel_time",
+								"cpm",
+								"is_casting",
+								"is_channeling",
+								"channeled_ticks",
+								"number_of_charges",
+								"time_to_next_charge",
+								"gcd_hasted_duration",
+								"full_cooldown",
+								"channel_clip_delay",
+								"input_delay",
+								"spell_in_flight",
+								"aura_known",
+								"aura_active",
+								"aura_active_with_reaction_time",
+								"aura_inactive",
+								"aura_inactive_with_reaction_time",
+								"aura_remaining_time",
+								"aura_num_stacks",
+								"aura_should_refresh",
+								"all_trinket_stat_procs_active",
+								"any_trinket_stat_procs_active",
+								"any_trinket_stat_procs_available",
+								"trinket_procs_min_remaining_time",
+								"trinket_procs_max_remaining_icd",
+								"num_equipped_stat_proc_trinkets",
+								"num_stat_buff_cooldowns",
+								"any_stat_buff_cooldowns_active",
+								"any_stat_buff_cooldowns_min_duration",
+								"dot_is_active",
+								"dot_is_active_on_all_targets",
+								"dot_remaining_time",
+								"dot_lowest_remaining_time",
+								"dot_tick_frequency",
+								"dot_time_to_next_tick",
+								"dot_percent_increase",
+								"sequence_is_complete",
+								"sequence_is_ready",
+								"sequence_time_to_ready",
+								"totem_remaining_time",
+								"shaman_fire_elemental_duration",
+								"cat_excess_energy",
+								"cat_new_savage_roar_duration",
+								"warlock_hand_of_guldan_in_flight",
+								"warlock_haunt_in_flight",
+								"affliction_current_snapshot",
+								"affliction_exhale_window",
+								"mage_current_combustion_dot_estimate",
+								"brewmaster_monk_current_stagger_percent",
+								"protection_paladin_damage_taken_last_global",
+								"aura_remaining_icd",
+								"aura_icd_is_ready",
+								"aura_icd_is_ready_with_reaction_time",
+								"overlap"
+							]
+						},
+						"operators": {
+							"type": "object",
+							"properties": {
+								"equals": {
+									"type": "string"
+								},
+								"not_equals": {
+									"type": "string"
+								},
+								"greater_than_or_equal": {
+									"type": "string"
+								},
+								"greater_than": {
+									"type": "string"
+								},
+								"less_than_or_equal": {
+									"type": "string"
+								},
+								"less_than": {
+									"type": "string"
+								},
+								"add": {
+									"type": "string"
+								},
+								"subtract": {
+									"type": "string"
+								},
+								"multiply": {
+									"type": "string"
+								},
+								"divide": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"equals",
+								"not_equals",
+								"greater_than_or_equal",
+								"greater_than",
+								"less_than_or_equal",
+								"less_than",
+								"add",
+								"subtract",
+								"multiply",
+								"divide"
+							]
+						},
+						"execute_phases": {
+							"type": "object",
+							"properties": {
+								"e20": {
+									"type": "string"
+								},
+								"e25": {
+									"type": "string"
+								},
+								"e35": {
+									"type": "string"
+								},
+								"e45": {
+									"type": "string"
+								},
+								"e90": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["e20", "e25", "e35", "e45", "e90"]
+						},
+						"totem_types": {
+							"type": "object",
+							"properties": {
+								"earth": {
+									"type": "string"
+								},
+								"air": {
+									"type": "string"
+								},
+								"fire": {
+									"type": "string"
+								},
+								"water": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["earth", "air", "fire", "water"]
+						},
+						"submenus": {
+							"type": "object",
+							"properties": {
+								"logic": {
+									"type": "string"
+								},
+								"encounter": {
+									"type": "string"
+								},
+								"boss": {
+									"type": "string"
+								},
+								"unit": {
+									"type": "string"
+								},
+								"resources": {
+									"type": "string"
+								},
+								"gcd": {
+									"type": "string"
+								},
+								"auto": {
+									"type": "string"
+								},
+								"spell": {
+									"type": "string"
+								},
+								"aura": {
+									"type": "string"
+								},
+								"aura_sets": {
+									"type": "string"
+								},
+								"dot": {
+									"type": "string"
+								},
+								"sequence": {
+									"type": "string"
+								},
+								"casting": {
+									"type": "string"
+								},
+								"timing": {
+									"type": "string"
+								},
+								"sequences": {
+									"type": "string"
+								},
+								"misc": {
+									"type": "string"
+								},
+								"feral_druid": {
+									"type": "string"
+								},
+								"guardian_druid": {
+									"type": "string"
+								},
+								"shaman": {
+									"type": "string"
+								},
+								"warlock": {
+									"type": "string"
+								},
+								"mage": {
+									"type": "string"
+								},
+								"tank": {
+									"type": "string"
+								},
+								"health": {
+									"type": "string"
+								},
+								"mana": {
+									"type": "string"
+								},
+								"rage": {
+									"type": "string"
+								},
+								"focus": {
+									"type": "string"
+								},
+								"energy": {
+									"type": "string"
+								},
+								"combo_points": {
+									"type": "string"
+								},
+								"chi": {
+									"type": "string"
+								},
+								"runic_power": {
+									"type": "string"
+								},
+								"eclipse": {
+									"type": "string"
+								},
+								"runes": {
+									"type": "string"
+								},
+								"cooldowns": {
+									"type": "string"
+								},
+								"non_combat_potions": {
+									"type": "string"
+								},
+								"placeholders": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"logic",
+								"encounter",
+								"boss",
+								"unit",
+								"resources",
+								"gcd",
+								"auto",
+								"spell",
+								"aura",
+								"aura_sets",
+								"dot",
+								"sequence",
+								"casting",
+								"timing",
+								"sequences",
+								"misc",
+								"feral_druid",
+								"guardian_druid",
+								"shaman",
+								"warlock",
+								"mage",
+								"tank",
+								"health",
+								"mana",
+								"rage",
+								"focus",
+								"energy",
+								"combo_points",
+								"chi",
+								"runic_power",
+								"eclipse",
+								"runes",
+								"cooldowns",
+								"non_combat_potions",
+								"placeholders"
+							]
+						},
+						"item_swap_sets": {
+							"type": "object",
+							"properties": {
+								"main": {
+									"type": "string"
+								},
+								"swapped": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["main", "swapped"]
+						},
+						"helpers": {
+							"type": "object",
+							"properties": {
+								"action_id_sets": {
+									"type": "object",
+									"properties": {
+										"auras": {
+											"type": "string"
+										},
+										"stackable_auras": {
+											"type": "string"
+										},
+										"icd_auras": {
+											"type": "string"
+										},
+										"exclusive_effect_auras": {
+											"type": "string"
+										},
+										"spells": {
+											"type": "string"
+										},
+										"castable_spells": {
+											"type": "string"
+										},
+										"channel_spells": {
+											"type": "string"
+										},
+										"dot_spells": {
+											"type": "string"
+										},
+										"castable_dot_spells": {
+											"type": "string"
+										},
+										"shield_spells": {
+											"type": "string"
+										},
+										"non_instant_spells": {
+											"type": "string"
+										},
+										"friendly_spells": {
+											"type": "string"
+										},
+										"expected_dot_spells": {
+											"type": "string"
+										},
+										"spells_with_travelTime": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"auras",
+										"stackable_auras",
+										"icd_auras",
+										"exclusive_effect_auras",
+										"spells",
+										"castable_spells",
+										"channel_spells",
+										"dot_spells",
+										"castable_dot_spells",
+										"shield_spells",
+										"non_instant_spells",
+										"friendly_spells",
+										"expected_dot_spells",
+										"spells_with_travelTime"
+									]
+								},
+								"field_configs": {
+									"type": "object",
+									"properties": {
+										"type": {
+											"type": "string"
+										},
+										"strategy": {
+											"type": "string"
+										},
+										"buff_type": {
+											"type": "string"
+										},
+										"min_icd": {
+											"type": "string"
+										},
+										"min_icd_tooltip": {
+											"type": "string"
+										},
+										"include_reaction_time": {
+											"type": "string"
+										},
+										"include_reaction_time_tooltip": {
+											"type": "string"
+										},
+										"use_base_value": {
+											"type": "string"
+										},
+										"use_base_value_tooltip": {
+											"type": "string"
+										},
+										"variable_assignment_tooltip": {
+											"type": "string"
+										},
+										"amplification_type": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"type",
+										"strategy",
+										"buff_type",
+										"min_icd",
+										"min_icd_tooltip",
+										"include_reaction_time",
+										"include_reaction_time_tooltip",
+										"use_base_value",
+										"use_base_value_tooltip",
+										"variable_assignment_tooltip",
+										"amplification_type"
+									]
+								},
+								"eclipse_types": {
+									"type": "object",
+									"properties": {
+										"lunar": {
+											"type": "string"
+										},
+										"solar": {
+											"type": "string"
+										},
+										"neutral": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["lunar", "solar", "neutral"]
+								},
+								"rune_types": {
+									"type": "object",
+									"properties": {
+										"blood": {
+											"type": "string"
+										},
+										"frost": {
+											"type": "string"
+										},
+										"unholy": {
+											"type": "string"
+										},
+										"death": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["blood", "frost", "unholy", "death"]
+								},
+								"rune_slots": {
+									"type": "object",
+									"properties": {
+										"blood_left": {
+											"type": "string"
+										},
+										"blood_right": {
+											"type": "string"
+										},
+										"frost_left": {
+											"type": "string"
+										},
+										"frost_right": {
+											"type": "string"
+										},
+										"unholy_left": {
+											"type": "string"
+										},
+										"unholy_right": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["blood_left", "blood_right", "frost_left", "frost_right", "unholy_left", "unholy_right"]
+								},
+								"rotation_types": {
+									"type": "object",
+									"properties": {
+										"single_target": {
+											"type": "string"
+										},
+										"aoe": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["single_target", "aoe"]
+								},
+								"hotw_strategies": {
+									"type": "object",
+									"properties": {
+										"caster": {
+											"type": "string"
+										},
+										"cat": {
+											"type": "string"
+										},
+										"hybrid": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["caster", "cat", "hybrid"]
+								},
+								"amplification_types": {
+									"type": "object",
+									"properties": {
+										"caster_buff": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										},
+										"environment_buff": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										},
+										"target_debuff": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										}
+									},
+									"additionalProperties": false,
+									"required": ["caster_buff", "environment_buff", "target_debuff"]
+								},
+								"unit_labels": {
+									"type": "object",
+									"properties": {
+										"self": {
+											"type": "string"
+										},
+										"current_target": {
+											"type": "string"
+										},
+										"previous_target": {
+											"type": "string"
+										},
+										"next_target": {
+											"type": "string"
+										},
+										"player": {
+											"type": "string"
+										},
+										"target": {
+											"type": "string"
+										},
+										"pet": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["self", "current_target", "previous_target", "next_target", "player", "target", "pet"]
+								},
+								"placeholder_tooltip": {
+									"type": "string"
+								},
+								"select_variable": {
+									"type": "string"
+								},
+								"select_group": {
+									"type": "string"
+								},
+								"no_variables_defined": {
+									"type": "string"
+								},
+								"no_groups_defined": {
+									"type": "string"
+								},
+								"buttons": {
+									"type": "object",
+									"properties": {
+										"enable_action": {
+											"type": "string"
+										},
+										"disable_action": {
+											"type": "string"
+										},
+										"enable_disable": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["enable_action", "disable_action", "enable_disable"]
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"action_id_sets",
+								"field_configs",
+								"eclipse_types",
+								"rune_types",
+								"rune_slots",
+								"rotation_types",
+								"hotw_strategies",
+								"amplification_types",
+								"unit_labels",
+								"placeholder_tooltip",
+								"select_variable",
+								"select_group",
+								"no_variables_defined",
+								"no_groups_defined",
+								"buttons"
+							]
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"actionGroups",
+						"floatingActionBar",
+						"nameModal",
+						"prePullActions",
+						"priorityList",
+						"tabs",
+						"variables",
+						"variablePlaceholder",
+						"prepull_actions",
+						"priority_list",
+						"actions",
+						"values",
+						"operators",
+						"execute_phases",
+						"totem_types",
+						"submenus",
+						"item_swap_sets",
+						"helpers"
+					]
+				},
+				"auto": {
+					"type": "object",
+					"properties": {
+						"description": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["description"]
+				},
+				"simple": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title"]
+				},
+				"cooldowns": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"tooltip": {
+							"type": "string"
+						},
+						"delete_tooltip": {
+							"type": "string"
+						},
+						"timings_placeholder": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title", "tooltip", "delete_tooltip", "timings_placeholder"]
+				},
+				"saved_rotations": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"label": {
+							"type": "string"
+						},
+						"name_label": {
+							"type": "string"
+						},
+						"save_button": {
+							"type": "string"
+						},
+						"delete": {
+							"type": "object",
+							"properties": {
+								"confirm": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["confirm", "tooltip"]
+						},
+						"alerts": {
+							"type": "object",
+							"properties": {
+								"choose_name": {
+									"type": "string"
+								},
+								"name_exists": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["choose_name", "name_exists"]
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title", "label", "name_label", "save_button", "delete", "alerts"]
+				},
+				"options": {
+					"type": "object",
+					"properties": {
+						"druid": {
+							"type": "object",
+							"properties": {
+								"feral": {
+									"type": "object",
+									"properties": {
+										"target_type": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"single_target": {
+													"type": "string"
+												},
+												"aoe": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "single_target", "aoe"]
+										},
+										"bear_weave": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										},
+										"snek_weave": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										},
+										"use_ns": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										},
+										"manual_params": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										},
+										"hotw_strategy": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												},
+												"values": {
+													"type": "object",
+													"properties": {
+														"passives_only": {
+															"type": "string"
+														},
+														"enhanced_bear_weaving": {
+															"type": "string"
+														},
+														"wrath_weaving": {
+															"type": "string"
+														}
+													},
+													"additionalProperties": false,
+													"required": ["passives_only", "enhanced_bear_weaving", "wrath_weaving"]
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip", "values"]
+										},
+										"allow_aoe_berserk": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										},
+										"roar_offset": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										},
+										"rip_leeway": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										},
+										"bite_during_rotation": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										},
+										"bite_time": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										},
+										"berserk_bite_time": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"target_type",
+										"bear_weave",
+										"snek_weave",
+										"use_ns",
+										"manual_params",
+										"hotw_strategy",
+										"allow_aoe_berserk",
+										"roar_offset",
+										"rip_leeway",
+										"bite_during_rotation",
+										"bite_time",
+										"berserk_bite_time"
+									]
+								}
+							},
+							"additionalProperties": false,
+							"required": ["feral"]
+						},
+						"guardian": {
+							"type": "object",
+							"properties": {
+								"maintain_faerie_fire": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"maintain_demo_roar": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"demo_roar_refresh_leeway": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"pulverize_refresh_leeway": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								}
+							},
+							"additionalProperties": false,
+							"required": ["maintain_faerie_fire", "maintain_demo_roar", "demo_roar_refresh_leeway", "pulverize_refresh_leeway"]
+						},
+						"rogue": {
+							"type": "object",
+							"properties": {
+								"apply_poisons_manually": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"subtlety": {
+									"type": "object",
+									"properties": {
+										"honor_of_thieves_crit_rate": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										}
+									},
+									"additionalProperties": false,
+									"required": ["honor_of_thieves_crit_rate"]
+								}
+							},
+							"additionalProperties": false,
+							"required": ["apply_poisons_manually", "subtlety"]
+						},
+						"shaman": {
+							"type": "object",
+							"properties": {
+								"elemental": {
+									"type": "object",
+									"properties": {
+										"thunderstorm_in_range": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										}
+									},
+									"additionalProperties": false,
+									"required": ["thunderstorm_in_range"]
+								}
+							},
+							"additionalProperties": false,
+							"required": ["elemental"]
+						},
+						"warlock": {
+							"type": "object",
+							"properties": {
+								"affliction": {
+									"type": "object",
+									"properties": {
+										"exhale_window": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										}
+									},
+									"additionalProperties": false,
+									"required": ["exhale_window"]
+								}
+							},
+							"additionalProperties": false,
+							"required": ["affliction"]
+						},
+						"hunter": {
+							"type": "object",
+							"properties": {
+								"beast_mastery": {
+									"type": "object",
+									"properties": {
+										"sting": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												},
+												"values": {
+													"type": "object",
+													"properties": {
+														"none": {
+															"type": "string"
+														},
+														"serpent_sting": {
+															"type": "string"
+														}
+													},
+													"additionalProperties": false,
+													"required": ["none", "serpent_sting"]
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip", "values"]
+										},
+										"trap_weave": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										},
+										"multi_dot_serpent_sting": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										}
+									},
+									"additionalProperties": false,
+									"required": ["sting", "trap_weave", "multi_dot_serpent_sting"]
+								},
+								"marksmanship": {
+									"type": "object",
+									"properties": {
+										"sting": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												},
+												"values": {
+													"type": "object",
+													"properties": {
+														"none": {
+															"type": "string"
+														},
+														"serpent_sting": {
+															"type": "string"
+														}
+													},
+													"additionalProperties": false,
+													"required": ["none", "serpent_sting"]
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip", "values"]
+										},
+										"trap_weave": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										},
+										"multi_dot_serpent_sting": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										}
+									},
+									"additionalProperties": false,
+									"required": ["sting", "trap_weave", "multi_dot_serpent_sting"]
+								},
+								"survival": {
+									"type": "object",
+									"properties": {
+										"multi_dot_serpent_sting": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										}
+									},
+									"additionalProperties": false,
+									"required": ["multi_dot_serpent_sting"]
+								}
+							},
+							"additionalProperties": false,
+							"required": ["beast_mastery", "marksmanship", "survival"]
+						}
+					},
+					"additionalProperties": false,
+					"required": ["druid", "guardian", "rogue", "shaman", "warlock", "hunter"]
+				}
+			},
+			"additionalProperties": false,
+			"required": ["title", "common", "apl", "auto", "simple", "cooldowns", "saved_rotations", "options"]
+		},
+		"results_tab": {
+			"type": "object",
+			"properties": {
+				"title": {
+					"type": "string"
+				},
+				"details": {
+					"type": "object",
+					"properties": {
+						"no_results": {
+							"type": "string"
+						},
+						"view_in_separate_tab": {
+							"type": "string"
+						},
+						"sim_1_iteration": {
+							"type": "string"
+						},
+						"sim_1_death": {
+							"type": "string"
+						},
+						"all_targets": {
+							"type": "string"
+						},
+						"all_players": {
+							"type": "string"
+						},
+						"target_number": {
+							"type": "string"
+						},
+						"damage": {
+							"type": "object",
+							"properties": {
+								"dps_histogram": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["dps_histogram"]
+						},
+						"timeline": {
+							"type": "object",
+							"properties": {
+								"disclaimer": {
+									"type": "string"
+								},
+								"note": {
+									"type": "string"
+								},
+								"chart_types": {
+									"type": "object",
+									"properties": {
+										"rotation": {
+											"type": "string"
+										},
+										"dps": {
+											"type": "string"
+										},
+										"threat": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["rotation", "dps", "threat"]
+								},
+								"chart_options": {
+									"type": "object",
+									"properties": {
+										"time_axis": {
+											"type": "string"
+										},
+										"waiting_for_data": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["time_axis", "waiting_for_data"]
+								},
+								"tooltips": {
+									"type": "object",
+									"properties": {
+										"dps": {
+											"type": "string"
+										},
+										"dtps": {
+											"type": "string"
+										},
+										"amount": {
+											"type": "string"
+										},
+										"player_damage": {
+											"type": "string"
+										},
+										"player_damage_taken": {
+											"type": "string"
+										},
+										"before": {
+											"type": "string"
+										},
+										"after": {
+											"type": "string"
+										},
+										"threat": {
+											"type": "string"
+										},
+										"active_auras": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["dps", "dtps", "amount", "player_damage", "player_damage_taken", "before", "after", "threat", "active_auras"]
+								}
+							},
+							"additionalProperties": false,
+							"required": ["disclaimer", "note", "chart_types", "chart_options", "tooltips"]
+						},
+						"logs": {
+							"type": "object",
+							"properties": {
+								"top_button": {
+									"type": "string"
+								},
+								"time_column": {
+									"type": "string"
+								},
+								"event_column": {
+									"type": "string"
+								},
+								"show_debug": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["top_button", "time_column", "event_column", "show_debug"]
+						},
+						"tabs": {
+							"type": "object",
+							"properties": {
+								"damage": {
+									"type": "string"
+								},
+								"healing": {
+									"type": "string"
+								},
+								"damage_taken": {
+									"type": "string"
+								},
+								"buffs": {
+									"type": "string"
+								},
+								"debuffs": {
+									"type": "string"
+								},
+								"casts": {
+									"type": "string"
+								},
+								"resources": {
+									"type": "string"
+								},
+								"timeline": {
+									"type": "string"
+								},
+								"replay": {
+									"type": "string"
+								},
+								"log": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["damage", "healing", "damage_taken", "buffs", "debuffs", "casts", "resources", "timeline", "replay", "log"]
+						},
+						"columns": {
+							"type": "object",
+							"properties": {
+								"damage_done": {
+									"type": "string"
+								},
+								"casts": {
+									"type": "string"
+								},
+								"avg_cast": {
+									"type": "string"
+								},
+								"hits": {
+									"type": "string"
+								},
+								"avg_hit": {
+									"type": "string"
+								},
+								"crit_percent": {
+									"type": "string"
+								},
+								"miss_percent": {
+									"type": "string"
+								},
+								"dpet": {
+									"type": "string"
+								},
+								"dps": {
+									"type": "string"
+								},
+								"healing_done": {
+									"type": "string"
+								},
+								"cpm": {
+									"type": "string"
+								},
+								"cast_time": {
+									"type": "string"
+								},
+								"hpm": {
+									"type": "string"
+								},
+								"hpet": {
+									"type": "string"
+								},
+								"amount": {
+									"type": "string"
+								},
+								"dtps": {
+									"type": "string"
+								},
+								"avg_heal": {
+									"type": "string"
+								},
+								"hps": {
+									"type": "string"
+								},
+								"damage_taken": {
+									"type": "string"
+								},
+								"overhealing": {
+									"type": "string"
+								},
+								"name": {
+									"type": "string"
+								},
+								"duration": {
+									"type": "string"
+								},
+								"uptime": {
+									"type": "string"
+								},
+								"procs": {
+									"type": "string"
+								},
+								"ppm": {
+									"type": "string"
+								},
+								"casts_per_minute": {
+									"type": "string"
+								},
+								"mana_gain": {
+									"type": "string"
+								},
+								"mana_cost": {
+									"type": "string"
+								},
+								"rage_gain": {
+									"type": "string"
+								},
+								"rage_cost": {
+									"type": "string"
+								},
+								"energy_gain": {
+									"type": "string"
+								},
+								"energy_cost": {
+									"type": "string"
+								},
+								"focus_gain": {
+									"type": "string"
+								},
+								"focus_cost": {
+									"type": "string"
+								},
+								"runic_power_gain": {
+									"type": "string"
+								},
+								"runic_power_cost": {
+									"type": "string"
+								},
+								"chi_gain": {
+									"type": "string"
+								},
+								"chi_cost": {
+									"type": "string"
+								},
+								"holy_power_gain": {
+									"type": "string"
+								},
+								"holy_power_cost": {
+									"type": "string"
+								},
+								"shadow_orbs_gain": {
+									"type": "string"
+								},
+								"shadow_orbs_cost": {
+									"type": "string"
+								},
+								"combo_points_gain": {
+									"type": "string"
+								},
+								"combo_points_cost": {
+									"type": "string"
+								},
+								"maelstrom_gain": {
+									"type": "string"
+								},
+								"maelstrom_cost": {
+									"type": "string"
+								},
+								"demonic_fury_gain": {
+									"type": "string"
+								},
+								"demonic_fury_cost": {
+									"type": "string"
+								},
+								"burning_embers_gain": {
+									"type": "string"
+								},
+								"burning_embers_cost": {
+									"type": "string"
+								},
+								"gain": {
+									"type": "string"
+								},
+								"gain_per_second": {
+									"type": "string"
+								},
+								"avg_gain": {
+									"type": "string"
+								},
+								"wasted_gain": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"damage_done",
+								"casts",
+								"avg_cast",
+								"hits",
+								"avg_hit",
+								"crit_percent",
+								"miss_percent",
+								"dpet",
+								"dps",
+								"healing_done",
+								"cpm",
+								"cast_time",
+								"hpm",
+								"hpet",
+								"amount",
+								"dtps",
+								"avg_heal",
+								"hps",
+								"damage_taken",
+								"overhealing",
+								"name",
+								"duration",
+								"uptime",
+								"procs",
+								"ppm",
+								"casts_per_minute",
+								"mana_gain",
+								"mana_cost",
+								"rage_gain",
+								"rage_cost",
+								"energy_gain",
+								"energy_cost",
+								"focus_gain",
+								"focus_cost",
+								"runic_power_gain",
+								"runic_power_cost",
+								"chi_gain",
+								"chi_cost",
+								"holy_power_gain",
+								"holy_power_cost",
+								"shadow_orbs_gain",
+								"shadow_orbs_cost",
+								"combo_points_gain",
+								"combo_points_cost",
+								"maelstrom_gain",
+								"maelstrom_cost",
+								"demonic_fury_gain",
+								"demonic_fury_cost",
+								"burning_embers_gain",
+								"burning_embers_cost",
+								"gain",
+								"gain_per_second",
+								"avg_gain",
+								"wasted_gain"
+							]
+						},
+						"tooltips": {
+							"type": "object",
+							"properties": {
+								"damage_avg_cast": {
+									"type": "string"
+								},
+								"player_damage": {
+									"type": "string"
+								},
+								"player_damage_taken": {
+									"type": "string"
+								},
+								"damage_taken_per_encounter": {
+									"type": "string"
+								},
+								"healing_per_encounter": {
+									"type": "string"
+								},
+								"threat_per_encounter": {
+									"type": "string"
+								},
+								"damage_taken": {
+									"type": "string"
+								},
+								"damage_per_encounter": {
+									"type": "string"
+								},
+								"damage_avg_cast_tooltip": {
+									"type": "string"
+								},
+								"healing_avg_cast_tooltip": {
+									"type": "string"
+								},
+								"healing_avg_hit_tooltip": {
+									"type": "string"
+								},
+								"healing_hits_tooltip": {
+									"type": "string"
+								},
+								"hit_miss_percent_tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"damage_avg_cast",
+								"player_damage",
+								"player_damage_taken",
+								"damage_taken_per_encounter",
+								"healing_per_encounter",
+								"threat_per_encounter",
+								"damage_taken",
+								"damage_per_encounter",
+								"damage_avg_cast_tooltip",
+								"healing_avg_cast_tooltip",
+								"healing_avg_hit_tooltip",
+								"healing_hits_tooltip",
+								"hit_miss_percent_tooltip"
+							]
+						},
+						"attack_types": {
+							"type": "object",
+							"properties": {
+								"hit": {
+									"type": "string"
+								},
+								"critical_hit": {
+									"type": "string"
+								},
+								"tick": {
+									"type": "string"
+								},
+								"critical_tick": {
+									"type": "string"
+								},
+								"glancing_blow": {
+									"type": "string"
+								},
+								"blocked_glancing_blow": {
+									"type": "string"
+								},
+								"blocked_hit": {
+									"type": "string"
+								},
+								"blocked_critical_hit": {
+									"type": "string"
+								},
+								"miss": {
+									"type": "string"
+								},
+								"parry": {
+									"type": "string"
+								},
+								"dodge": {
+									"type": "string"
+								},
+								"threat": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"hit",
+								"critical_hit",
+								"tick",
+								"critical_tick",
+								"glancing_blow",
+								"blocked_glancing_blow",
+								"blocked_hit",
+								"blocked_critical_hit",
+								"miss",
+								"parry",
+								"dodge",
+								"threat"
+							]
+						},
+						"tooltip_table": {
+							"type": "object",
+							"properties": {
+								"type": {
+									"type": "string"
+								},
+								"count": {
+									"type": "string"
+								},
+								"average": {
+									"type": "string"
+								},
+								"amount": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["type", "count", "average", "amount"]
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"no_results",
+						"view_in_separate_tab",
+						"sim_1_iteration",
+						"sim_1_death",
+						"all_targets",
+						"all_players",
+						"target_number",
+						"damage",
+						"timeline",
+						"logs",
+						"tabs",
+						"columns",
+						"tooltips",
+						"attack_types",
+						"tooltip_table"
+					]
+				}
+			},
+			"additionalProperties": false,
+			"required": ["title", "details"]
+		},
+		"import": {
+			"type": "object",
+			"properties": {
+				"title": {
+					"type": "string"
+				},
+				"json": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"description": {
+							"type": "string"
+						},
+						"instructions": {
+							"type": "string"
+						},
+						"upload_button": {
+							"type": "string"
+						},
+						"import_button": {
+							"type": "string"
+						},
+						"error_invalid_json": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title", "description", "instructions", "upload_button", "import_button", "error_invalid_json"]
+				},
+				"wowhead": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"description": {
+							"type": "string"
+						},
+						"gear_planner_link": {
+							"type": "string"
+						},
+						"feature_description": {
+							"type": "string"
+						},
+						"instructions": {
+							"type": "string"
+						},
+						"upload_button": {
+							"type": "string"
+						},
+						"import_button": {
+							"type": "string"
+						},
+						"tinker_warning": {
+							"type": "object",
+							"properties": {
+								"title": {
+									"type": "string"
+								},
+								"message": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["title", "message"]
+						},
+						"error_invalid_url": {
+							"type": "string"
+						},
+						"error_cannot_parse_class": {
+							"type": "string"
+						},
+						"error_cannot_parse_race": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"title",
+						"description",
+						"gear_planner_link",
+						"feature_description",
+						"instructions",
+						"upload_button",
+						"import_button",
+						"tinker_warning",
+						"error_invalid_url",
+						"error_cannot_parse_class",
+						"error_cannot_parse_race"
+					]
+				},
+				"addon": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"description": {
+							"type": "string"
+						},
+						"addon_link": {
+							"type": "string"
+						},
+						"feature_description": {
+							"type": "string"
+						},
+						"instructions": {
+							"type": "string"
+						},
+						"upload_button": {
+							"type": "string"
+						},
+						"import_button": {
+							"type": "string"
+						},
+						"reforge_warning": {
+							"type": "object",
+							"properties": {
+								"title": {
+									"type": "string"
+								},
+								"message": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["title", "message"]
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"title",
+						"description",
+						"addon_link",
+						"feature_description",
+						"instructions",
+						"upload_button",
+						"import_button",
+						"reforge_warning"
+					]
+				}
+			},
+			"additionalProperties": false,
+			"required": ["title", "json", "wowhead", "addon"]
+		},
+		"export": {
+			"type": "object",
+			"properties": {
+				"title": {
+					"type": "string"
+				},
+				"link": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"description": {
+							"type": "string"
+						},
+						"instructions": {
+							"type": "string"
+						},
+						"copy_button": {
+							"type": "string"
+						},
+						"copy_tooltip": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title", "description", "instructions", "copy_button", "copy_tooltip"]
+				},
+				"json": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"description": {
+							"type": "string"
+						},
+						"instructions": {
+							"type": "string"
+						},
+						"copy_button": {
+							"type": "string"
+						},
+						"copy_tooltip": {
+							"type": "string"
+						},
+						"download_button": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title", "description", "instructions", "copy_button", "copy_tooltip", "download_button"]
+				},
+				"wowhead": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"description": {
+							"type": "string"
+						},
+						"instructions": {
+							"type": "string"
+						},
+						"copy_button": {
+							"type": "string"
+						},
+						"copy_tooltip": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title", "description", "instructions", "copy_button", "copy_tooltip"]
+				},
+				"pawn_ep": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"description": {
+							"type": "string"
+						},
+						"instructions": {
+							"type": "string"
+						},
+						"copy_button": {
+							"type": "string"
+						},
+						"copy_tooltip": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title", "description", "instructions", "copy_button", "copy_tooltip"]
+				},
+				"cli": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"description": {
+							"type": "string"
+						},
+						"instructions": {
+							"type": "string"
+						},
+						"copy_button": {
+							"type": "string"
+						},
+						"copy_tooltip": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title", "description", "instructions", "copy_button", "copy_tooltip"]
+				},
+				"categories": {
+					"type": "object",
+					"properties": {
+						"gear": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"talents": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"rotation": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"consumes": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"external": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"miscellaneous": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"encounter": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						}
+					},
+					"additionalProperties": false,
+					"required": ["gear", "talents", "rotation", "consumes", "external", "miscellaneous", "encounter"]
+				}
+			},
+			"additionalProperties": false,
+			"required": ["title", "link", "json", "wowhead", "pawn_ep", "cli", "categories"]
+		},
+		"info": {
+			"type": "object",
+			"properties": {
+				"known_issues": {
+					"type": "string"
+				},
+				"bug_report": {
+					"type": "string"
+				},
+				"sim_options": {
+					"type": "string"
+				},
+				"discord": {
+					"type": "string"
+				},
+				"patreon": {
+					"type": "string"
+				},
+				"github": {
+					"type": "string"
+				},
+				"status": {
+					"type": "object",
+					"properties": {
+						"unlaunched": {
+							"type": "string"
+						},
+						"alpha": {
+							"type": "string"
+						},
+						"beta": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["unlaunched", "alpha", "beta"]
+				},
+				"options": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"fixed_rng_seed": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								},
+								"last_used": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip", "last_used"]
+						},
+						"language": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label", "tooltip"]
+						},
+						"feature_toggles": {
+							"type": "object",
+							"properties": {
+								"show_threat_metrics": {
+									"type": "string"
+								},
+								"show_experimental": {
+									"type": "string"
+								},
+								"show_quick_swap": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["show_threat_metrics", "show_experimental", "show_quick_swap"]
+						},
+						"use_multiple_cpu_cores": {
+							"type": "object",
+							"properties": {
+								"label": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["label"]
+						},
+						"restore_defaults": {
+							"type": "object",
+							"properties": {
+								"button": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								},
+								"success_message": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["button", "tooltip", "success_message"]
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title", "fixed_rng_seed", "language", "feature_toggles", "use_multiple_cpu_cores", "restore_defaults"]
+				}
+			},
+			"additionalProperties": false,
+			"required": ["known_issues", "bug_report", "sim_options", "discord", "patreon", "github", "status", "options"]
+		},
+		"sidebar": {
+			"type": "object",
+			"properties": {
+				"iterations": {
+					"type": "string"
+				},
+				"warnings": {
+					"type": "object",
+					"properties": {
+						"meta_gem_disabled": {
+							"type": "string"
+						},
+						"profession_requirement": {
+							"type": "string"
+						},
+						"too_many_jc_gems": {
+							"type": "string"
+						},
+						"unspent_talent_points": {
+							"type": "string"
+						},
+						"armor_specialization": {
+							"type": "string"
+						},
+						"dual_wield_2h_without_titans_grip": {
+							"type": "string"
+						},
+						"shaman_fele_autocast": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"meta_gem_disabled",
+						"profession_requirement",
+						"too_many_jc_gems",
+						"unspent_talent_points",
+						"armor_specialization",
+						"dual_wield_2h_without_titans_grip",
+						"shaman_fele_autocast"
+					]
+				},
+				"buttons": {
+					"type": "object",
+					"properties": {
+						"simulate": {
+							"type": "string"
+						},
+						"stat_weights": {
+							"type": "object",
+							"properties": {
+								"title": {
+									"type": "string"
+								},
+								"modal": {
+									"type": "object",
+									"properties": {
+										"title": {
+											"type": "string"
+										},
+										"ep": {
+											"type": "string"
+										},
+										"weights": {
+											"type": "string"
+										},
+										"show_all_stats": {
+											"type": "string"
+										},
+										"dps_tps_reference": {
+											"type": "string"
+										},
+										"healing_reference": {
+											"type": "string"
+										},
+										"mitigation_reference": {
+											"type": "string"
+										},
+										"reference_description": {
+											"type": "string"
+										},
+										"current_ep_description": {
+											"type": "string"
+										},
+										"copy_icon_description": {
+											"type": "string"
+										},
+										"stat": {
+											"type": "string"
+										},
+										"update": {
+											"type": "string"
+										},
+										"ep_ratio": {
+											"type": "string"
+										},
+										"update_ep": {
+											"type": "string"
+										},
+										"calculate": {
+											"type": "string"
+										},
+										"compute_weighted_ep": {
+											"type": "string"
+										},
+										"dps_weight": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										},
+										"dps_ep": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										},
+										"hps_weight": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										},
+										"hps_ep": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										},
+										"tps_weight": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										},
+										"tps_ep": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										},
+										"dtps_weight": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										},
+										"dtps_ep": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										},
+										"tmi_weight": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										},
+										"tmi_ep": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										},
+										"death_weight": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										},
+										"death_ep": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										},
+										"current_ep": {
+											"type": "object",
+											"properties": {
+												"label": {
+													"type": "string"
+												},
+												"tooltip": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["label", "tooltip"]
+										},
+										"not_applicable": {
+											"type": "string"
+										},
+										"column_headers": {
+											"type": "object",
+											"properties": {
+												"stat": {
+													"type": "string"
+												},
+												"update": {
+													"type": "string"
+												},
+												"ep_ratio": {
+													"type": "string"
+												},
+												"update_ep_button": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["stat", "update", "ep_ratio", "update_ep_button"]
+										},
+										"tooltips": {
+											"type": "object",
+											"properties": {
+												"normalized_by": {
+													"type": "string"
+												},
+												"copy_to_current_ep": {
+													"type": "string"
+												},
+												"restore_default_ep": {
+													"type": "string"
+												},
+												"compute_weighted_ep": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["normalized_by", "copy_to_current_ep", "restore_default_ep", "compute_weighted_ep"]
+										},
+										"progress": {
+											"type": "object",
+											"properties": {
+												"simulations_complete": {
+													"type": "string"
+												},
+												"iterations_complete": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["simulations_complete", "iterations_complete"]
+										}
+									},
+									"additionalProperties": false,
+									"required": [
+										"title",
+										"ep",
+										"weights",
+										"show_all_stats",
+										"dps_tps_reference",
+										"healing_reference",
+										"mitigation_reference",
+										"reference_description",
+										"current_ep_description",
+										"copy_icon_description",
+										"stat",
+										"update",
+										"ep_ratio",
+										"update_ep",
+										"calculate",
+										"compute_weighted_ep",
+										"dps_weight",
+										"dps_ep",
+										"hps_weight",
+										"hps_ep",
+										"tps_weight",
+										"tps_ep",
+										"dtps_weight",
+										"dtps_ep",
+										"tmi_weight",
+										"tmi_ep",
+										"death_weight",
+										"death_ep",
+										"current_ep",
+										"not_applicable",
+										"column_headers",
+										"tooltips",
+										"progress"
+									]
+								},
+								"saved_ep_weights": {
+									"type": "object",
+									"properties": {
+										"title": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["title"]
+								}
+							},
+							"additionalProperties": false,
+							"required": ["title", "modal", "saved_ep_weights"]
+						},
+						"suggest_reforges": {
+							"type": "object",
+							"properties": {
+								"title": {
+									"type": "string"
+								},
+								"tooltip": {
+									"type": "string"
+								},
+								"use_soft_cap_breakpoints": {
+									"type": "string"
+								},
+								"force_stat_proc": {
+									"type": "string"
+								},
+								"any": {
+									"type": "string"
+								},
+								"optimize_gems_tooltip": {
+									"type": "string"
+								},
+								"freeze_item_slots_tooltip": {
+									"type": "string"
+								},
+								"edit_stat_caps": {
+									"type": "string"
+								},
+								"stat_caps_tooltip": {
+									"type": "string"
+								},
+								"reset_to_defaults": {
+									"type": "string"
+								},
+								"stat": {
+									"type": "string"
+								},
+								"select_preset": {
+									"type": "string"
+								},
+								"breakpoint_limit": {
+									"type": "string"
+								},
+								"breakpoint_limit_tooltip": {
+									"type": "string"
+								},
+								"no_limit_set": {
+									"type": "string"
+								},
+								"breakpoints_implemented": {
+									"type": "string"
+								},
+								"post_cap_ep": {
+									"type": "string"
+								},
+								"reforge_optimization_failed": {
+									"type": "string"
+								},
+								"reforge_optimization_cancelled": {
+									"type": "string"
+								},
+								"use_custom": {
+									"type": "string"
+								},
+								"enable_modification": {
+									"type": "string"
+								},
+								"modify_in_editor": {
+									"type": "string"
+								},
+								"hard_cap_info": {
+									"type": "string"
+								},
+								"edit_weights": {
+									"type": "string"
+								},
+								"include_gems": {
+									"type": "string"
+								},
+								"freeze_item_slots": {
+									"type": "string"
+								},
+								"include_eotbp_socket": {
+									"type": "string"
+								},
+								"include_eotbp_socket_tooltip": {
+									"type": "string"
+								},
+								"limit_execution_time": {
+									"type": "string"
+								},
+								"limit_execution_time_tooltip": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"title",
+								"tooltip",
+								"use_soft_cap_breakpoints",
+								"force_stat_proc",
+								"any",
+								"optimize_gems_tooltip",
+								"freeze_item_slots_tooltip",
+								"edit_stat_caps",
+								"stat_caps_tooltip",
+								"reset_to_defaults",
+								"stat",
+								"select_preset",
+								"breakpoint_limit",
+								"breakpoint_limit_tooltip",
+								"no_limit_set",
+								"breakpoints_implemented",
+								"post_cap_ep",
+								"reforge_optimization_failed",
+								"reforge_optimization_cancelled",
+								"use_custom",
+								"enable_modification",
+								"modify_in_editor",
+								"hard_cap_info",
+								"edit_weights",
+								"include_gems",
+								"freeze_item_slots",
+								"include_eotbp_socket",
+								"include_eotbp_socket_tooltip",
+								"limit_execution_time",
+								"limit_execution_time_tooltip"
+							]
+						}
+					},
+					"additionalProperties": false,
+					"required": ["simulate", "stat_weights", "suggest_reforges"]
+				},
+				"header": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"phase": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title", "phase"]
+				},
+				"results": {
+					"type": "object",
+					"properties": {
+						"progress": {
+							"type": "object",
+							"properties": {
+								"presim_running": {
+									"type": "string"
+								},
+								"iterations_complete": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["presim_running", "iterations_complete"]
+						},
+						"reference": {
+							"type": "object",
+							"properties": {
+								"save_as_reference": {
+									"type": "string"
+								},
+								"use_as_reference": {
+									"type": "string"
+								},
+								"swap": {
+									"type": "string"
+								},
+								"swap_reference_with_current": {
+									"type": "string"
+								},
+								"cancel": {
+									"type": "string"
+								},
+								"remove_reference": {
+									"type": "string"
+								},
+								"vs_ref": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["save_as_reference", "use_as_reference", "swap", "swap_reference_with_current", "cancel", "remove_reference", "vs_ref"]
+						},
+						"metrics": {
+							"type": "object",
+							"properties": {
+								"dps": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"hps": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"tps": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"dtps": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"tmi": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "object",
+											"properties": {
+												"title": {
+													"type": "string"
+												},
+												"description": {
+													"type": "string"
+												},
+												"note": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["title", "description", "note"]
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"cod": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "object",
+											"properties": {
+												"title": {
+													"type": "string"
+												},
+												"description": {
+													"type": "string"
+												},
+												"note": {
+													"type": "string"
+												}
+											},
+											"additionalProperties": false,
+											"required": ["title", "description", "note"]
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"dur": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"tto": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								},
+								"oom": {
+									"type": "object",
+									"properties": {
+										"label": {
+											"type": "string"
+										},
+										"tooltip": {
+											"type": "string"
+										}
+									},
+									"additionalProperties": false,
+									"required": ["label", "tooltip"]
+								}
+							},
+							"additionalProperties": false,
+							"required": ["dps", "hps", "tps", "dtps", "tmi", "cod", "dur", "tto", "oom"]
+						}
+					},
+					"additionalProperties": false,
+					"required": ["progress", "reference", "metrics"]
+				},
+				"character_stats": {
+					"type": "object",
+					"properties": {
+						"title": {
+							"type": "string"
+						},
+						"melee_crit_cap": {
+							"type": "string"
+						},
+						"tooltip": {
+							"type": "object",
+							"properties": {
+								"base": {
+									"type": "string"
+								},
+								"gear": {
+									"type": "string"
+								},
+								"talents": {
+									"type": "string"
+								},
+								"buffs": {
+									"type": "string"
+								},
+								"consumes": {
+									"type": "string"
+								},
+								"bonus": {
+									"type": "string"
+								},
+								"total": {
+									"type": "string"
+								},
+								"glancing": {
+									"type": "string"
+								},
+								"suppression": {
+									"type": "string"
+								},
+								"to_hit_cap": {
+									"type": "string"
+								},
+								"to_exp_cap": {
+									"type": "string"
+								},
+								"spec_offsets": {
+									"type": "string"
+								},
+								"final_crit_cap": {
+									"type": "string"
+								},
+								"can_raise_by": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": [
+								"base",
+								"gear",
+								"talents",
+								"buffs",
+								"consumes",
+								"bonus",
+								"total",
+								"glancing",
+								"suppression",
+								"to_hit_cap",
+								"to_exp_cap",
+								"spec_offsets",
+								"final_crit_cap",
+								"can_raise_by"
+							]
+						},
+						"attack_table": {
+							"type": "object",
+							"properties": {
+								"glancing": {
+									"type": "string"
+								},
+								"suppression": {
+									"type": "string"
+								},
+								"to_hit_cap": {
+									"type": "string"
+								},
+								"to_exp_cap": {
+									"type": "string"
+								},
+								"spec_offsets": {
+									"type": "string"
+								},
+								"final_crit_cap": {
+									"type": "string"
+								},
+								"can_raise_by": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["glancing", "suppression", "to_hit_cap", "to_exp_cap", "spec_offsets", "final_crit_cap", "can_raise_by"]
+						},
+						"crit_cap": {
+							"type": "object",
+							"properties": {
+								"exact": {
+									"type": "string"
+								},
+								"over_by": {
+									"type": "string"
+								},
+								"under_by": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["exact", "over_by", "under_by"]
+						},
+						"bonus_prefix": {
+							"type": "string"
+						},
+						"points_suffix": {
+							"type": "string"
+						},
+						"percent_suffix": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": ["title", "melee_crit_cap", "tooltip", "attack_table", "crit_cap", "bonus_prefix", "points_suffix", "percent_suffix"]
+				}
+			},
+			"additionalProperties": false,
+			"required": ["iterations", "warnings", "buttons", "header", "results", "character_stats"]
+		},
+		"combat_replay": {
+			"type": "object",
+			"properties": {
+				"empty_title": {
+					"type": "string"
+				},
+				"empty_desc": {
+					"type": "string"
+				},
+				"default_player": {
+					"type": "string"
+				},
+				"training_dummy": {
+					"type": "string"
+				},
+				"seek_back": {
+					"type": "string"
+				},
+				"seek_fwd": {
+					"type": "string"
+				}
+			},
+			"additionalProperties": false,
+			"required": ["empty_title", "empty_desc", "default_player", "training_dummy", "seek_back", "seek_fwd"]
+		}
+	},
+	"additionalProperties": false,
+	"required": [
+		"landing",
+		"common",
+		"sim",
+		"gear_tab",
+		"settings_tab",
+		"talents_tab",
+		"bulk_tab",
+		"rotation_tab",
+		"results_tab",
+		"import",
+		"export",
+		"info",
+		"sidebar",
+		"combat_replay"
+	],
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"title": "Generated Schema",
+	"description": "Auto-generated JSON Schema",
+	"definitions": {}
 }

--- a/ui/core/components/individual_sim_ui/bulk_tab.tsx
+++ b/ui/core/components/individual_sim_ui/bulk_tab.tsx
@@ -18,7 +18,7 @@ import { canEquipItem, getEligibleItemSlots, isSecondaryItemSlot } from '../../p
 import { RequestTypes } from '../../sim_signal_manager';
 import { RelativeStatCap } from '../suggest_reforges_action';
 import { TypedEvent } from '../../typed_event';
-import { getEnumValues, isExternal } from '../../utils';
+import { getEnumValues, isExternal, noop } from '../../utils';
 import { ItemData } from '../gear_picker/item_list';
 import SelectorModal from '../gear_picker/selector_modal';
 import { ResultsViewer } from '../results_viewer';
@@ -40,7 +40,7 @@ import { BulkGearJsonImporter } from './importers';
 import { BooleanPicker } from '../pickers/boolean_picker';
 import { trackEvent } from '../../../tracking/utils';
 import { EnumPicker } from '../pickers/enum_picker';
-import { t } from 'i18next';
+import { translateBulkSlotName } from '../../../i18n/localization';
 
 const WEB_DEFAULT_ITERATIONS = 1000;
 const WEB_ITERATIONS_LIMIT = 50_000;
@@ -576,7 +576,7 @@ export class BulkTab extends SimTab {
 
 			if ([BulkSimItemSlot.ItemSlotFinger, BulkSimItemSlot.ItemSlotTrinket].includes(bulkItemSlot)) {
 				if (numOptions < 2) {
-					throw 'At least 2 items must be selected for ' + BulkSimItemSlot[bulkItemSlot];
+					throw `At least 2 items must be selected for ${translateBulkSlotName(bulkItemSlot)}`;
 				}
 
 				let pairsForSlot = getAllPairs(optionsForSlot);
@@ -603,7 +603,7 @@ export class BulkTab extends SimTab {
 		return itemsForCombo;
 	}
 
-	protected async calculateBulkCombinations() {
+	protected calculateBulkCombinations() {
 		try {
 			let numCombinations: number = this.getAllWeaponCombos().length;
 
@@ -776,12 +776,17 @@ export class BulkTab extends SimTab {
 				let simStart = new Date().getTime();
 
 				this.resetResultsTabContent();
-				await this.calculateBulkCombinations();
-				await this.simUI.runSim((progressMetrics: ProgressMetrics) => {
+				this.calculateBulkCombinations();
+				const response = await this.simUI.runSimLightweight(this.originalGear, (progressMetrics: ProgressMetrics) => {
 					const msSinceStart = new Date().getTime() - simStart;
 					this.setSimProgress(progressMetrics, msSinceStart / 1000, 0, this.combinations);
 				});
-				const referenceDpsMetrics = this.simUI.raidSimResultsManager!.currentData!.simResult!.getFirstPlayer()!.dps;
+				if (!response || (response && 'type' in response)) {
+					throw new Error(response?.message);
+				}
+
+				const [_, result] = response;
+				const referenceDpsMetrics = result!.raidMetrics!.dps!;
 
 				const allItemCombos: Map<ItemSlot, EquippedItem>[] = [];
 
@@ -830,7 +835,7 @@ export class BulkTab extends SimTab {
 						}
 					}
 
-					await this.simUI.player.setGearAsync(TypedEvent.nextEventID(), updatedGear);
+					updatedGear = (await this.simUI.reforger?.optimizeReforges(updatedGear, true).catch(noop)) || updatedGear;
 
 					if (this.simUI.reforger) {
 						this.simUI.reforger.setIncludeGems(TypedEvent.nextEventID(), true);
@@ -845,7 +850,7 @@ export class BulkTab extends SimTab {
 						}
 
 						try {
-							await this.simUI.reforger.optimizeReforges(true);
+							updatedGear = await this.simUI.reforger.optimizeReforges(updatedGear, true);
 						} catch (error) {
 							await this.simUI.player.setGearAsync(TypedEvent.nextEventID(), updatedGear);
 							this.simUI.reforger.setIncludeGems(TypedEvent.nextEventID(), false);
@@ -858,32 +863,34 @@ export class BulkTab extends SimTab {
 							}
 
 							try {
-								await this.simUI.reforger.optimizeReforges(true);
+								updatedGear = await this.simUI.reforger.optimizeReforges(updatedGear, true);
 							} catch (error) {
 								continue;
 							}
 						}
 					}
 
-					const result = await this.simUI.runSim(
-						(progressMetrics: ProgressMetrics) => {
-							const msSinceStart = new Date().getTime() - simStart;
-							this.setSimProgress(progressMetrics, msSinceStart / 1000, comboIdx + 1, this.combinations);
-						},
-						{ silent: true },
-					);
+					const response = await this.simUI.runSimLightweight(updatedGear, (progressMetrics: ProgressMetrics) => {
+						const msSinceStart = new Date().getTime() - simStart;
+						this.setSimProgress(progressMetrics, msSinceStart / 1000, comboIdx + 1, this.combinations);
+					});
 
-					if (result && 'type' in result) {
-						throw new Error(result.message);
+					if (!response || (response && 'type' in response)) {
+						throw new Error(response?.message);
 					}
 
-					updatedGear = this.simUI.player.getGear();
+					const [_, result] = response;
+
 					const isOriginalGear = this.originalGear.equals(updatedGear);
-					if (!isOriginalGear)
+					if (!isOriginalGear) {
+						const dpsMetrics = result!.raidMetrics!.dps!;
+						dpsMetrics.hist = [];
+						dpsMetrics.allValues = [];
 						topGearResults.push({
 							gear: updatedGear,
-							dpsMetrics: result!.getFirstPlayer()!.dps,
+							dpsMetrics,
 						});
+					}
 
 					topGearResults.sort((a, b) => b.dpsMetrics.avg - a.dpsMetrics.avg);
 					if (topGearResults.length > 5) topGearResults.pop();
@@ -904,6 +911,12 @@ export class BulkTab extends SimTab {
 				this.buildResultsTabContent();
 			} catch (error) {
 				console.error(error);
+				if (!isAborted && typeof error === 'string') {
+					new Toast({
+						variant: 'error',
+						body: error,
+					});
+				}
 				await this.simUI.player.setGearAsync(TypedEvent.nextEventID(), this.originalGear!);
 			} finally {
 				this.isRunning = false;

--- a/ui/core/components/individual_sim_ui/bulk_tab.tsx
+++ b/ui/core/components/individual_sim_ui/bulk_tab.tsx
@@ -43,8 +43,8 @@ import { translateBulkSlotName } from '../../../i18n/localization';
 import { ProgressTrackerModal } from '../progress_tracker_modal';
 
 const WEB_DEFAULT_ITERATIONS = 1000;
-const WEB_ITERATIONS_LIMIT = 50_000;
-const LOCAL_ITERATIONS_LIMIT = 1_000_000;
+const WEB_ITERATIONS_LIMIT = 100_000;
+const LOCAL_ITERATIONS_LIMIT = 5_000_000;
 
 export interface TopGearResult {
 	gear: Gear;
@@ -925,7 +925,7 @@ export class BulkTab extends SimTab {
 
 		if (warningRef.value) {
 			tippy(warningRef.value, {
-				content: i18n.t('bulk_tab.warning.iterations_limit', { limit: WEB_ITERATIONS_LIMIT }),
+				content: i18n.t('bulk_tab.warning.iterations_limit', { limit: this.getIterationsLimit() }),
 				placement: 'left',
 				popperOptions: {
 					modifiers: [

--- a/ui/core/components/individual_sim_ui/bulk_tab.tsx
+++ b/ui/core/components/individual_sim_ui/bulk_tab.tsx
@@ -6,7 +6,7 @@ import { ref } from 'tsx-vanilla';
 import { REPO_RELEASES_URL } from '../../constants/other';
 import { IndividualSimUI } from '../../individual_sim_ui';
 import i18n from '../../../i18n/config';
-import { BulkSettings, DistributionMetrics, ProgressMetrics } from '../../proto/api';
+import { BulkSettings, DistributionMetrics, ProgressMetrics, RaidSimResult } from '../../proto/api';
 import { Class, GemColor, HandType, ItemRandomSuffix, ItemSlot, ItemSpec, RangedWeaponType, ReforgeStat, Spec } from '../../proto/common';
 import { ItemEffectRandPropPoints, SimDatabase, SimEnchant, SimGem, SimItem } from '../../proto/db';
 import { UIEnchant, UIGem, UIItem } from '../../proto/ui';
@@ -18,7 +18,7 @@ import { canEquipItem, getEligibleItemSlots, isSecondaryItemSlot } from '../../p
 import { RequestTypes } from '../../sim_signal_manager';
 import { RelativeStatCap } from '../suggest_reforges_action';
 import { TypedEvent } from '../../typed_event';
-import { getEnumValues, isExternal, noop } from '../../utils';
+import { getEnumValues, isDevMode, isExternal, noop } from '../../utils';
 import { ItemData } from '../gear_picker/item_list';
 import SelectorModal from '../gear_picker/selector_modal';
 import { ResultsViewer } from '../results_viewer';
@@ -41,6 +41,7 @@ import { BooleanPicker } from '../pickers/boolean_picker';
 import { trackEvent } from '../../../tracking/utils';
 import { EnumPicker } from '../pickers/enum_picker';
 import { translateBulkSlotName } from '../../../i18n/localization';
+import { ProgressTrackerModal } from '../progress_tracker_modal';
 
 const WEB_DEFAULT_ITERATIONS = 1000;
 const WEB_ITERATIONS_LIMIT = 50_000;
@@ -69,7 +70,7 @@ export class BulkTab extends SimTab {
 
 	private setupTab: Tab;
 	private resultsTab: Tab;
-	private pendingResults: ResultsViewer;
+	protected progressTrackerModal: ProgressTrackerModal;
 
 	readonly selectorModal: SelectorModal;
 
@@ -77,21 +78,23 @@ export class BulkTab extends SimTab {
 	protected items: Array<ItemSpec | null> = new Array<ItemSpec | null>();
 	protected pickerGroups: Map<BulkSimItemSlot, BulkItemPickerGroup> = new Map();
 
+	protected simStart: number = 0;
 	protected combinations = 0;
 	protected iterations = 0;
+	protected isRunning: boolean = false;
+	protected isCancelling = false;
 
 	inheritUpgrades: boolean;
 	frozenItems: Map<BulkSimItemSlot, EquippedItem | null> = new Map([
 		[BulkSimItemSlot.ItemSlotFinger, null],
 		[BulkSimItemSlot.ItemSlotTrinket, null],
 	]);
-	defaultGems: SimGem[];
+	fallbackGems: SimGem[];
 	gemIconElements: HTMLImageElement[];
 
 	protected topGearResults: TopGearResult[] | null = null;
 	protected originalGear: Gear | null = null;
 	protected originalGearResults: TopGearResult | null = null;
-	protected isRunning: boolean = false;
 
 	constructor(parentElem: HTMLElement, simUI: IndividualSimUI<any>) {
 		super(parentElem, simUI, { identifier: 'bulk-tab', title: i18n.t('bulk_tab.title') });
@@ -160,7 +163,7 @@ export class BulkTab extends SimTab {
 				</div>
 				<div className="bulk-tab-right tab-panel-right">
 					<div className="bulk-settings-outer-container">
-						<div className="bulk-settings-container" ref={settingsContainerRef}>
+						<div className="bulk-settings-container progress-tracker-modal-content" ref={settingsContainerRef}>
 							<div className="bulk-combinations-count h4" ref={combinationsElemRef} />
 							<button className="btn btn-primary bulk-settings-btn" ref={bulkSimBtnRef}>
 								{i18n.t('bulk_tab.actions.simulate_batch')}
@@ -182,14 +185,29 @@ export class BulkTab extends SimTab {
 		this.setupTab = new Tab(setupTabBtnRef.value!);
 		this.resultsTab = new Tab(resultsTabBtnRef.value!);
 
-		this.pendingResults = new ResultsViewer(this.pendingDiv);
-		this.pendingResults.hideAll();
 		this.selectorModal = new SelectorModal(this.simUI.rootElem, this.simUI, this.simUI.player, undefined, {
 			id: 'bulk-selector-modal',
 		});
 
+		this.progressTrackerModal = new ProgressTrackerModal(simUI.rootElem, {
+			id: 'bulk-sim-progress-tracker',
+			title: 'Bulk Sim',
+			hasProgressBar: true,
+			onCancel: async () => {
+				if (this.isCancelling) return;
+
+				try {
+					this.isCancelling = true;
+					await this.simUI.sim.signalManager.abortType(RequestTypes.All);
+				} catch (error) {
+					console.error('Error on bulk sim abort!');
+					console.error(error);
+				}
+			},
+		});
+
 		this.inheritUpgrades = true;
-		this.defaultGems = Array.from({ length: 5 }, () => UIGem.create());
+		this.fallbackGems = Array.from({ length: 5 }, () => UIGem.create());
 		this.gemIconElements = [];
 
 		this.buildTabContent();
@@ -222,16 +240,18 @@ export class BulkTab extends SimTab {
 
 				this.itemsChangedEmitter.emit(TypedEvent.nextEventID());
 			};
-			loadEquippedItems();
+			const updateCombinationsCount = () => {
+				this.combinationsElem.replaceChildren(this.getCombinationsCount());
+			};
 
 			TypedEvent.onAny([this.simUI.player.challengeModeChangeEmitter, this.simUI.player.gearChangeEmitter]).on(() => loadEquippedItems());
-
 			TypedEvent.onAny([this.settingsChangedEmitter, this.itemsChangedEmitter]).on(() => this.storeSettings());
+			TypedEvent.onAny([this.itemsChangedEmitter, this.settingsChangedEmitter, this.simUI.sim.iterationsChangeEmitter]).on(() =>
+				updateCombinationsCount(),
+			);
 
-			TypedEvent.onAny([this.itemsChangedEmitter, this.settingsChangedEmitter, this.simUI.sim.iterationsChangeEmitter]).on(() => {
-				this.getCombinationsCount().then(result => this.combinationsElem.replaceChildren(result));
-			});
-			this.getCombinationsCount().then(result => this.combinationsElem.replaceChildren(result));
+			loadEquippedItems();
+			updateCombinationsCount();
 		});
 	}
 
@@ -248,7 +268,7 @@ export class BulkTab extends SimTab {
 
 			this.addItems(settings.items, true);
 			this.setInheritUpgrades(settings.inheritUpgrades);
-			this.defaultGems = new Array<SimGem>(
+			this.fallbackGems = new Array<SimGem>(
 				SimGem.create({ id: settings.defaultRedGem }),
 				SimGem.create({ id: settings.defaultYellowGem }),
 				SimGem.create({ id: settings.defaultBlueGem }),
@@ -256,7 +276,7 @@ export class BulkTab extends SimTab {
 				SimGem.create({ id: settings.defaultPrismaticGem }),
 			);
 
-			this.defaultGems.forEach((gem, idx) => {
+			this.fallbackGems.forEach((gem, idx) => {
 				ActionId.fromItemId(gem.id)
 					.fill()
 					.then(filledId => {
@@ -279,11 +299,11 @@ export class BulkTab extends SimTab {
 		return BulkSettings.create({
 			items: this.getItems(),
 			inheritUpgrades: this.inheritUpgrades,
-			defaultRedGem: this.defaultGems[0].id,
-			defaultYellowGem: this.defaultGems[1].id,
-			defaultBlueGem: this.defaultGems[2].id,
-			defaultMetaGem: this.defaultGems[3].id,
-			defaultPrismaticGem: this.defaultGems[4].id,
+			defaultRedGem: this.fallbackGems[0].id,
+			defaultYellowGem: this.fallbackGems[1].id,
+			defaultBlueGem: this.fallbackGems[2].id,
+			defaultMetaGem: this.fallbackGems[3].id,
+			defaultPrismaticGem: this.fallbackGems[4].id,
 			iterationsPerCombo: this.getDefaultIterationsCount(),
 		});
 	}
@@ -337,7 +357,7 @@ export class BulkTab extends SimTab {
 				}
 			}
 		}
-		for (const gem of this.defaultGems) {
+		for (const gem of this.fallbackGems) {
 			if (gem.id > 0) {
 				itemsDb.gems.push(gem);
 			}
@@ -708,7 +728,7 @@ export class BulkTab extends SimTab {
 		for (const topGearResult of this.topGearResults) {
 			new BulkSimResultRenderer(this.resultsTabElem, this.simUI, topGearResult, this.originalGearResults);
 		}
-		this.isPending = false;
+
 		this.resultsTab.show();
 	}
 
@@ -718,219 +738,8 @@ export class BulkTab extends SimTab {
 		return isSecondaryItemSlot(slot) || (this.playerCanDualWield && slot === ItemSlot.ItemSlotOffHand);
 	}
 
-	private set isPending(value: boolean) {
-		if (value) {
-			this.simUI.rootElem.classList.add('blurred');
-			this.simUI.rootElem.insertAdjacentElement('afterend', this.pendingDiv);
-		} else {
-			this.simUI.rootElem.classList.remove('blurred');
-			this.pendingDiv.remove();
-			this.pendingResults.hideAll();
-		}
-	}
-
 	protected buildBatchSettings() {
-		this.isRunning = false;
-		this.bulkSimButton.addEventListener('click', async () => {
-			if (this.isRunning) return;
-			trackEvent({
-				action: 'sim',
-				category: 'simulate',
-				label: 'batch',
-				value: this.combinations,
-			});
-
-			this.isRunning = true;
-			this.bulkSimButton.disabled = true;
-			this.isPending = true;
-			let waitAbort = false;
-			let isAborted = false;
-			this.topGearResults = null;
-			this.originalGearResults = null;
-			const playerPhase = this.simUI.sim.getPhase() >= 2;
-			const challengeModeEnabled = this.simUI.player.getChallengeModeEnabled();
-			const hasBlacksmithing = this.simUI.player.isBlacksmithing();
-
-			try {
-				await this.simUI.sim.signalManager.abortType(RequestTypes.All);
-
-				this.originalGear = this.simUI.player.getGear();
-				let updatedGear: Gear = this.originalGear;
-				let topGearResults: TopGearResult[] = [];
-
-				this.pendingResults.addAbortButton(async () => {
-					if (waitAbort) return;
-					try {
-						waitAbort = true;
-						await this.simUI.sim.signalManager.abortType(RequestTypes.All);
-					} catch (error) {
-						console.error('Error on bulk sim abort!');
-						console.error(error);
-					} finally {
-						waitAbort = false;
-						isAborted = true;
-						if (!this.isRunning) this.bulkSimButton.disabled = false;
-					}
-				});
-
-				let simStart = new Date().getTime();
-
-				this.resetResultsTabContent();
-				this.calculateBulkCombinations();
-				const response = await this.simUI.runSimLightweight(this.originalGear, (progressMetrics: ProgressMetrics) => {
-					const msSinceStart = new Date().getTime() - simStart;
-					this.setSimProgress(progressMetrics, msSinceStart / 1000, 0, this.combinations);
-				});
-				if (!response || (response && 'type' in response)) {
-					throw new Error(response?.message);
-				}
-
-				const [_, result] = response;
-				const referenceDpsMetrics = result!.raidMetrics!.dps!;
-
-				const allItemCombos: Map<ItemSlot, EquippedItem>[] = [];
-
-				for (let comboIdx = 0; comboIdx < this.combinations; comboIdx++) {
-					allItemCombos.push(this.getItemsForCombo(comboIdx));
-				}
-
-				const defaultGemsByColor = new Map<GemColor, UIGem | null>();
-
-				for (const [colorIdx, color] of [
-					GemColor.GemColorRed,
-					GemColor.GemColorYellow,
-					GemColor.GemColorBlue,
-					GemColor.GemColorMeta,
-					GemColor.GemColorPrismatic,
-				].entries()) {
-					defaultGemsByColor.set(color, this.simUI.sim.db.lookupGem(this.defaultGems[colorIdx].id));
-				}
-
-				for (let comboIdx = 0; comboIdx < this.combinations; comboIdx++) {
-					if (isAborted) {
-						throw new Error('Bulk Sim Aborted');
-					}
-
-					updatedGear = this.originalGear;
-
-					for (const [itemSlot, equippedItem] of allItemCombos[comboIdx].entries()) {
-						const equippedItemInSlot = this.originalGear.getEquippedItem(itemSlot);
-						let updatedItem = equippedItemInSlot
-							? equippedItemInSlot.withItem(equippedItem.item)
-							: equippedItem.withChallengeMode(challengeModeEnabled);
-
-						if (equippedItem._randomSuffix) {
-							updatedItem = updatedItem.withRandomSuffix(equippedItem._randomSuffix);
-						}
-						if (!this.inheritUpgrades) {
-							updatedItem = updatedItem.withUpgrade(equippedItem._upgrade);
-						}
-
-						updatedGear = updatedGear.withEquippedItem(itemSlot, updatedItem, this.playerIsFuryWarrior);
-
-						for (const [socketIdx, socketColor] of equippedItem.curSocketColors(hasBlacksmithing).entries()) {
-							if (defaultGemsByColor.get(socketColor)) {
-								updatedGear = updatedGear.withGem(itemSlot, socketIdx, defaultGemsByColor.get(socketColor)!);
-							}
-						}
-					}
-
-					updatedGear = (await this.simUI.reforger?.optimizeReforges(updatedGear, true).catch(noop)) || updatedGear;
-
-					if (this.simUI.reforger) {
-						this.simUI.reforger.setIncludeGems(TypedEvent.nextEventID(), true);
-						this.simUI.reforger.setIncludeEOTBPGemSocket(TypedEvent.nextEventID(), playerPhase);
-
-						if (RelativeStatCap.hasRoRo(this.simUI.player) && this.simUI.reforger.relativeStatCapStat !== -1) {
-							this.simUI.reforger.relativeStatCap = new RelativeStatCap(
-								this.simUI.reforger.relativeStatCapStat,
-								this.simUI.player,
-								this.simUI.player.getClass(),
-							);
-						}
-
-						try {
-							updatedGear = await this.simUI.reforger.optimizeReforges(updatedGear, true);
-						} catch (error) {
-							await this.simUI.player.setGearAsync(TypedEvent.nextEventID(), updatedGear);
-							this.simUI.reforger.setIncludeGems(TypedEvent.nextEventID(), false);
-							if (RelativeStatCap.hasRoRo(this.simUI.player) && this.simUI.reforger.relativeStatCapStat !== -1) {
-								this.simUI.reforger.relativeStatCap = new RelativeStatCap(
-									this.simUI.reforger.relativeStatCapStat,
-									this.simUI.player,
-									this.simUI.player.getClass(),
-								);
-							}
-
-							try {
-								updatedGear = await this.simUI.reforger.optimizeReforges(updatedGear, true);
-							} catch (error) {
-								continue;
-							}
-						}
-					}
-
-					const response = await this.simUI.runSimLightweight(updatedGear, (progressMetrics: ProgressMetrics) => {
-						const msSinceStart = new Date().getTime() - simStart;
-						this.setSimProgress(progressMetrics, msSinceStart / 1000, comboIdx + 1, this.combinations);
-					});
-
-					if (!response || (response && 'type' in response)) {
-						throw new Error(response?.message);
-					}
-
-					const [_, result] = response;
-
-					const isOriginalGear = this.originalGear.equals(updatedGear);
-					if (!isOriginalGear) {
-						const dpsMetrics = result!.raidMetrics!.dps!;
-						dpsMetrics.hist = [];
-						dpsMetrics.allValues = [];
-						topGearResults.push({
-							gear: updatedGear,
-							dpsMetrics,
-						});
-					}
-
-					topGearResults.sort((a, b) => b.dpsMetrics.avg - a.dpsMetrics.avg);
-					if (topGearResults.length > 5) topGearResults.pop();
-				}
-
-				await this.simUI.player.setGearAsync(TypedEvent.nextEventID(), this.originalGear);
-
-				this.topGearResults = topGearResults;
-				this.originalGearResults = {
-					gear: this.originalGear,
-					dpsMetrics: referenceDpsMetrics,
-				};
-
-				this.topGearResults.push(this.originalGearResults);
-				this.topGearResults.sort((a, b) => b.dpsMetrics.avg - a.dpsMetrics.avg);
-
-				this.simUI.resultsViewer.hideAll();
-				this.buildResultsTabContent();
-			} catch (error) {
-				console.error(error);
-				if (!isAborted && typeof error === 'string') {
-					new Toast({
-						variant: 'error',
-						body: error,
-					});
-				}
-				await this.simUI.player.setGearAsync(TypedEvent.nextEventID(), this.originalGear!);
-			} finally {
-				this.isRunning = false;
-				if (!waitAbort) this.bulkSimButton.disabled = false;
-				if (isAborted) {
-					new Toast({
-						variant: 'error',
-						body: i18n.t('bulk_tab.notifications.bulk_sim_cancelled'),
-					});
-				}
-				this.simUI.resultsViewer.hideAll();
-				this.isPending = false;
-			}
-		});
+		this.bulkSimButton.addEventListener('click', () => this.runBatchSim());
 
 		const socketsContainerRef = ref<HTMLDivElement>();
 		const inheritUpgradesDiv = ref<HTMLDivElement>();
@@ -939,8 +748,8 @@ export class BulkTab extends SimTab {
 
 		this.settingsContainer.appendChild(
 			<>
-				<div className="default-gem-container">
-					<h6>{i18n.t('bulk_tab.settings.default_gems')}</h6>
+				<div className="fallback-gem-container">
+					<h6>{i18n.t('bulk_tab.settings.fallback_gems')}</h6>
 					<div ref={socketsContainerRef} className="sockets-container"></div>
 				</div>
 				<div ref={inheritUpgradesDiv} className="inherit-upgrades-container"></div>
@@ -1069,7 +878,7 @@ export class BulkTab extends SimTab {
 				let selector: GemSelectorModal;
 
 				const onSelectHandler = (itemData: ItemData<UIGem>) => {
-					this.defaultGems[socketIndex] = itemData.item;
+					this.fallbackGems[socketIndex] = itemData.item;
 					this.storeSettings();
 					ActionId.fromItemId(itemData.id)
 						.fill()
@@ -1083,7 +892,7 @@ export class BulkTab extends SimTab {
 				};
 
 				const onRemoveHandler = () => {
-					this.defaultGems[socketIndex] = UIGem.create();
+					this.fallbackGems[socketIndex] = UIGem.create();
 					this.storeSettings();
 					this.gemIconElements[socketIndex].classList.add('hide');
 					this.gemIconElements[socketIndex].src = '';
@@ -1101,8 +910,8 @@ export class BulkTab extends SimTab {
 		);
 	}
 
-	private async getCombinationsCount(): Promise<Element> {
-		await this.calculateBulkCombinations();
+	private getCombinationsCount(): Element {
+		this.calculateBulkCombinations();
 		this.bulkSimButton.disabled = this.combinations > 50000;
 
 		const warningRef = ref<HTMLButtonElement>();
@@ -1153,20 +962,238 @@ export class BulkTab extends SimTab {
 		return isExternal() ? WEB_ITERATIONS_LIMIT : LOCAL_ITERATIONS_LIMIT;
 	}
 
-	private setSimProgress(progress: ProgressMetrics, totalElapsedSeconds: number, currentRound: number, rounds: number) {
-		const roundsRemaining = rounds - currentRound + 1;
-		const secondsRemaining = (totalElapsedSeconds * roundsRemaining) / currentRound;
+	private setReforgeProgress(currentRound: number, rounds: number) {
+		this.progressTrackerModal.updateProgress({
+			stage: 'reforging',
+			title: i18n.t('bulk_tab.progress.reforging_rounds'),
+			current: currentRound - 1,
+			total: rounds,
+		});
+	}
+
+	private setSimProgress(progress: ProgressMetrics, currentRound: number, rounds: number) {
+		const isBaselineRound = currentRound === 1;
+		const totalElapsedSeconds = (new Date().getTime() - this.simStart) / 1000;
+		const roundFraction = progress.totalIterations > 0 ? progress.completedIterations / progress.totalIterations : 0;
+		const completedRounds = Math.max(0, currentRound - 1 + roundFraction);
+		const roundsRemaining = Math.max(0, rounds - completedRounds);
+		const secondsRemaining = completedRounds > 0 ? (totalElapsedSeconds / completedRounds) * roundsRemaining : 0;
+
 		if (isNaN(Number(secondsRemaining))) return;
 
-		this.pendingResults.setContent(
-			<div className="results-sim">
-				<div>{rounds > 0 && <>{i18n.t('bulk_tab.progress.refining_rounds', { current: currentRound, total: rounds })}</>}</div>
-				<div
-					innerHTML={i18n.t('bulk_tab.progress.iterations_complete', { completed: progress.completedIterations, total: progress.totalIterations })}
-				/>
-				<div>{i18n.t('bulk_tab.progress.seconds_remaining', { seconds: Math.round(secondsRemaining) })}</div>
-			</div>,
-		);
+		this.progressTrackerModal.updateProgress({
+			stage: 'sim',
+			title: isBaselineRound ? i18n.t('bulk_tab.progress.baseline_round') : i18n.t('bulk_tab.progress.refining_rounds'),
+			current: currentRound - 1 + roundFraction,
+			total: rounds,
+			message: (
+				<div className="results-sim">
+					<div
+						innerHTML={i18n.t('bulk_tab.progress.iterations_complete', {
+							completed: progress.completedIterations,
+							total: progress.totalIterations,
+						})}
+					/>
+					<div>{i18n.t('bulk_tab.progress.seconds_remaining', { seconds: Math.round(secondsRemaining) })}</div>
+				</div>
+			),
+		});
+	}
+
+	private updateRelativeStatCapReforges() {
+		if (!this.simUI.reforger) {
+			return;
+		}
+
+		if (RelativeStatCap.hasRoRo(this.simUI.player) && this.simUI.reforger.relativeStatCapStat !== -1) {
+			this.simUI.reforger.relativeStatCap = new RelativeStatCap(this.simUI.reforger.relativeStatCapStat, this.simUI.player, this.simUI.player.getClass());
+		}
+	}
+
+	private async runBatchSim() {
+		if (this.isRunning) return;
+
+		this.progressTrackerModal.show();
+
+		trackEvent({
+			action: 'sim',
+			category: 'simulate',
+			label: 'batch',
+			value: this.combinations,
+		});
+
+		this.isRunning = true;
+		this.isCancelling = false;
+		this.bulkSimButton.disabled = true;
+		this.topGearResults = null;
+		this.originalGearResults = null;
+
+		const playerPhase = this.simUI.sim.getPhase() >= 2;
+		const challengeModeEnabled = this.simUI.player.getChallengeModeEnabled();
+		const hasBlacksmithing = this.simUI.player.isBlacksmithing();
+		const reforgedGearSets: Gear[] = [];
+
+		try {
+			await this.simUI.sim.signalManager.abortType(RequestTypes.All);
+			this.simStart = new Date().getTime();
+			this.originalGear = this.simUI.player.getGear();
+			let updatedGear: Gear = this.originalGear;
+			let topGearResults: TopGearResult[] = [];
+
+			this.resetResultsTabContent();
+			this.calculateBulkCombinations();
+
+			const allItemCombos: Map<ItemSlot, EquippedItem>[] = [];
+
+			for (let comboIdx = 0; comboIdx < this.combinations; comboIdx++) {
+				allItemCombos.push(this.getItemsForCombo(comboIdx));
+			}
+
+			const defaultGemsByColor = new Map<GemColor, UIGem | null>();
+
+			for (const [colorIdx, color] of [
+				GemColor.GemColorRed,
+				GemColor.GemColorYellow,
+				GemColor.GemColorBlue,
+				GemColor.GemColorMeta,
+				GemColor.GemColorPrismatic,
+			].entries()) {
+				defaultGemsByColor.set(color, this.simUI.sim.db.lookupGem(this.fallbackGems[colorIdx].id));
+			}
+
+			for (let comboIdx = 0; comboIdx < this.combinations; comboIdx++) {
+				if (this.isCancelling) {
+					throw new Error('Bulk Sim Aborted');
+				}
+
+				this.setReforgeProgress(comboIdx + 1, this.combinations);
+
+				updatedGear = this.originalGear;
+
+				for (const [itemSlot, equippedItem] of allItemCombos[comboIdx].entries()) {
+					const equippedItemInSlot = this.originalGear.getEquippedItem(itemSlot);
+					let updatedItem = equippedItemInSlot
+						? equippedItemInSlot.withItem(equippedItem.item)
+						: equippedItem.withChallengeMode(challengeModeEnabled);
+
+					if (equippedItem._randomSuffix) {
+						updatedItem = updatedItem.withRandomSuffix(equippedItem._randomSuffix);
+					}
+					if (!this.inheritUpgrades) {
+						updatedItem = updatedItem.withUpgrade(equippedItem._upgrade);
+					}
+
+					updatedGear = updatedGear.withEquippedItem(itemSlot, updatedItem, this.playerIsFuryWarrior);
+
+					for (const [socketIdx, socketColor] of equippedItem.curSocketColors(hasBlacksmithing).entries()) {
+						if (defaultGemsByColor.get(socketColor)) {
+							updatedGear = updatedGear.withGem(itemSlot, socketIdx, defaultGemsByColor.get(socketColor)!);
+						}
+					}
+				}
+
+				const reforgedGear = await this.optimizeReforges(updatedGear, playerPhase);
+				if (!reforgedGear) {
+					continue;
+				}
+
+				reforgedGearSets.push(reforgedGear);
+			}
+
+			const totalSimRounds = reforgedGearSets.length + 1;
+			const result = await this.runSingleGearSim(this.originalGear, 1, totalSimRounds);
+			const referenceDpsMetrics = result!.raidMetrics!.dps!;
+
+			for (let comboIdx = 0; comboIdx < reforgedGearSets.length; comboIdx++) {
+				if (this.isCancelling) {
+					throw new Error('Bulk Sim Aborted');
+				}
+
+				const reforgedGear = reforgedGearSets[comboIdx];
+				const result = await this.runSingleGearSim(reforgedGear, comboIdx + 2, totalSimRounds);
+
+				const isOriginalGear = this.originalGear.equals(updatedGear);
+				if (!isOriginalGear) {
+					const dpsMetrics = result!.raidMetrics!.dps!;
+					dpsMetrics.hist = [];
+					dpsMetrics.allValues = [];
+					topGearResults.push({
+						gear: updatedGear,
+						dpsMetrics,
+					});
+				}
+
+				topGearResults.sort((a, b) => b.dpsMetrics.avg - a.dpsMetrics.avg);
+				if (topGearResults.length > 5) topGearResults.pop();
+			}
+
+			this.topGearResults = topGearResults;
+			this.originalGearResults = {
+				gear: this.originalGear,
+				dpsMetrics: referenceDpsMetrics,
+			};
+
+			this.topGearResults.push(this.originalGearResults);
+			this.topGearResults.sort((a, b) => b.dpsMetrics.avg - a.dpsMetrics.avg);
+
+			this.buildResultsTabContent();
+		} catch (error) {
+			console.error(error);
+			if (!this.isCancelling && typeof error === 'string') {
+				new Toast({
+					variant: 'error',
+					body: error,
+				});
+			}
+		} finally {
+			await this.simUI.player.setGearAsync(TypedEvent.nextEventID(), this.originalGear!);
+			this.bulkSimButton.disabled = false;
+			if (this.isCancelling) {
+				new Toast({
+					variant: 'error',
+					body: i18n.t('bulk_tab.notifications.bulk_sim_cancelled'),
+				});
+			}
+			this.isRunning = false;
+			this.isCancelling = false;
+			this.progressTrackerModal.hide();
+		}
+	}
+
+	private async runSingleGearSim(gear: Gear, currentRound: number, totalRounds: number): Promise<RaidSimResult> {
+		const response = await this.simUI.runSimLightweight(gear, (progressMetrics: ProgressMetrics) => {
+			this.setSimProgress(progressMetrics, currentRound, totalRounds);
+		});
+		if (!response || (response && 'type' in response)) {
+			throw new Error(response?.message);
+		}
+
+		const [_, result] = response;
+
+		return result;
+	}
+
+	private async optimizeReforges(gear: Gear, playerPhase: boolean): Promise<Gear | null> {
+		if (!this.simUI.reforger) {
+			return gear;
+		}
+
+		this.simUI.reforger.setIncludeGems(TypedEvent.nextEventID(), true);
+		this.simUI.reforger.setIncludeEOTBPGemSocket(TypedEvent.nextEventID(), playerPhase);
+		this.updateRelativeStatCapReforges();
+
+		try {
+			return await this.simUI.reforger.optimizeReforges(gear, true);
+		} catch {
+			this.simUI.reforger.setIncludeGems(TypedEvent.nextEventID(), false);
+			this.updateRelativeStatCapReforges();
+
+			try {
+				return await this.simUI.reforger.optimizeReforges(gear, true);
+			} catch {
+				return gear;
+			}
+		}
 	}
 
 	private setInheritUpgrades(newValue: boolean) {

--- a/ui/core/components/individual_sim_ui/bulk_tab.tsx
+++ b/ui/core/components/individual_sim_ui/bulk_tab.tsx
@@ -1037,7 +1037,6 @@ export class BulkTab extends SimTab {
 			await this.simUI.sim.signalManager.abortType(RequestTypes.All);
 			this.simStart = new Date().getTime();
 			this.originalGear = this.simUI.player.getGear();
-			let updatedGear: Gear = this.originalGear;
 			let topGearResults: TopGearResult[] = [];
 
 			this.resetResultsTabContent();
@@ -1068,7 +1067,7 @@ export class BulkTab extends SimTab {
 
 				this.setReforgeProgress(comboIdx + 1, this.combinations);
 
-				updatedGear = this.originalGear;
+				let reforgeGear = this.originalGear;
 
 				for (const [itemSlot, equippedItem] of allItemCombos[comboIdx].entries()) {
 					const equippedItemInSlot = this.originalGear.getEquippedItem(itemSlot);
@@ -1083,16 +1082,16 @@ export class BulkTab extends SimTab {
 						updatedItem = updatedItem.withUpgrade(equippedItem._upgrade);
 					}
 
-					updatedGear = updatedGear.withEquippedItem(itemSlot, updatedItem, this.playerIsFuryWarrior);
+					reforgeGear = reforgeGear.withEquippedItem(itemSlot, updatedItem, this.playerIsFuryWarrior);
 
 					for (const [socketIdx, socketColor] of equippedItem.curSocketColors(hasBlacksmithing).entries()) {
 						if (defaultGemsByColor.get(socketColor)) {
-							updatedGear = updatedGear.withGem(itemSlot, socketIdx, defaultGemsByColor.get(socketColor)!);
+							reforgeGear = reforgeGear.withGem(itemSlot, socketIdx, defaultGemsByColor.get(socketColor)!);
 						}
 					}
 				}
 
-				const reforgedGear = await this.optimizeReforges(updatedGear, playerPhase);
+				const reforgedGear = await this.optimizeReforges(reforgeGear, playerPhase);
 				if (!reforgedGear) {
 					continue;
 				}
@@ -1100,6 +1099,7 @@ export class BulkTab extends SimTab {
 				reforgedGearSets.push(reforgedGear);
 			}
 
+			this.simStart = new Date().getTime();
 			const totalSimRounds = reforgedGearSets.length + 1;
 			const result = await this.runSingleGearSim(this.originalGear, 1, totalSimRounds);
 			const referenceDpsMetrics = result!.raidMetrics!.dps!;
@@ -1112,13 +1112,13 @@ export class BulkTab extends SimTab {
 				const reforgedGear = reforgedGearSets[comboIdx];
 				const result = await this.runSingleGearSim(reforgedGear, comboIdx + 2, totalSimRounds);
 
-				const isOriginalGear = this.originalGear.equals(updatedGear);
+				const isOriginalGear = this.originalGear.equals(reforgedGear);
 				if (!isOriginalGear) {
 					const dpsMetrics = result!.raidMetrics!.dps!;
 					dpsMetrics.hist = [];
 					dpsMetrics.allValues = [];
 					topGearResults.push({
-						gear: updatedGear,
+						gear: reforgedGear,
 						dpsMetrics,
 					});
 				}

--- a/ui/core/components/individual_sim_ui/bulk_tab.tsx
+++ b/ui/core/components/individual_sim_ui/bulk_tab.tsx
@@ -18,10 +18,9 @@ import { canEquipItem, getEligibleItemSlots, isSecondaryItemSlot } from '../../p
 import { RequestTypes } from '../../sim_signal_manager';
 import { RelativeStatCap } from '../suggest_reforges_action';
 import { TypedEvent } from '../../typed_event';
-import { getEnumValues, isDevMode, isExternal, noop } from '../../utils';
+import { getEnumValues, isExternal } from '../../utils';
 import { ItemData } from '../gear_picker/item_list';
 import SelectorModal from '../gear_picker/selector_modal';
-import { ResultsViewer } from '../results_viewer';
 import { SimTab } from '../sim_tab';
 import Toast from '../toast';
 import BulkItemPickerGroup from './bulk/bulk_item_picker_group';
@@ -66,8 +65,6 @@ export class BulkTab extends SimTab {
 	private readonly bulkSimButton: HTMLButtonElement;
 	private readonly settingsContainer: HTMLElement;
 
-	private pendingDiv: HTMLDivElement;
-
 	private setupTab: Tab;
 	private resultsTab: Tab;
 	protected progressTrackerModal: ProgressTrackerModal;
@@ -83,6 +80,7 @@ export class BulkTab extends SimTab {
 	protected iterations = 0;
 	protected isRunning: boolean = false;
 	protected isCancelling = false;
+	protected bulkSimAbortController: AbortController | null = null;
 
 	inheritUpgrades: boolean;
 	frozenItems: Map<BulkSimItemSlot, EquippedItem | null> = new Map([
@@ -176,7 +174,6 @@ export class BulkTab extends SimTab {
 
 		this.setupTabElem = setupTabRef.value!;
 		this.resultsTabElem = resultsTabRef.value!;
-		this.pendingDiv = (<div className="results-pending-overlay" />) as HTMLDivElement;
 
 		this.combinationsElem = combinationsElemRef.value!;
 		this.bulkSimButton = bulkSimBtnRef.value!;
@@ -193,16 +190,8 @@ export class BulkTab extends SimTab {
 			id: 'bulk-sim-progress-tracker',
 			title: 'Bulk Sim',
 			hasProgressBar: true,
-			onCancel: async () => {
-				if (this.isCancelling) return;
-
-				try {
-					this.isCancelling = true;
-					await this.simUI.sim.signalManager.abortType(RequestTypes.All);
-				} catch (error) {
-					console.error('Error on bulk sim abort!');
-					console.error(error);
-				}
+			onCancel: () => {
+				this.abortBulkSim();
 			},
 		});
 
@@ -968,6 +957,7 @@ export class BulkTab extends SimTab {
 			title: i18n.t('bulk_tab.progress.reforging_rounds'),
 			current: currentRound - 1,
 			total: rounds,
+			message: undefined,
 		});
 	}
 
@@ -1024,6 +1014,8 @@ export class BulkTab extends SimTab {
 
 		this.isRunning = true;
 		this.isCancelling = false;
+		this.bulkSimAbortController = new AbortController();
+		const abortSignal = this.bulkSimAbortController.signal;
 		this.bulkSimButton.disabled = true;
 		this.topGearResults = null;
 		this.originalGearResults = null;
@@ -1031,6 +1023,7 @@ export class BulkTab extends SimTab {
 		const playerPhase = this.simUI.sim.getPhase() >= 2;
 		const challengeModeEnabled = this.simUI.player.getChallengeModeEnabled();
 		const hasBlacksmithing = this.simUI.player.isBlacksmithing();
+		const candidateGearSets: Gear[] = [];
 		const reforgedGearSets: Gear[] = [];
 
 		try {
@@ -1061,11 +1054,7 @@ export class BulkTab extends SimTab {
 			}
 
 			for (let comboIdx = 0; comboIdx < this.combinations; comboIdx++) {
-				if (this.isCancelling) {
-					throw new Error('Bulk Sim Aborted');
-				}
-
-				this.setReforgeProgress(comboIdx + 1, this.combinations);
+				this.throwIfBulkAborted(abortSignal);
 
 				let reforgeGear = this.originalGear;
 
@@ -1091,26 +1080,32 @@ export class BulkTab extends SimTab {
 					}
 				}
 
-				const reforgedGear = await this.optimizeReforges(reforgeGear, playerPhase);
-				if (!reforgedGear) {
-					continue;
-				}
-
-				reforgedGearSets.push(reforgedGear);
+				candidateGearSets.push(reforgeGear);
 			}
 
+			let completedReforges = 1;
+			this.setReforgeProgress(completedReforges, candidateGearSets.length);
+			const reforgeResults = await Promise.all(
+				candidateGearSets.map(async reforgeGear => {
+					const reforgedGear = await this.optimizeReforges(reforgeGear, playerPhase, abortSignal);
+					this.throwIfBulkAborted(abortSignal);
+					completedReforges += 1;
+					this.setReforgeProgress(completedReforges, candidateGearSets.length);
+					return reforgedGear;
+				}),
+			);
+
+			reforgedGearSets.push(...reforgeResults.filter((gear): gear is Gear => !!gear));
 			this.simStart = new Date().getTime();
 			const totalSimRounds = reforgedGearSets.length + 1;
-			const result = await this.runSingleGearSim(this.originalGear, 1, totalSimRounds);
+			const result = await this.runWithBulkAbort(this.runSingleGearSim(this.originalGear, 1, totalSimRounds), abortSignal);
 			const referenceDpsMetrics = result!.raidMetrics!.dps!;
 
 			for (let comboIdx = 0; comboIdx < reforgedGearSets.length; comboIdx++) {
-				if (this.isCancelling) {
-					throw new Error('Bulk Sim Aborted');
-				}
+				this.throwIfBulkAborted(abortSignal);
 
 				const reforgedGear = reforgedGearSets[comboIdx];
-				const result = await this.runSingleGearSim(reforgedGear, comboIdx + 2, totalSimRounds);
+				const result = await this.runWithBulkAbort(this.runSingleGearSim(reforgedGear, comboIdx + 2, totalSimRounds), abortSignal);
 
 				const isOriginalGear = this.originalGear.equals(reforgedGear);
 				if (!isOriginalGear) {
@@ -1173,24 +1168,28 @@ export class BulkTab extends SimTab {
 		return result;
 	}
 
-	private async optimizeReforges(gear: Gear, playerPhase: boolean): Promise<Gear | null> {
+	private async optimizeReforges(gear: Gear, playerPhase: boolean, signal: AbortSignal): Promise<Gear | null> {
 		if (!this.simUI.reforger) {
 			return gear;
 		}
+
+		this.throwIfBulkAborted(signal);
 
 		this.simUI.reforger.setIncludeGems(TypedEvent.nextEventID(), true);
 		this.simUI.reforger.setIncludeEOTBPGemSocket(TypedEvent.nextEventID(), playerPhase);
 		this.updateRelativeStatCapReforges();
 
 		try {
-			return await this.simUI.reforger.optimizeReforges(gear, true);
+			return this.runWithBulkAbort(this.simUI.reforger.optimizeReforges(gear, true), signal);
 		} catch {
+			this.throwIfBulkAborted(signal);
 			this.simUI.reforger.setIncludeGems(TypedEvent.nextEventID(), false);
 			this.updateRelativeStatCapReforges();
 
 			try {
-				return await this.simUI.reforger.optimizeReforges(gear, true);
+				return this.runWithBulkAbort(this.simUI.reforger.optimizeReforges(gear, true), signal);
 			} catch {
+				this.throwIfBulkAborted(signal);
 				return gear;
 			}
 		}
@@ -1199,5 +1198,44 @@ export class BulkTab extends SimTab {
 	private setInheritUpgrades(newValue: boolean) {
 		this.inheritUpgrades = newValue;
 		this.settingsChangedEmitter.emit(TypedEvent.nextEventID());
+	}
+
+	private async abortBulkSim() {
+		if (this.isCancelling) return;
+
+		try {
+			this.isCancelling = true;
+			await Promise.all([this.simUI.reforger?.abortReforgeOptimization(), this.simUI.sim.signalManager.abortType(RequestTypes.All)]);
+			if (!this.bulkSimAbortController?.signal.aborted) {
+				this.bulkSimAbortController?.abort();
+				this.bulkSimAbortController = null;
+			}
+		} finally {
+			this.bulkSimButton.disabled = false;
+		}
+	}
+
+	private throwIfBulkAborted(signal: AbortSignal) {
+		if (signal.aborted || this.isCancelling) {
+			throw new Error('Bulk Sim Aborted');
+		}
+	}
+
+	private async runWithBulkAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+		this.throwIfBulkAborted(signal);
+
+		let abortHandler: (() => void) | null = null;
+		const abortPromise = new Promise<never>((_, reject) => {
+			abortHandler = () => reject(new Error('Bulk Sim Aborted'));
+			signal.addEventListener('abort', abortHandler, { once: true });
+		});
+
+		try {
+			return Promise.race([promise, abortPromise]);
+		} finally {
+			if (abortHandler) {
+				signal.removeEventListener('abort', abortHandler);
+			}
+		}
 	}
 }

--- a/ui/core/components/progress_tracker_modal.tsx
+++ b/ui/core/components/progress_tracker_modal.tsx
@@ -6,7 +6,10 @@ import i18n from '../../i18n/config.js';
 
 export interface ProgressTrackerModalState {
 	stage: 'initializing' | 'complete' | 'error' | string;
-	message?: string;
+	title?: string;
+	message?: string | Element;
+	current?: number;
+	total?: number;
 }
 
 interface ProgressTrackerModalOptions {
@@ -15,7 +18,8 @@ interface ProgressTrackerModalOptions {
 	onComplete?: () => void;
 	title: string;
 	warning?: string | Element;
-	initializingMessage?: string;
+	initializingMessage?: string | Element;
+	hasProgressBar?: boolean;
 }
 
 export class ProgressTrackerModal extends Component {
@@ -26,6 +30,9 @@ export class ProgressTrackerModal extends Component {
 	private startTime: number = 0;
 	private updateInterval: number | null = null;
 
+	private progressBarElement: HTMLElement | null = null;
+	private progressTitleElement: HTMLElement | null = null;
+	private progressTextElement: HTMLElement | null = null;
 	private messageElement: HTMLElement | null = null;
 	private elapsedTimeElement: HTMLElement | null = null;
 	private contentElement: HTMLElement | null = null;
@@ -46,6 +53,9 @@ export class ProgressTrackerModal extends Component {
 		});
 		this.modal.rootElem.id = this.id;
 
+		const progressBarRef = ref<HTMLDivElement>();
+		const progressTitleRef = ref<HTMLDivElement>();
+		const progressTextRef = ref<HTMLDivElement>();
 		const messageRef = ref<HTMLDivElement>();
 		const contentRef = ref<HTMLDivElement>();
 		const elapsedRef = ref<HTMLSpanElement>();
@@ -55,6 +65,23 @@ export class ProgressTrackerModal extends Component {
 				<div className="progress-tracker-modal-overlay"></div>
 				<div className="progress-tracker-modal-content" ref={contentRef}>
 					{options.warning && <div className="progress-tracker-modal-warning">{options.warning}</div>}
+					{options.hasProgressBar && (
+						<div className="progress-tracker-modal-progress-container">
+							<div className="progress-tracker-modal-progress-title mb-2" ref={progressTitleRef}>
+								{this.progressState.title}
+							</div>
+							<div className="progress">
+								<div
+									ref={progressBarRef}
+									className="progress-bar"
+									attributes={{
+										role: 'progressbar',
+									}}
+								/>
+							</div>
+							<div className="progress-tracker-modal-progress-text" ref={progressTextRef} />
+						</div>
+					)}
 					<div className="progress-tracker-modal-time-display">
 						<strong>{i18n.t('common.elapsed_time')}:</strong>{' '}
 						<span className="time-elapsed" ref={elapsedRef}>
@@ -85,6 +112,9 @@ export class ProgressTrackerModal extends Component {
 		);
 
 		this.elapsedTimeElement = elapsedRef.value!;
+		this.progressTitleElement = progressTitleRef.value!;
+		this.progressBarElement = progressBarRef.value!;
+		this.progressTextElement = progressTextRef.value!;
 		this.messageElement = messageRef.value!;
 		this.contentElement = contentRef.value!;
 	}
@@ -111,7 +141,7 @@ export class ProgressTrackerModal extends Component {
 	}
 
 	private render(): void {
-		const { stage, message } = this.progressState;
+		const { stage, title, message, current, total } = this.progressState;
 
 		// Update data-stage attribute for CSS styling
 		if (this.contentElement) this.contentElement.dataset.stage = stage;
@@ -119,7 +149,30 @@ export class ProgressTrackerModal extends Component {
 		if (!this.messageElement) return;
 
 		this.messageElement.classList[message ? 'remove' : 'add']('d-none');
-		this.messageElement.textContent = message || '';
+
+		if (message instanceof Element) {
+			this.messageElement.replaceChildren(message);
+		} else if (typeof message === 'string') {
+			this.messageElement.textContent = message;
+		} else {
+			this.messageElement.replaceChildren();
+		}
+
+		this.progressTitleElement?.classList[title ? 'remove' : 'add']('d-none');
+		if (this.progressBarElement && current !== undefined && total !== undefined) {
+			if (this.progressTitleElement && title) {
+				this.progressTitleElement.textContent = title;
+			}
+			const currentRounded = Math.ceil(current);
+			if (this.progressTextElement) {
+				this.progressTextElement.textContent = `${currentRounded}/${total}`;
+			}
+			this.progressBarElement.style.width = `${(current / total) * 100}%`;
+
+			this.progressBarElement.setAttribute('aria-valuenow', currentRounded.toString());
+			this.progressBarElement.setAttribute('aria-valuemin', '0');
+			this.progressBarElement.setAttribute('aria-valuemax', total.toString());
+		}
 	}
 
 	private updateTimeDisplay(): void {

--- a/ui/core/components/progress_tracker_modal.tsx
+++ b/ui/core/components/progress_tracker_modal.tsx
@@ -7,7 +7,7 @@ import i18n from '../../i18n/config.js';
 export interface ProgressTrackerModalState {
 	stage: 'initializing' | 'complete' | 'error' | string;
 	title?: string;
-	message?: string | Element;
+	message?: string | Element | DocumentFragment;
 	current?: number;
 	total?: number;
 }
@@ -18,7 +18,7 @@ interface ProgressTrackerModalOptions {
 	onComplete?: () => void;
 	title: string;
 	warning?: string | Element;
-	initializingMessage?: string | Element;
+	initializingMessage?: string | Element | DocumentFragment;
 	hasProgressBar?: boolean;
 }
 
@@ -150,7 +150,7 @@ export class ProgressTrackerModal extends Component {
 
 		this.messageElement.classList[message ? 'remove' : 'add']('d-none');
 
-		if (message instanceof Element) {
+		if (message instanceof Element || message instanceof DocumentFragment) {
 			this.messageElement.replaceChildren(message);
 		} else if (typeof message === 'string') {
 			this.messageElement.textContent = message;

--- a/ui/core/components/suggest_reforges_action.tsx
+++ b/ui/core/components/suggest_reforges_action.tsx
@@ -251,6 +251,7 @@ export class ReforgeOptimizer {
 	protected pendingWorker: ReforgeWorkerPool | null = null;
 	protected previousGear: Gear | null = null;
 	protected previousReforges = new Map<ItemSlot, ReforgeData>();
+	protected updatedGear: Gear | null = null;
 	protected currentReforges = new Map<ItemSlot, ReforgeData>();
 	relativeStatCapStat: number = -1;
 	relativeStatCap: RelativeStatCap | null = null;
@@ -348,7 +349,8 @@ export class ReforgeOptimizer {
 					if (this.wasCM) {
 						simUI.player.setChallengeModeEnabled(TypedEvent.nextEventID(), false);
 					}
-					await this.optimizeReforges();
+					const gear = await this.optimizeReforges();
+					await this.player.setGearAsync(TypedEvent.nextEventID(), gear);
 					this.onReforgeDone();
 				} catch (error) {
 					if (this.isCancelling) return;
@@ -1276,7 +1278,7 @@ export class ReforgeOptimizer {
 		return statCaps;
 	}
 
-	async optimizeReforges(batchRun?: boolean) {
+	async optimizeReforges(gear?: Gear, batchRun?: boolean) {
 		if (isDevMode()) console.log('Starting Reforge optimization...');
 
 		// First, clear all existing Reforges
@@ -1285,16 +1287,16 @@ export class ReforgeOptimizer {
 			console.log('The following slots will not be cleared:');
 			console.log(Array.from(this.frozenItemSlots.keys()).filter(key => this.getFrozenItemSlot(key)));
 		}
-		this.previousGear = this.player.getGear();
+		this.previousGear = gear || this.player.getGear();
 
 		this.previousReforges = this.previousGear.getAllReforges();
-		let baseGear = this.previousGear.withoutReforges(this.player.canDualWield2H(), this.frozenItemSlots);
+		this.updatedGear = this.previousGear.withoutReforges(this.player.canDualWield2H(), this.frozenItemSlots);
 
 		if (this.includeGems) {
-			baseGear = baseGear.withoutGems(this.player.canDualWield2H(), this.frozenItemSlots, true);
+			this.updatedGear = this.updatedGear.withoutGems(this.player.canDualWield2H(), this.frozenItemSlots, true);
 		}
 
-		const baseStats = await this.updateGear(baseGear);
+		const baseStats = await this.updateGear(this.updatedGear);
 
 		// Compute effective stat caps for just the Reforge contribution
 		let reforgeCaps = baseStats.computeStatCapsDelta(this.processedStatCaps);
@@ -1321,8 +1323,8 @@ export class ReforgeOptimizer {
 		}
 
 		// Set up YALPS model
-		const variables = this.buildYalpsVariables(baseGear, validatedWeights, reforgeCaps, reforgeSoftCaps);
-		const constraints = this.buildYalpsConstraints(baseGear, baseStats);
+		const variables = this.buildYalpsVariables(this.updatedGear!, validatedWeights, reforgeCaps, reforgeSoftCaps);
+		const constraints = this.buildYalpsConstraints(this.updatedGear!, baseStats);
 
 		// After building variables and constraints we check for
 		// SocketBonusLink constraints for the all-or-nothing socket bonus variables.
@@ -1336,7 +1338,6 @@ export class ReforgeOptimizer {
 
 		// Solve in multiple passes to enforce caps
 		await this.solveModel(
-			baseGear,
 			validatedWeights,
 			reforgeCaps,
 			reforgeSoftCaps,
@@ -1345,11 +1346,13 @@ export class ReforgeOptimizer {
 			(this.includeTimeout ? (this.relativeStatCap ? 120 : 30) : 3600) / (batchRun ? 4 : 1),
 		);
 		this.currentReforges = this.player.getGear().getAllReforges();
+
+		return this.updatedGear!;
 	}
 
 	async updateGear(gear: Gear): Promise<Stats> {
-		await this.player.setGearAsync(TypedEvent.nextEventID(), gear);
-		let baseStats = Stats.fromProto(this.player.getCurrentStats().finalStats);
+		const currentStats = await this.sim.getCharacterStatsForGear(TypedEvent.nextEventID(), gear);
+		let baseStats = Stats.fromProto(currentStats.finalStats);
 		baseStats = baseStats.addStat(Stat.StatMasteryRating, this.player.getBaseMastery() * Mechanics.MASTERY_RATING_PER_MASTERY_POINT);
 		if (this.updateGearStatsModifier) baseStats = this.updateGearStatsModifier(baseStats);
 		return baseStats;
@@ -1785,7 +1788,6 @@ export class ReforgeOptimizer {
 	}
 
 	async solveModel(
-		gear: Gear,
 		weights: Stats,
 		reforgeCaps: Stats,
 		reforgeSoftCaps: StatCap[],
@@ -1837,7 +1839,7 @@ export class ReforgeOptimizer {
 		}
 
 		// Apply the current solution
-		const updatedGear = await this.applyLPSolution(gear, solution);
+		this.updatedGear = await this.applyLPSolution(this.updatedGear!, solution);
 
 		// Check if any unconstrained stats exceeded their specified cap.
 		// If so, add these stats to the constraint list and re-run the solver.
@@ -1855,15 +1857,7 @@ export class ReforgeOptimizer {
 			return solution.result;
 		} else {
 			await sleep(100);
-			return await this.solveModel(
-				updatedGear,
-				updatedWeights,
-				reforgeCaps,
-				reforgeSoftCaps,
-				updatedVariables,
-				updatedConstraints,
-				maxSeconds - elapsedSeconds,
-			);
+			return await this.solveModel(updatedWeights, reforgeCaps, reforgeSoftCaps, updatedVariables, updatedConstraints, maxSeconds - elapsedSeconds);
 		}
 	}
 

--- a/ui/core/components/suggest_reforges_action.tsx
+++ b/ui/core/components/suggest_reforges_action.tsx
@@ -1345,7 +1345,7 @@ export class ReforgeOptimizer {
 			constraints,
 			(this.includeTimeout ? (this.relativeStatCap ? 120 : 30) : 3600) / (batchRun ? 4 : 1),
 		);
-		this.currentReforges = this.player.getGear().getAllReforges();
+		this.currentReforges = this.updatedGear.getAllReforges();
 
 		return this.updatedGear!;
 	}

--- a/ui/core/components/suggest_reforges_action.tsx
+++ b/ui/core/components/suggest_reforges_action.tsx
@@ -248,7 +248,7 @@ export class ReforgeOptimizer {
 	protected undershootCaps = new Stats();
 	protected wasCM: boolean = false;
 	protected isCancelling: boolean = false;
-	protected pendingWorker: ReforgeWorkerPool | null = null;
+	protected workers: ReforgeWorkerPool | null = null;
 	protected previousGear: Gear | null = null;
 	protected previousReforges = new Map<ItemSlot, ReforgeData>();
 	protected updatedGear: Gear | null = null;
@@ -302,13 +302,13 @@ export class ReforgeOptimizer {
 					<p className="mb-0">You may cancel this operation at any time using the button below.</p>
 				</>
 			),
-			onCancel: () => {
+			onCancel: async () => {
 				this.isCancelling = true;
 				if (isDevMode()) {
 					console.log('User cancelled reforge optimization');
 				}
 				try {
-					this.pendingWorker?.terminate();
+					await this.abortReforgeOptimization();
 				} catch {}
 				if (this.previousGear) this.player.setGear(TypedEvent.nextEventID(), this.previousGear);
 				this.progressTrackerModal.hide();
@@ -325,6 +325,18 @@ export class ReforgeOptimizer {
 				});
 			},
 		});
+
+		const syncReforgeWorkerPoolConcurrency = async () => {
+			const isWasm = await this.sim.isWasm();
+			let workerCount = navigator.hardwareConcurrency || 4;
+			if (isWasm) {
+				workerCount = Math.min(this.sim.getWasmConcurrency(), workerCount);
+			}
+			getReforgeWorkerPool().setNumWorkers(workerCount);
+		};
+
+		syncReforgeWorkerPoolConcurrency();
+		this.sim.wasmConcurrencyChangeEmitter.on(() => syncReforgeWorkerPoolConcurrency());
 
 		// Pre-warm the worker pool
 		getReforgeWorkerPool().warmUp();
@@ -1287,16 +1299,16 @@ export class ReforgeOptimizer {
 			console.log('The following slots will not be cleared:');
 			console.log(Array.from(this.frozenItemSlots.keys()).filter(key => this.getFrozenItemSlot(key)));
 		}
-		this.previousGear = gear || this.player.getGear();
+		const previousGear = gear || this.player.getGear();
 
-		this.previousReforges = this.previousGear.getAllReforges();
-		this.updatedGear = this.previousGear.withoutReforges(this.player.canDualWield2H(), this.frozenItemSlots);
+		const previousReforges = previousGear.getAllReforges();
+		let updatedGear = previousGear.withoutReforges(this.player.canDualWield2H(), this.frozenItemSlots);
 
 		if (this.includeGems) {
-			this.updatedGear = this.updatedGear.withoutGems(this.player.canDualWield2H(), this.frozenItemSlots, true);
+			updatedGear = updatedGear.withoutGems(this.player.canDualWield2H(), this.frozenItemSlots, true);
 		}
 
-		const baseStats = await this.updateGear(this.updatedGear);
+		const baseStats = await this.updateGear(updatedGear);
 
 		// Compute effective stat caps for just the Reforge contribution
 		let reforgeCaps = baseStats.computeStatCapsDelta(this.processedStatCaps);
@@ -1323,8 +1335,8 @@ export class ReforgeOptimizer {
 		}
 
 		// Set up YALPS model
-		const variables = this.buildYalpsVariables(this.updatedGear!, validatedWeights, reforgeCaps, reforgeSoftCaps);
-		const constraints = this.buildYalpsConstraints(this.updatedGear!, baseStats);
+		const variables = this.buildYalpsVariables(updatedGear, validatedWeights, reforgeCaps, reforgeSoftCaps);
+		const constraints = this.buildYalpsConstraints(updatedGear, baseStats);
 
 		// After building variables and constraints we check for
 		// SocketBonusLink constraints for the all-or-nothing socket bonus variables.
@@ -1337,17 +1349,26 @@ export class ReforgeOptimizer {
 		}
 
 		// Solve in multiple passes to enforce caps
-		await this.solveModel(
+		const optimized = await this.solveModel(
 			validatedWeights,
 			reforgeCaps,
 			reforgeSoftCaps,
 			variables,
 			constraints,
+			updatedGear,
 			(this.includeTimeout ? (this.relativeStatCap ? 120 : 30) : 3600) / (batchRun ? 4 : 1),
 		);
-		this.currentReforges = this.updatedGear.getAllReforges();
 
-		return this.updatedGear!;
+		updatedGear = optimized.gear;
+
+		if (!batchRun) {
+			this.previousGear = previousGear;
+			this.previousReforges = previousReforges;
+			this.updatedGear = updatedGear;
+			this.currentReforges = updatedGear.getAllReforges();
+		}
+
+		return updatedGear;
 	}
 
 	async updateGear(gear: Gear): Promise<Stats> {
@@ -1793,8 +1814,9 @@ export class ReforgeOptimizer {
 		reforgeSoftCaps: StatCap[],
 		variables: YalpsVariables,
 		constraints: YalpsConstraints,
+		currentGear: Gear,
 		maxSeconds: number,
-	): Promise<number> {
+	): Promise<{ result: number; gear: Gear }> {
 		// Calculate EP scores for each Reforge option
 		if (isDevMode()) {
 			console.log('Stat weights for this iteration:');
@@ -1817,8 +1839,8 @@ export class ReforgeOptimizer {
 
 		const startTimeMs: number = Date.now();
 
-		this.pendingWorker = getReforgeWorkerPool();
-		const solution: LPSolution = await this.pendingWorker.solve(model, {
+		this.workers = getReforgeWorkerPool();
+		const solution: LPSolution = await this.workers.solve(model, {
 			timeout: maxSeconds * 1000,
 			tolerance: 0.005, // unused currently
 		});
@@ -1839,7 +1861,7 @@ export class ReforgeOptimizer {
 		}
 
 		// Apply the current solution
-		this.updatedGear = await this.applyLPSolution(this.updatedGear!, solution);
+		const solvedGear = await this.applyLPSolution(currentGear, solution);
 
 		// Check if any unconstrained stats exceeded their specified cap.
 		// If so, add these stats to the constraint list and re-run the solver.
@@ -1854,10 +1876,18 @@ export class ReforgeOptimizer {
 		);
 
 		if (!anyCapsExceeded) {
-			return solution.result;
+			return { result: solution.result, gear: solvedGear };
 		} else {
 			await sleep(100);
-			return await this.solveModel(updatedWeights, reforgeCaps, reforgeSoftCaps, updatedVariables, updatedConstraints, maxSeconds - elapsedSeconds);
+			return await this.solveModel(
+				updatedWeights,
+				reforgeCaps,
+				reforgeSoftCaps,
+				updatedVariables,
+				updatedConstraints,
+				solvedGear,
+				maxSeconds - elapsedSeconds,
+			);
 		}
 	}
 
@@ -2315,6 +2345,10 @@ export class ReforgeOptimizer {
 		});
 	}
 
+	async abortReforgeOptimization() {
+		this.workers?.abort();
+	}
+
 	fromProto(eventID: EventID, proto: ReforgeSettings) {
 		TypedEvent.freezeAllAndDo(() => {
 			this.setUseCustomEPValues(eventID, proto.useCustomEpValues);
@@ -2331,6 +2365,7 @@ export class ReforgeOptimizer {
 			}
 		});
 	}
+
 	toProto(): ReforgeSettings {
 		return ReforgeSettings.create({
 			useCustomEpValues: this.useCustomEPValues,
@@ -2345,6 +2380,7 @@ export class ReforgeOptimizer {
 			statCaps: this.statCaps.toProto(),
 		});
 	}
+
 	applyDefaults(eventID: EventID) {
 		TypedEvent.freezeAllAndDo(() => {
 			this.setUseCustomEPValues(eventID, false);

--- a/ui/core/concurrent_worker_pool.ts
+++ b/ui/core/concurrent_worker_pool.ts
@@ -1,0 +1,102 @@
+type ResizeResult<TWorker> = {
+	added: TWorker[];
+	removed: TWorker[];
+};
+
+type WorkerPoolManagerConfig<TWorker> = {
+	create: (index: number) => TWorker;
+	getWorkAmount: (worker: TWorker) => number;
+	enable?: (worker: TWorker, index: number) => void;
+	disable?: (worker: TWorker, index: number) => void;
+	destroy?: (worker: TWorker, index: number) => void;
+};
+
+export class WorkerPoolManager<TWorker> {
+	private readonly workers: Array<TWorker | undefined> = [];
+	private readonly disabledWorkers: Array<TWorker | undefined> = [];
+	private readonly createWorker: WorkerPoolManagerConfig<TWorker>['create'];
+	private readonly getWorkAmount: WorkerPoolManagerConfig<TWorker>['getWorkAmount'];
+	private readonly enable?: WorkerPoolManagerConfig<TWorker>['enable'];
+	private readonly disable?: WorkerPoolManagerConfig<TWorker>['disable'];
+	private readonly destroy?: WorkerPoolManagerConfig<TWorker>['destroy'];
+
+	constructor(config: WorkerPoolManagerConfig<TWorker>) {
+		this.createWorker = config.create;
+		this.getWorkAmount = config.getWorkAmount;
+		this.enable = config.enable;
+		this.disable = config.disable;
+		this.destroy = config.destroy;
+	}
+
+	resize(numWorkers: number): ResizeResult<TWorker> {
+		const nextWorkerCount = Math.max(1, numWorkers);
+		const added: TWorker[] = [];
+		const removed: TWorker[] = [];
+
+		if (nextWorkerCount < this.workers.length) {
+			for (let idx = this.workers.length - 1; idx >= nextWorkerCount; idx--) {
+				const worker = this.workers[idx];
+				if (!worker) continue;
+
+				removed.push(worker);
+				if (this.disable) {
+					this.disable(worker, idx);
+					this.disabledWorkers[idx] = worker;
+				} else if (this.destroy) {
+					this.destroy(worker, idx);
+				}
+			}
+			this.workers.length = nextWorkerCount;
+			return { added, removed };
+		}
+
+		for (let idx = 0; idx < nextWorkerCount; idx++) {
+			if (this.workers[idx]) continue;
+
+			if (this.enable && this.disabledWorkers[idx]) {
+				const worker = this.disabledWorkers[idx]!;
+				this.workers[idx] = worker;
+				delete this.disabledWorkers[idx];
+				this.enable(worker, idx);
+				added.push(worker);
+				continue;
+			}
+
+			const worker = this.createWorker(idx);
+			this.workers[idx] = worker;
+			added.push(worker);
+		}
+
+		return { added, removed };
+	}
+
+	getNumWorkers(): number {
+		return this.workers.length;
+	}
+
+	getWorkers(): TWorker[] {
+		return this.workers.filter((worker): worker is TWorker => !!worker);
+	}
+
+	hasWorker(predicate: (worker: TWorker) => boolean): boolean {
+		return this.getWorkers().some(predicate);
+	}
+
+	getLeastBusyWorker(predicate?: (worker: TWorker) => boolean): TWorker {
+		const workers = predicate ? this.getWorkers().filter(predicate) : this.getWorkers();
+		if (workers.length === 0) {
+			throw new Error('No workers available');
+		}
+		return workers.reduce((curMinWorker, nextWorker) => (this.getWorkAmount(curMinWorker) <= this.getWorkAmount(nextWorker) ? curMinWorker : nextWorker));
+	}
+
+	clear(): void {
+		const destroy = this.destroy ?? this.disable;
+		if (destroy) {
+			this.getWorkers().forEach((worker, idx) => destroy(worker, idx));
+			(this.disabledWorkers.filter(Boolean) as TWorker[]).forEach((worker, idx) => destroy(worker, idx));
+		}
+		this.workers.length = 0;
+		this.disabledWorkers.length = 0;
+	}
+}

--- a/ui/core/proto_utils/utils.ts
+++ b/ui/core/proto_utils/utils.ts
@@ -1920,6 +1920,8 @@ export function validWeaponCombo(mainHand: Item | null | undefined, offHand: Ite
 	return true;
 }
 
+export const hasBlacksmithing = (player: Player) => [player.profession1, player.profession2].includes(Profession.Blacksmithing);
+
 // Returns all item slots to which the enchant might be applied.
 //
 // Note that this alone is not enough; some items have further restrictions,

--- a/ui/core/reforge_worker_pool.ts
+++ b/ui/core/reforge_worker_pool.ts
@@ -6,6 +6,7 @@
 
 import { REPO_NAME } from './constants/other.js';
 import type { LPModel, LPSolution, ReforgeWorkerReceiveMessage, ReforgeWorkerSendMessage, SolverOptions } from '../worker/reforge_types';
+import { WorkerPoolManager } from './concurrent_worker_pool';
 
 const REFORGE_WORKER_URL = `/${REPO_NAME}/reforge_worker.js`;
 
@@ -29,10 +30,11 @@ class ReforgeWorker {
 			reject: (reason: unknown) => void;
 		}
 	>();
-	private isReady = false;
 	private readyPromise: Promise<void>;
 	private readyResolve!: () => void;
 	private workerId: string;
+	private solveTasksRunning = 0;
+	private initialized = false;
 
 	constructor(id: number) {
 		this.workerId = `reforge-worker-${id}`;
@@ -57,7 +59,6 @@ class ReforgeWorker {
 	private handleMessage(data: ReforgeWorkerSendMessage) {
 		switch (data.msg) {
 			case 'ready':
-				this.isReady = true;
 				this.readyResolve();
 				break;
 
@@ -115,7 +116,10 @@ class ReforgeWorker {
 
 		return new Promise((resolve, reject) => {
 			this.pendingRequests.set(id, {
-				resolve: resolve as (value: unknown) => void,
+				resolve: value => {
+					this.initialized = !!value;
+					resolve(value as boolean);
+				},
 				reject,
 			});
 
@@ -131,11 +135,18 @@ class ReforgeWorker {
 		await this.readyPromise;
 
 		const id = generateRequestId('solve');
+		this.solveTasksRunning += 1;
 
 		return new Promise((resolve, reject) => {
 			this.pendingRequests.set(id, {
-				resolve: resolve as (value: unknown) => void,
-				reject,
+				resolve: value => {
+					this.solveTasksRunning = Math.max(0, this.solveTasksRunning - 1);
+					resolve(value as LPSolution);
+				},
+				reject: reason => {
+					this.solveTasksRunning = Math.max(0, this.solveTasksRunning - 1);
+					reject(reason);
+				},
 			});
 
 			this.postMessage({
@@ -147,13 +158,34 @@ class ReforgeWorker {
 		});
 	}
 
+	getSolveTaskWorkAmount(): number {
+		return this.solveTasksRunning;
+	}
+
+	isInitialized(): boolean {
+		return this.initialized;
+	}
+
+	abort() {
+		if (!this.pendingRequests.size) return;
+
+		for (const [_, pending] of this.pendingRequests) {
+			pending.reject(new Error('Solve cancelled'));
+		}
+
+		this.pendingRequests.clear();
+		this.worker?.terminate();
+		this.solveTasksRunning = 0;
+	}
+
 	terminate() {
 		this.worker?.terminate();
 		this.worker = null;
-		this.isReady = false;
+		this.solveTasksRunning = 0;
+		this.initialized = false;
 
 		// Reject all pending requests
-		for (const [id, pending] of this.pendingRequests) {
+		for (const [_, pending] of this.pendingRequests) {
 			pending.reject(new Error('Worker terminated'));
 		}
 		this.pendingRequests.clear();
@@ -162,23 +194,52 @@ class ReforgeWorker {
 
 /**
  * Pool of reforge workers
- * Currently single-threaded since HiGHS WASM is already optimized
- * Worker is pre-warmed on getInstance() to reduce first-solve latency
+ * Multi-threaded and load-balanced across dedicated HiGHS worker instances.
+ * Workers are pre-warmed on warmUp() to reduce first-solve latency.
  */
 export class ReforgeWorkerPool {
-	private worker: ReforgeWorker | null = null;
+	private readonly concurrencyPool: WorkerPoolManager<ReforgeWorker>;
 	private static instance: ReforgeWorkerPool | null = null;
 	private initPromise: Promise<boolean> | null = null;
 	private isWarmedUp = false;
+	private wasmUrl?: string;
 
-	private constructor() {}
+	private constructor(numWorkers: number) {
+		this.concurrencyPool = new WorkerPoolManager<ReforgeWorker>({
+			create: i => new ReforgeWorker(i),
+			getWorkAmount: worker => worker.getSolveTaskWorkAmount(),
+			destroy: worker => worker.terminate(),
+		});
+		this.setNumWorkers(numWorkers);
+	}
+
+	async setNumWorkers(numWorkers: number): Promise<void> {
+		const { added: addedWorkers } = this.concurrencyPool.resize(numWorkers);
+
+		if (addedWorkers.length > 0 && (this.isWarmedUp || this.initPromise)) {
+			await Promise.all(
+				addedWorkers.map(async worker => {
+					await worker.waitForReady();
+					return worker.initHiGHS(this.wasmUrl);
+				}),
+			);
+		}
+	}
+
+	getNumWorkers(): number {
+		return this.concurrencyPool.getNumWorkers();
+	}
+
+	private getLeastBusyWorker(): ReforgeWorker {
+		return this.concurrencyPool.getLeastBusyWorker(worker => worker.isInitialized());
+	}
 
 	/**
 	 * Get singleton instance
 	 */
 	static getInstance(): ReforgeWorkerPool {
 		if (!ReforgeWorkerPool.instance) {
-			ReforgeWorkerPool.instance = new ReforgeWorkerPool();
+			ReforgeWorkerPool.instance = new ReforgeWorkerPool(1);
 		}
 		return ReforgeWorkerPool.instance;
 	}
@@ -215,33 +276,72 @@ export class ReforgeWorkerPool {
 			return this.initPromise;
 		}
 
-		if (!this.worker) {
-			this.worker = new ReforgeWorker(0);
-		}
+		this.wasmUrl = wasmUrl;
 
-		await this.worker.waitForReady();
-		const success = await this.worker.initHiGHS(wasmUrl);
-		this.isWarmedUp = success;
-		return success;
+		this.initPromise = (async () => {
+			const initResults = await Promise.all(
+				this.concurrencyPool.getWorkers().map(async worker => {
+					await worker.waitForReady();
+					return worker.initHiGHS(wasmUrl);
+				}),
+			);
+
+			const success = initResults.some(Boolean);
+			this.isWarmedUp = success;
+			return success;
+		})();
+
+		return this.initPromise;
 	}
 
 	/**
 	 * Solve an LP problem using HiGHS
 	 */
 	async solve(model: LPModel, options: SolverOptions = {}): Promise<LPSolution> {
-		if (!this.worker) {
+		if (this.concurrencyPool.getNumWorkers() === 0) {
 			await this.init();
 		}
 
-		return this.worker!.solve(model, options);
+		if (!this.concurrencyPool.hasWorker(worker => worker.isInitialized())) {
+			this.initPromise = null;
+			await this.init(this.wasmUrl);
+		}
+
+		if (this.concurrencyPool.hasWorker(worker => !worker.isInitialized())) {
+			this.initPromise = null;
+			await this.init(this.wasmUrl);
+		}
+
+		if (!this.concurrencyPool.hasWorker(worker => worker.isInitialized())) {
+			throw new Error('Failed to initialize reforge workers');
+		}
+
+		const worker = this.getLeastBusyWorker();
+		return worker.solve(model, options);
+	}
+
+	async abort() {
+		const workerCount = Math.max(1, this.concurrencyPool.getNumWorkers());
+		const wasmUrl = this.wasmUrl;
+		const shouldWarmUp = this.isWarmedUp || !!this.initPromise;
+		this.concurrencyPool.clear();
+		this.initPromise = null;
+		this.isWarmedUp = false;
+
+		await this.setNumWorkers(workerCount);
+		if (shouldWarmUp) {
+			await this.init(wasmUrl);
+		}
 	}
 
 	/**
 	 * Terminate the worker
 	 */
 	terminate() {
-		this.worker?.terminate();
-		this.worker = null;
+		this.concurrencyPool.clear();
+		this.initPromise = null;
+		this.isWarmedUp = false;
+		this.wasmUrl = undefined;
 		ReforgeWorkerPool.instance = null;
 	}
 }

--- a/ui/core/sim.ts
+++ b/ui/core/sim.ts
@@ -193,7 +193,7 @@ export class Sim {
 	 * Whether the current environment should use wasm/worker concurrency methods.
 	 * @returns true if running wasm workers and concurrency setting is active.
 	 */
-	private async shouldUseWasmConcurrency() {
+	async shouldUseWasmConcurrency() {
 		return (await this.isWasm()) && this.getWasmConcurrency() >= 2 && this.workerPool.getNumWorkers() >= 2;
 	}
 

--- a/ui/core/sim.ts
+++ b/ui/core/sim.ts
@@ -8,6 +8,7 @@ import {
 	ComputeStatsRequest,
 	ErrorOutcome,
 	ErrorOutcomeType,
+	PlayerStats,
 	Raid as RaidProto,
 	RaidSimRequest,
 	RaidSimResult,
@@ -30,8 +31,9 @@ import {
 } from './proto/common.js';
 import { DatabaseFilters, RaidFilterOption, SimSettings as SimSettingsProto, SourceFilterOption } from './proto/ui.js';
 import { Database } from './proto_utils/database.js';
+import { Gear } from './proto_utils/gear';
 import { SimResult } from './proto_utils/sim_result.js';
-import { extendPlayerProtoWithMissingEffects } from './proto_utils/utils';
+import { extendPlayerProtoWithMissingEffects, hasBlacksmithing } from './proto_utils/utils';
 import { Raid } from './raid.js';
 import { runConcurrentSim, runConcurrentStatWeights } from './sim_concurrent';
 import { RequestTypes, SimSignalManager } from './sim_signal_manager';
@@ -217,7 +219,7 @@ export class Sim {
 				let gear = this.db.lookupEquipmentSpec(player.equipment);
 				let gearChanged = false;
 
-				const isBlacksmith = [player.profession1, player.profession2].includes(Profession.Blacksmithing);
+				const isBlacksmith = hasBlacksmithing(player);
 
 				// Disable meta gem if inactive.
 				if (gear.hasInactiveMetaGem(isBlacksmith)) {
@@ -300,6 +302,65 @@ export class Sim {
 		}
 	}
 
+	// Runs a lightweight version of the sim that uses a gear set and doesn't compute combat logs or other expensive data,
+	// and returns the raw result from the sim worker.
+	async runRaidSimLightweight(
+		gear: Gear,
+		onProgress: WorkerProgressCallback,
+		_: RunSimOptions = {},
+	): Promise<[RaidSimRequest, RaidSimResult] | ErrorOutcome> {
+		if (this.raid.isEmpty()) {
+			throw new Error('Raid is empty! Try adding some players first.');
+		} else if (this.encounter.targets.length < 1) {
+			throw new Error('Encounter has no targets! Try adding some targets first.');
+		}
+
+		const signals = this.signalManager.registerRunning(RequestTypes.RaidSim);
+		try {
+			await this.waitForInit();
+
+			const request = this.makeRaidSimRequest(false);
+			const player = request.raid!.parties[0].players[0];
+
+			// Disable meta gem if inactive.
+			const isBlacksmith = hasBlacksmithing(player);
+			if (gear.hasInactiveMetaGem(isBlacksmith)) {
+				gear = gear.withoutMetaGem();
+			}
+
+			// Remove bonus sockets if not blacksmith.
+			if (!isBlacksmith) {
+				gear = gear.withoutBlacksmithSockets();
+			}
+
+			player.database = gear.toDatabase(this.db);
+			player.equipment = gear.asSpec();
+
+			request.raid!.parties[0].players[0] = player;
+
+			let result;
+			// Only use worker base concurrency when running wasm. Local sim has native threading.
+			if (await this.shouldUseWasmConcurrency()) {
+				result = await runConcurrentSim(request, this.workerPool, onProgress, signals);
+			} else {
+				result = await this.workerPool.raidSimAsync(request, onProgress, signals);
+			}
+
+			if (result.error) {
+				if (result.error.type != ErrorOutcomeType.ErrorOutcomeError) return result.error;
+				throw new SimError(result.error.message);
+			}
+
+			return [request, result];
+		} catch (error) {
+			if (error instanceof SimError) throw error;
+			console.error(error);
+			throw new Error('Something went wrong running your lightweight raid sim. Reload the page and try again.');
+		} finally {
+			this.signalManager.unregisterRunning(signals);
+		}
+	}
+
 	async runRaidSimWithLogs(eventID: EventID, options: RunSimOptions = {}): Promise<SimResult | null> {
 		if (this.raid.isEmpty()) {
 			throw new Error('Raid is empty! Try adding some players first.');
@@ -376,6 +437,47 @@ export class Sim {
 				this.unitMetadataEmitter.emit(eventID);
 			}
 		});
+	}
+
+	// Returns the stats for Player 0 without triggering any metadata updates.
+	// Can be used for Suggest Gems / Batch Simming without interfering with the UI.
+	async getCharacterStatsForGear(eventID: EventID, gear: Gear): Promise<PlayerStats> {
+		await this.waitForInit();
+
+		const raidProto = this.raid.toProto(false, true);
+		this.modifyRaidProto(raidProto);
+
+		const player = raidProto.parties[0].players[0];
+
+		const isBlacksmith = hasBlacksmithing(player);
+
+		// Disable meta gem if inactive.
+		if (gear.hasInactiveMetaGem(isBlacksmith)) {
+			gear = gear.withoutMetaGem();
+		}
+
+		// Remove bonus sockets if not blacksmith.
+		if (!isBlacksmith) {
+			gear = gear.withoutBlacksmithSockets();
+		}
+
+		player.database = gear.toDatabase(this.db);
+		player.equipment = gear.asSpec();
+
+		extendPlayerProtoWithMissingEffects(player, this.db);
+		raidProto.parties[0].players[0] = player;
+
+		const req = ComputeStatsRequest.create({
+			raid: raidProto,
+			encounter: this.encounter.toProto(),
+		});
+
+		const result = await this.workerPool.computeStats(req);
+		if (result.errorResult != '') {
+			this.crashEmitter.emit(eventID, new SimError(result.errorResult));
+		}
+
+		return result.raidStats!.parties[0].players[0];
 	}
 
 	async statWeights(

--- a/ui/core/sim_ui.tsx
+++ b/ui/core/sim_ui.tsx
@@ -24,6 +24,7 @@ import { EventID, TypedEvent } from './typed_event.js';
 import { WorkerProgressCallback } from './worker_pool';
 import { isDevMode } from './utils';
 import { trackEvent } from '../tracking/utils';
+import { Gear } from './proto_utils/gear';
 
 const URLMAXLEN = 2048;
 const globalKnownIssues: Array<string> = [];
@@ -342,6 +343,17 @@ export abstract class SimUI extends Component {
 			return result;
 		} catch (e) {
 			this.resultsViewer.hideAll();
+			this.handleCrash(e);
+		}
+	}
+
+	// Runs a lightweight version of the sim that uses a gear set and doesn't compute combat logs or other expensive data,
+	// and returns the raw result from the sim worker.
+	async runSimLightweight(gear: Gear, onProgress: WorkerProgressCallback, options: RunSimOptions = {}) {
+		try {
+			await this.sim.signalManager.abortType(RequestTypes.All);
+			return this.sim.runRaidSimLightweight(gear, onProgress, options);
+		} catch (e) {
 			this.handleCrash(e);
 		}
 	}

--- a/ui/core/worker_pool.ts
+++ b/ui/core/worker_pool.ts
@@ -18,6 +18,7 @@ import {
 } from './proto/api.js';
 import { SimSignals } from './sim_signal_manager';
 import { isDevMode, noop } from './utils';
+import { WorkerPoolManager } from './concurrent_worker_pool';
 
 const SIM_WORKER_URL = `/${REPO_NAME}/sim_worker.js`;
 export type WorkerProgressCallback = (progressMetrics: ProgressMetrics) => void;
@@ -33,46 +34,28 @@ export const generateRequestId = (type: SimRequest) => {
 };
 
 export class WorkerPool {
-	private readonly workers: Array<SimWorker>;
-	private readonly workersDisabled: Array<SimWorker>;
+	private readonly concurrencyPool: WorkerPoolManager<SimWorker>;
 
 	constructor(numWorkers: number) {
-		this.workers = [];
-		this.workersDisabled = [];
+		this.concurrencyPool = new WorkerPoolManager<SimWorker>({
+			create: i => new SimWorker(i),
+			getWorkAmount: worker => worker.getSimTaskWorkAmount(),
+			enable: worker => worker.enable(),
+			disable: worker => worker.disable(),
+		});
 		this.setNumWorkers(numWorkers);
 	}
 
 	setNumWorkers(numWorkers: number) {
-		if (numWorkers < this.workers.length) {
-			for (let i = this.workers.length - 1; i >= numWorkers; i--) {
-				this.workers[i].disable();
-				this.workersDisabled[i] = this.workers[i];
-			}
-			this.workers.length = numWorkers;
-			return;
-		}
-
-		for (let i = 0; i < numWorkers; i++) {
-			if (!this.workers[i]) {
-				if (this.workersDisabled[i]) {
-					this.workers[i] = this.workersDisabled[i];
-					delete this.workersDisabled[i];
-					this.workers[i].enable();
-				} else {
-					this.workers[i] = new SimWorker(i);
-				}
-			}
-		}
+		this.concurrencyPool.resize(numWorkers);
 	}
 
 	getNumWorkers() {
-		return this.workers.length;
+		return this.concurrencyPool.getNumWorkers();
 	}
 
 	private getLeastBusyWorker(): SimWorker {
-		return this.workers.reduce((curMinWorker, nextWorker) =>
-			curMinWorker.getSimTaskWorkAmount() < nextWorker.getSimTaskWorkAmount() ? curMinWorker : nextWorker,
-		);
+		return this.concurrencyPool.getLeastBusyWorker();
 	}
 
 	async makeApiCall(requestName: SimRequest, request: Uint8Array): Promise<Uint8Array> {
@@ -148,7 +131,11 @@ export class WorkerPool {
 	 * @returns True if workers are running wasm.
 	 */
 	isWasm() {
-		return this.workers[0].isWasmWorker();
+		const firstWorker = this.concurrencyPool.getWorkers()[0];
+		if (!firstWorker) {
+			throw new Error('No workers available');
+		}
+		return firstWorker.isWasmWorker();
 	}
 
 	/**

--- a/ui/scss/core/components/_progress_tracker_modal.scss
+++ b/ui/scss/core/components/_progress_tracker_modal.scss
@@ -24,3 +24,50 @@
 	align-items: center;
 	text-align: center;
 }
+
+.progress-tracker-modal-progress-container {
+	position: relative;
+	align-self: center;
+	width: 100%;
+	max-width: 250px;
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacer-1);
+
+	.progress {
+		--bs-progress-height: 12px;
+		width: 100%;
+		background-color: var(--bs-modal-border-color);
+		border-radius: 4px;
+		overflow: hidden;
+	}
+
+	.progress-bar {
+		background: linear-gradient(
+			90deg,
+			var(--bs-success) 0%,
+			color-mix(in srgb, var(--bs-success) 85%, var(--bs-black)) 25%,
+			var(--bs-success) 50%,
+			color-mix(in srgb, var(--bs-success) 85%, var(--bs-black)) 75%,
+			var(--bs-success) 100%
+		);
+		background-size: 200% 100%;
+		animation: loading-shimmer 6s linear infinite;
+	}
+}
+
+.progress-tracker-modal-progress-text {
+	font-size: 12px;
+	text-align: right;
+	color: var(--bs-border-color);
+}
+
+@keyframes loading-shimmer {
+	from {
+		background-position: 200% 0;
+	}
+
+	to {
+		background-position: -200% 0;
+	}
+}

--- a/ui/scss/core/components/individual_sim_ui/_bulk_tab.scss
+++ b/ui/scss/core/components/individual_sim_ui/_bulk_tab.scss
@@ -68,7 +68,7 @@
 		}
 	}
 
-	.default-gem-container {
+	.fallback-gem-container {
 		display: flex;
 		flex-direction: column;
 

--- a/ui/scss/index.scss
+++ b/ui/scss/index.scss
@@ -26,6 +26,7 @@
 @import 'bootstrap/scss/badge';
 @import 'bootstrap/scss/alert';
 @import 'bootstrap/scss/close';
+@import 'bootstrap/scss/progress';
 @import 'bootstrap/scss/modal';
 @import 'bootstrap/scss/toasts';
 @import 'bootstrap/scss/carousel';

--- a/ui/worker/reforge_worker.ts
+++ b/ui/worker/reforge_worker.ts
@@ -4,7 +4,7 @@
  * Uses HiGHS WASM for high-performance linear programming solving
  */
 
-import type { LPSolution, ReforgeWorkerReceiveMessage, ReforgeWorkerSendMessage } from './reforge_types';
+import type { ReforgeWorkerReceiveMessage, ReforgeWorkerSendMessage } from './reforge_types';
 import { modelToLPFormat, highsSolutionToLPSolution, type HighsSolution } from './lp_format';
 
 // HiGHS module type


### PR DESCRIPTION
Migrated from TBC: Added a "headless" way of reforging / Bulk simming that doesn't update the UI every time.

- Added "lightweight" Sim option which only requires gear and returns the result (this saves the UI from repainting a boatload of times and blocking the main thread)
- Made reforging accept a gear option to prevent UI updates when using the batch Sim
- Separated Reforging and Simming. Reforging will be done first for all combinations and then it will run the Sim back to back.
- Changed to the ProgressTracker component and added a progress bar for Reforging/Simming refinement rounds

<img width="2120" height="1319" alt="image" src="https://github.com/user-attachments/assets/6b7ba4ac-202e-4a1a-9e4e-15bc304e819c" />
<img width="2120" height="1319" alt="image" src="https://github.com/user-attachments/assets/08822d58-7ecd-4299-9514-4228f488be57" />
