### PR TITLE
Fix T16 2p bonus bug with back to back Brain Freeze FFB's

### DIFF
--- a/sim/mage/frost/TestFrost.results
+++ b/sim/mage/frost/TestFrost.results
@@ -180,8 +180,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-ChronomancerRegalia"
  value: {
-  dps: 164834.2759
-  tps: 118013.15231
+  dps: 162153.28025
+  tps: 115239.4401
  }
 }
 dps_results: {

--- a/sim/mage/items.go
+++ b/sim/mage/items.go
@@ -213,16 +213,14 @@ var ItemSetChronomancerRegalia = core.NewItemSet(core.ItemSet{
 			// Icy Veins split-bolt variant share ClassSpellMask MageSpellFrostbolt,
 			// so OnSpellRegistered would fire twice and add the OnExpire callback
 			// twice, causing a duplicate Frozen Thoughts activation per Brain Freeze.
-			brainFreezeCallbackRegistered2pc := false
+			// Tag != 0 identifies variant spells (e.g. Tag 1 = Icy Veins split-bolt).
 			mage.OnSpellRegistered(func(spell *core.Spell) {
-				if !spell.Matches(MageSpellFrostbolt) || brainFreezeCallbackRegistered2pc {
+				if !spell.Matches(MageSpellFrostbolt) || spell.ActionID.Tag != 0 {
 					return
 				}
 				if mage.BrainFreezeAura == nil {
 					return
-
 				}
-				brainFreezeCallbackRegistered2pc = true
 				mage.BrainFreezeAura.ApplyOnExpire(func(_ *core.Aura, sim *core.Simulation) {
 					if setBonusAura.IsActive() {
 						frostAura.Activate(sim)
@@ -272,17 +270,15 @@ var ItemSetChronomancerRegalia = core.NewItemSet(core.ItemSet{
 				},
 			})
 
-			// Same guard as T16 2pc: prevent double registration from the Icy Veins
-			// Frostbolt variant which shares the MageSpellFrostbolt ClassSpellMask.
-			brainFreezeCallbackRegistered4pc := false
+			// Same guard as T16 2pc: Tag != 0 skips the Icy Veins split-bolt variant
+			// which shares the MageSpellFrostbolt ClassSpellMask but uses Tag 1.
 			mage.OnSpellRegistered(func(spell *core.Spell) {
-				if !spell.Matches(MageSpellFrostbolt) || brainFreezeCallbackRegistered4pc {
+				if !spell.Matches(MageSpellFrostbolt) || spell.ActionID.Tag != 0 {
 					return
 				}
 				if mage.BrainFreezeAura == nil {
 					return
 				}
-				brainFreezeCallbackRegistered4pc = true
 				mage.BrainFreezeAura.ApplyOnExpire(func(_ *core.Aura, sim *core.Simulation) {
 					if setBonusAura.IsActive() && sim.Proc(0.30, "Item - Mage T16 4P Bonus - Frigid Blast") {
 						frigidBlast.Cast(sim, mage.CurrentTarget)

--- a/sim/mage/items.go
+++ b/sim/mage/items.go
@@ -192,10 +192,15 @@ var ItemSetChronomancerRegalia = core.NewItemSet(core.ItemSet{
 				FloatValue: 0.25,
 			})
 
+			// TriggerImmediately is required so the consume fires synchronously during
+			// DealDamage — before BrainFreezeAura.Deactivate re-activates Frozen Thoughts
+			// via its OnExpire chain. Without it the 10ms SpellBatchWindow defers the
+			// Deactivate call until after the new proc is already live, wiping it.
 			setBonusAura.MakeDependentProcTriggerAura(&mage.Unit, core.ProcTrigger{
-				Name:           "Frozen Thoughts - Consume",
-				ClassSpellMask: frostClassMask,
-				Callback:       core.CallbackOnSpellHitDealt,
+				Name:               "Frozen Thoughts - Consume",
+				ClassSpellMask:     frostClassMask,
+				Callback:           core.CallbackOnSpellHitDealt,
+				TriggerImmediately: true,
 				ExtraCondition: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) bool {
 					return frostAura.IsActive()
 				},
@@ -204,13 +209,20 @@ var ItemSetChronomancerRegalia = core.NewItemSet(core.ItemSet{
 				},
 			})
 
+			// Guard against double registration: both the main Frostbolt and the
+			// Icy Veins split-bolt variant share ClassSpellMask MageSpellFrostbolt,
+			// so OnSpellRegistered would fire twice and add the OnExpire callback
+			// twice, causing a duplicate Frozen Thoughts activation per Brain Freeze.
+			brainFreezeCallbackRegistered2pc := false
 			mage.OnSpellRegistered(func(spell *core.Spell) {
-				if !spell.Matches(MageSpellFrostbolt) {
+				if !spell.Matches(MageSpellFrostbolt) || brainFreezeCallbackRegistered2pc {
 					return
 				}
 				if mage.BrainFreezeAura == nil {
 					return
+
 				}
+				brainFreezeCallbackRegistered2pc = true
 				mage.BrainFreezeAura.ApplyOnExpire(func(_ *core.Aura, sim *core.Simulation) {
 					if setBonusAura.IsActive() {
 						frostAura.Activate(sim)
@@ -260,13 +272,17 @@ var ItemSetChronomancerRegalia = core.NewItemSet(core.ItemSet{
 				},
 			})
 
+			// Same guard as T16 2pc: prevent double registration from the Icy Veins
+			// Frostbolt variant which shares the MageSpellFrostbolt ClassSpellMask.
+			brainFreezeCallbackRegistered4pc := false
 			mage.OnSpellRegistered(func(spell *core.Spell) {
-				if !spell.Matches(MageSpellFrostbolt) {
+				if !spell.Matches(MageSpellFrostbolt) || brainFreezeCallbackRegistered4pc {
 					return
 				}
 				if mage.BrainFreezeAura == nil {
 					return
 				}
+				brainFreezeCallbackRegistered4pc = true
 				mage.BrainFreezeAura.ApplyOnExpire(func(_ *core.Aura, sim *core.Simulation) {
 					if setBonusAura.IsActive() && sim.Proc(0.30, "Item - Mage T16 4P Bonus - Frigid Blast") {
 						frigidBlast.Cast(sim, mage.CurrentTarget)


### PR DESCRIPTION
This pull request addresses issues with the Mage Chronomancer Regalia set bonus logic by ensuring correct timing and preventing duplicate effect registrations. The changes focus on synchronizing aura consumption and guarding against double callback registration due to shared spell masks.

Key fixes and improvements:

**Synchronization and Timing:**
* Added `TriggerImmediately: true` to the set bonus proc trigger to ensure the consume effect fires synchronously during `DealDamage`, preventing a race condition where the aura could be incorrectly re-activated due to the spell batching window.

**Duplicate Callback Registration Prevention:**
* Introduced a guard variable (`brainFreezeCallbackRegistered2pc`) to prevent double registration of the Brain Freeze `OnExpire` callback for the 2-piece bonus, since both the main Frostbolt and its Icy Veins variant share the same class spell mask and could previously register the callback twice.
* Added a similar guard (`brainFreezeCallbackRegistered4pc`) for the 4-piece bonus to prevent duplicate callback registration from the Frostbolt variants, ensuring only a single activation per Brain Freeze.