### PR TITLE
[Druid] Fixed #1359

### DIFF
--- a/sim/druid/feral/items.go
+++ b/sim/druid/feral/items.go
@@ -7,6 +7,130 @@ import (
 	"github.com/wowsims/mop/sim/druid"
 )
 
+// T14 Feral
+var ItemSetBattlegearOfTheEternalBlossom = core.NewItemSet(core.ItemSet{
+	Name:                    "Battlegear of the Eternal Blossom",
+	DisabledInChallengeMode: true,
+	Bonuses: map[int32]core.ApplySetBonus{
+		2: func(_ core.Agent, setBonusAura *core.Aura) {
+			// Your Shred and Mangle (Cat) abilities deal 5% additional damage.
+			setBonusAura.AttachSpellMod(core.SpellModConfig{
+				Kind:       core.SpellMod_DamageDone_Pct,
+				ClassMask:  druid.DruidSpellMangleCat | druid.DruidSpellShred,
+				FloatValue: 0.05,
+			})
+		},
+		4: func(agent core.Agent, setBonusAura *core.Aura) {
+			// Increases the duration of your Rip by 4 sec.
+			druid := agent.(druid.DruidAgent).GetDruid()
+
+			setBonusAura.ApplyOnGain(func(_ *core.Aura, _ *core.Simulation) {
+				druid.RipBaseNumTicks += 2
+				druid.RipMaxNumTicks += 2
+			})
+
+			setBonusAura.ApplyOnExpire(func(_ *core.Aura, _ *core.Simulation) {
+				druid.RipBaseNumTicks -= 2
+				druid.RipMaxNumTicks -= 2
+			})
+		},
+	},
+})
+
+// T15 Feral
+var ItemSetBattlegearOfTheHauntedForest = core.NewItemSet(core.ItemSet{
+	Name:                    "Battlegear of the Haunted Forest",
+	DisabledInChallengeMode: true,
+	Bonuses: map[int32]core.ApplySetBonus{
+		2: func(agent core.Agent, setBonusAura *core.Aura) {
+			// Gives your finishing moves a 15% chance per combo point to add a combo point to your target.
+			anyDruid := agent.(druid.DruidAgent).GetDruid()
+			actionID := core.ActionID{SpellID: 138352}
+			cpMetrics := anyDruid.NewComboPointMetrics(actionID)
+
+			var cpSnapshot int32
+			var resultLanded bool
+
+			proc2pT15 := func(sim *core.Simulation, unit *core.Unit, isRoar bool) {
+				procChance := 0.15 * float64(cpSnapshot)
+
+				if sim.Proc(procChance, "2pT15") && (resultLanded || isRoar) {
+					unit.AddComboPoints(sim, 1, unit.CurrentComboTarget, cpMetrics)
+				}
+
+				cpSnapshot = 0
+				resultLanded = false
+			}
+
+			setBonusAura.OnApplyEffects = func(aura *core.Aura, _ *core.Simulation, _ *core.Unit, spell *core.Spell) {
+				if spell.Matches(druid.DruidSpellFinisher) {
+					cpSnapshot = aura.Unit.ComboPoints()
+				}
+			}
+
+			setBonusAura.OnSpellHitDealt = func(_ *core.Aura, _ *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				if spell.Matches(druid.DruidSpellFinisher) && result.Landed() {
+					resultLanded = true
+				}
+			}
+
+			setBonusAura.OnCastComplete = func(aura *core.Aura, sim *core.Simulation, spell *core.Spell) {
+				if spell.Matches(druid.DruidSpellFinisher) {
+					proc2pT15(sim, aura.Unit, spell.Matches(druid.DruidSpellSavageRoar))
+				}
+			}
+
+		},
+		4: func(agent core.Agent, setBonusAura *core.Aura) {
+			// After using Tiger's Fury, you gain 40% increased critical strike chance on the next 3 uses of Mangle, Shred, Ferocious Bite, Ravage, and Swipe.
+			cat, ok := agent.(*FeralDruid)
+			if !ok {
+				return
+			}
+
+			cat.registerTigersFury4PT15()
+
+			setBonusAura.OnCastComplete = func(_ *core.Aura, sim *core.Simulation, spell *core.Spell) {
+				if spell.Matches(druid.DruidSpellTigersFury) {
+					cat.TigersFury4PT15Aura.Activate(sim)
+				}
+			}
+		},
+	},
+})
+
+func (cat *FeralDruid) registerTigersFury4PT15() {
+	meleeAbilityMask := druid.DruidSpellMangleCat | druid.DruidSpellShred | druid.DruidSpellRavage | druid.DruidSpellSwipeCat | druid.DruidSpellFerociousBite
+
+	tfMod := cat.AddDynamicMod(core.SpellModConfig{
+		ClassMask:  meleeAbilityMask,
+		Kind:       core.SpellMod_BonusCrit_Percent,
+		FloatValue: 40,
+	})
+
+	cat.TigersFury4PT15Aura = cat.RegisterAura(core.Aura{
+		Label:     "Tiger's Fury 4PT15",
+		ActionID:  core.ActionID{SpellID: 138358},
+		Duration:  time.Second * 30,
+		MaxStacks: 3,
+
+		OnGain: func(aura *core.Aura, sim *core.Simulation) {
+			aura.SetStacks(sim, 3)
+			tfMod.Activate()
+		},
+
+		OnCastComplete: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell) {
+			if spell.Matches(meleeAbilityMask) {
+				aura.RemoveStack(sim)
+			}
+		},
+
+		OnExpire: func(_ *core.Aura, _ *core.Simulation) {
+			tfMod.Deactivate()
+		},
+	})
+}
+
 // T16 Feral
 var ItemSetBattlegearOfTheShatteredVale = core.NewItemSet(core.ItemSet{
 	ID:                      1197,
@@ -15,12 +139,20 @@ var ItemSetBattlegearOfTheShatteredVale = core.NewItemSet(core.ItemSet{
 	Bonuses: map[int32]core.ApplySetBonus{
 		2: func(agent core.Agent, setBonusAura *core.Aura) {
 			// Omen of Clarity increases damage of Shred, Mangle, Swipe, and Ravage by 50% for 6 sec.
-			cat := agent.(*FeralDruid)
+			cat, ok := agent.(*FeralDruid)
+			if !ok {
+				return
+			}
+
 			cat.registerFeralFury(setBonusAura)
 		},
 		4: func(agent core.Agent, setBonusAura *core.Aura) {
 			// After using Tiger's Fury, your next finishing move will restore 3 combo points on your current target after being used.
-			cat := agent.(*FeralDruid)
+			cat, ok := agent.(*FeralDruid)
+			if !ok {
+				return
+			}
+
 			cat.registerFeralRage()
 
 			setBonusAura.OnCastComplete = func(_ *core.Aura, sim *core.Simulation, spell *core.Spell) {

--- a/sim/druid/guardian/items.go
+++ b/sim/druid/guardian/items.go
@@ -10,6 +10,57 @@ import (
 func init() {
 }
 
+// T14 Guardian
+var ItemSetArmorOfTheEternalBlossom = core.NewItemSet(core.ItemSet{
+	Name:                    "Armor of the Eternal Blossom",
+	DisabledInChallengeMode: true,
+	Bonuses: map[int32]core.ApplySetBonus{
+		2: func(_ core.Agent, setBonusAura *core.Aura) {
+			// Reduces the cooldown of your Might of Ursoc ability by 60 sec.
+			setBonusAura.AttachSpellMod(core.SpellModConfig{
+				Kind:      core.SpellMod_Cooldown_Flat,
+				ClassMask: druid.DruidSpellMightOfUrsoc,
+				TimeValue: time.Second * -60,
+			}).ExposeToAPL(123086)
+		},
+		4: func(agent core.Agent, setBonusAura *core.Aura) {
+			bear, ok := agent.(*GuardianDruid)
+			if !ok {
+				return
+			}
+
+			// Increases the dodge granted by your Savage Defense by an additional 5%.
+			bear.OnSpellRegistered(func(spell *core.Spell) {
+				if !spell.Matches(druid.DruidSpellSavageDefense) {
+					return
+				}
+
+				hasDodgeBonus := false
+				spell.RelatedSelfBuff.ApplyOnGain(func(_ *core.Aura, sim *core.Simulation) {
+					if setBonusAura.IsActive() {
+						bear.PseudoStats.BaseDodgeChance += 0.05
+						hasDodgeBonus = true
+					}
+				}).ApplyOnExpire(func(_ *core.Aura, sim *core.Simulation) {
+					if hasDodgeBonus {
+						bear.PseudoStats.BaseDodgeChance -= 0.05
+						hasDodgeBonus = false
+					}
+				})
+			})
+
+			// Increases the healing received from your Frenzied Regeneration by 10%
+			setBonusAura.AttachSpellMod(core.SpellModConfig{
+				Kind:       core.SpellMod_DamageDone_Pct,
+				ClassMask:  druid.DruidSpellFrenziedRegeneration,
+				FloatValue: 0.1,
+			})
+
+			setBonusAura.ExposeToAPL(123087)
+		},
+	},
+})
+
 // T15 Guardian
 var ItemSetArmorOfTheHauntedForest = core.NewItemSet(core.ItemSet{
 	ID:                      1156,
@@ -18,7 +69,11 @@ var ItemSetArmorOfTheHauntedForest = core.NewItemSet(core.ItemSet{
 	Bonuses: map[int32]core.ApplySetBonus{
 		2: func(agent core.Agent, setBonusAura *core.Aura) {
 			// Each attack you dodge while Savage Defense is active increases the healing from your next Frenzied Regeneration within 10 sec by 10%, stacking up to 10 times.
-			bear := agent.(*GuardianDruid)
+			bear, ok := agent.(*GuardianDruid)
+			if !ok {
+				return
+			}
+
 			bear.registerImprovedRegeneration(setBonusAura)
 			setBonusAura.AttachProcTrigger(core.ProcTrigger{
 				Callback: core.CallbackOnSpellHitTaken,
@@ -34,7 +89,11 @@ var ItemSetArmorOfTheHauntedForest = core.NewItemSet(core.ItemSet{
 		},
 		4: func(agent core.Agent, setBonusAura *core.Aura) {
 			// You generate 50% more Rage from your attacks while Enrage is active.
-			bear := agent.(*GuardianDruid)
+			bear, ok := agent.(*GuardianDruid)
+			if !ok {
+				return
+			}
+
 			bear.Env.RegisterPreFinalizeEffect(func() {
 				bear.EnrageAura.ApplyOnGain(func(_ *core.Aura, _ *core.Simulation) {
 					if setBonusAura.IsActive() {
@@ -52,7 +111,7 @@ var ItemSetArmorOfTheHauntedForest = core.NewItemSet(core.ItemSet{
 	},
 })
 
-func (bear *GuardianDruid) registerImprovedRegeneration(setBonusTracker *core.Aura) {
+func (bear *GuardianDruid) registerImprovedRegeneration(_ *core.Aura) {
 	improveRegenMod := bear.AddDynamicMod(core.SpellModConfig{
 		ClassMask:  druid.DruidSpellFrenziedRegeneration,
 		Kind:       core.SpellMod_DamageDone_Pct,

--- a/sim/druid/items.go
+++ b/sim/druid/items.go
@@ -7,83 +7,6 @@ import (
 	"github.com/wowsims/mop/sim/core/proto"
 )
 
-// T14 Guardian
-var ItemSetArmorOfTheEternalBlossom = core.NewItemSet(core.ItemSet{
-	Name:                    "Armor of the Eternal Blossom",
-	DisabledInChallengeMode: true,
-	Bonuses: map[int32]core.ApplySetBonus{
-		2: func(_ core.Agent, setBonusAura *core.Aura) {
-			// Reduces the cooldown of your Might of Ursoc ability by 60 sec.
-			setBonusAura.AttachSpellMod(core.SpellModConfig{
-				Kind:      core.SpellMod_Cooldown_Flat,
-				ClassMask: DruidSpellMightOfUrsoc,
-				TimeValue: time.Second * -60,
-			}).ExposeToAPL(123086)
-		},
-		4: func(agent core.Agent, setBonusAura *core.Aura) {
-			druid := agent.(DruidAgent).GetDruid()
-			// Increases the dodge granted by your Savage Defense by an additional 5%.
-			druid.OnSpellRegistered(func(spell *core.Spell) {
-				if !spell.Matches(DruidSpellSavageDefense) {
-					return
-				}
-
-				hasDodgeBonus := false
-				spell.RelatedSelfBuff.ApplyOnGain(func(_ *core.Aura, sim *core.Simulation) {
-					if setBonusAura.IsActive() {
-						druid.PseudoStats.BaseDodgeChance += 0.05
-						hasDodgeBonus = true
-					}
-				}).ApplyOnExpire(func(_ *core.Aura, sim *core.Simulation) {
-					if hasDodgeBonus {
-						druid.PseudoStats.BaseDodgeChance -= 0.05
-						hasDodgeBonus = false
-					}
-				})
-			})
-
-			// Increases the healing received from your Frenzied Regeneration by 10%
-			setBonusAura.AttachSpellMod(core.SpellModConfig{
-				Kind:       core.SpellMod_DamageDone_Pct,
-				ClassMask:  DruidSpellFrenziedRegeneration,
-				FloatValue: 0.1,
-			})
-
-			setBonusAura.ExposeToAPL(123087)
-		},
-	},
-})
-
-// T14 Feral
-var ItemSetBattlegearOfTheEternalBlossom = core.NewItemSet(core.ItemSet{
-	Name:                    "Battlegear of the Eternal Blossom",
-	DisabledInChallengeMode: true,
-	Bonuses: map[int32]core.ApplySetBonus{
-		2: func(_ core.Agent, setBonusAura *core.Aura) {
-			// Your Shred and Mangle (Cat) abilities deal 5% additional damage.
-			setBonusAura.AttachSpellMod(core.SpellModConfig{
-				Kind:       core.SpellMod_DamageDone_Pct,
-				ClassMask:  DruidSpellMangleCat | DruidSpellShred,
-				FloatValue: 0.05,
-			})
-		},
-		4: func(agent core.Agent, setBonusAura *core.Aura) {
-			// Increases the duration of your Rip by 4 sec.
-			druid := agent.(DruidAgent).GetDruid()
-
-			setBonusAura.ApplyOnGain(func(_ *core.Aura, _ *core.Simulation) {
-				druid.RipBaseNumTicks += 2
-				druid.RipMaxNumTicks += 2
-			})
-
-			setBonusAura.ApplyOnExpire(func(_ *core.Aura, _ *core.Simulation) {
-				druid.RipBaseNumTicks -= 2
-				druid.RipMaxNumTicks -= 2
-			})
-		},
-	},
-})
-
 // Feral PvP
 var ItemSetGladiatorSanctuary = core.NewItemSet(core.ItemSet{
 	Name:                    "Gladiator's Sanctuary",
@@ -95,6 +18,11 @@ var ItemSetGladiatorSanctuary = core.NewItemSet(core.ItemSet{
 		4: func(agent core.Agent, setBonusAura *core.Aura) {
 			// Once every 30 sec, your next Ravage is free and has no positional or stealth requirement.
 			druid := agent.(DruidAgent).GetDruid()
+
+			if druid.Spec != proto.Spec_SpecFeralDruid && druid.Spec != proto.Spec_SpecGuardianDruid {
+				return
+			}
+
 			druid.registerStampede()
 			druid.registerStampedePending()
 			setBonusAura.ApplyOnEncounterStart(func(_ *core.Aura, sim *core.Simulation) {
@@ -144,101 +72,6 @@ func (druid *Druid) registerStampedePending() {
 
 		OnExpire: func(_ *core.Aura, sim *core.Simulation) {
 			druid.StampedeAura.Activate(sim)
-		},
-	})
-}
-
-// T15 Feral
-var ItemSetBattlegearOfTheHauntedForest = core.NewItemSet(core.ItemSet{
-	Name:                    "Battlegear of the Haunted Forest",
-	DisabledInChallengeMode: true,
-	Bonuses: map[int32]core.ApplySetBonus{
-		2: func(agent core.Agent, setBonusAura *core.Aura) {
-			// Gives your finishing moves a 15% chance per combo point to add a combo point to your target.
-			druid := agent.(DruidAgent).GetDruid()
-			actionID := core.ActionID{SpellID: 138352}
-			cpMetrics := druid.NewComboPointMetrics(actionID)
-
-			var cpSnapshot int32
-			var resultLanded bool
-
-			proc2pT15 := func(sim *core.Simulation, unit *core.Unit, isRoar bool) {
-				procChance := 0.15 * float64(cpSnapshot)
-
-				if sim.Proc(procChance, "2pT15") && (resultLanded || isRoar) {
-					unit.AddComboPoints(sim, 1, unit.CurrentComboTarget, cpMetrics)
-				}
-
-				cpSnapshot = 0
-				resultLanded = false
-			}
-
-			setBonusAura.OnApplyEffects = func(aura *core.Aura, _ *core.Simulation, _ *core.Unit, spell *core.Spell) {
-				if spell.Matches(DruidSpellFinisher) {
-					cpSnapshot = aura.Unit.ComboPoints()
-				}
-			}
-
-			setBonusAura.OnSpellHitDealt = func(_ *core.Aura, _ *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-				if spell.Matches(DruidSpellFinisher) && result.Landed() {
-					resultLanded = true
-				}
-			}
-
-			setBonusAura.OnCastComplete = func(aura *core.Aura, sim *core.Simulation, spell *core.Spell) {
-				if spell.Matches(DruidSpellFinisher) {
-					proc2pT15(sim, aura.Unit, spell.Matches(DruidSpellSavageRoar))
-				}
-			}
-
-		},
-		4: func(agent core.Agent, setBonusAura *core.Aura) {
-			// After using Tiger's Fury, you gain 40% increased critical strike chance on the next 3 uses of Mangle, Shred, Ferocious Bite, Ravage, and Swipe.
-			druid := agent.(DruidAgent).GetDruid()
-
-			if druid.Spec != proto.Spec_SpecFeralDruid {
-				return
-			}
-
-			druid.registerTigersFury4PT15()
-
-			setBonusAura.OnCastComplete = func(_ *core.Aura, sim *core.Simulation, spell *core.Spell) {
-				if spell.Matches(DruidSpellTigersFury) {
-					druid.TigersFury4PT15Aura.Activate(sim)
-				}
-			}
-		},
-	},
-})
-
-func (druid *Druid) registerTigersFury4PT15() {
-	meleeAbilityMask := DruidSpellMangleCat | DruidSpellShred | DruidSpellRavage | DruidSpellSwipeCat | DruidSpellFerociousBite
-
-	tfMod := druid.AddDynamicMod(core.SpellModConfig{
-		ClassMask:  meleeAbilityMask,
-		Kind:       core.SpellMod_BonusCrit_Percent,
-		FloatValue: 40,
-	})
-
-	druid.TigersFury4PT15Aura = druid.RegisterAura(core.Aura{
-		Label:     "Tiger's Fury 4PT15",
-		ActionID:  core.ActionID{SpellID: 138358},
-		Duration:  time.Second * 30,
-		MaxStacks: 3,
-
-		OnGain: func(aura *core.Aura, sim *core.Simulation) {
-			aura.SetStacks(sim, 3)
-			tfMod.Activate()
-		},
-
-		OnCastComplete: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell) {
-			if spell.Matches(meleeAbilityMask) {
-				aura.RemoveStack(sim)
-			}
-		},
-
-		OnExpire: func(_ *core.Aura, _ *core.Simulation) {
-			tfMod.Deactivate()
 		},
 	})
 }


### PR DESCRIPTION
Moved the set implementations to their respective files.
Added checks where it makes sense so using guardian set on a feral and vice versa doesn't produce errors.