### PR TITLE
[FDK] Frozen Power can trigger weapon enchant and trinket procs

### DIFF
--- a/sim/death_knight/blood/TestBlood.results
+++ b/sim/death_knight/blood/TestBlood.results
@@ -1932,8 +1932,8 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-RuneofRazorice-3370"
  value: {
-  dps: 386914.78126
-  tps: 1.95547620115e+06
+  dps: 386914.55402
+  tps: 1.95547461042e+06
   dtps: 155997.43194
   hps: 171551.06885
  }

--- a/sim/death_knight/frost/TestFrostMasterfrost.results
+++ b/sim/death_knight/frost/TestFrostMasterfrost.results
@@ -33,2600 +33,2600 @@ character_stats_results: {
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-AgilePrimalDiamond"
  value: {
-  dps: 431391.39964
-  tps: 398754.93604
+  dps: 431238.02491
+  tps: 398601.56131
   hps: 4330.83046
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-AlacrityofXuen-103989"
  value: {
-  dps: 401532.05064
-  tps: 372145.00623
+  dps: 401472.83392
+  tps: 372085.78951
   hps: 4339.18096
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-ArcaneBadgeoftheShieldwall-93347"
  value: {
-  dps: 384072.54366
-  tps: 357885.78245
+  dps: 383912.15726
+  tps: 357725.39606
   hps: 4291.27651
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-ArrowflightMedallion-93258"
  value: {
-  dps: 387378.6909
-  tps: 360664.30008
+  dps: 387423.90751
+  tps: 360709.51668
   hps: 4358.89618
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-AssuranceofConsequence-105472"
  value: {
-  dps: 385223.30987
-  tps: 359096.95229
+  dps: 385028.2743
+  tps: 358901.91672
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-AusterePrimalDiamond"
  value: {
-  dps: 424651.44058
-  tps: 392066.95975
+  dps: 424431.1595
+  tps: 391846.67866
   hps: 4314.03544
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BadJuju-96781"
  value: {
-  dps: 393372.70935
-  tps: 367309.54975
+  dps: 393176.04384
+  tps: 367112.88424
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BadgeofKypariZar-84079"
  value: {
-  dps: 390796.25541
-  tps: 364432.83967
+  dps: 390597.28339
+  tps: 364233.86765
   hps: 4333.52519
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BattlegearoftheLostCatacomb"
  value: {
-  dps: 315263.83517
-  tps: 289098.37764
+  dps: 315315.53337
+  tps: 289150.07585
   hps: 2556.77913
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BattleplateofCyclopeanDread"
  value: {
-  dps: 347063.77333
-  tps: 319239.9153
+  dps: 347093.97416
+  tps: 319270.11613
   hps: 3817.21123
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BattleplateoftheAll-ConsumingMaw"
  value: {
-  dps: 331366.65897
-  tps: 296941.47753
+  dps: 331469.09433
+  tps: 297043.9129
   hps: 2797.29334
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BlackBloodofY'Shaarj-105648"
  value: {
-  dps: 389255.80612
-  tps: 362774.16277
+  dps: 389371.47408
+  tps: 362889.83073
   hps: 4327.8508
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BlossomofPureSnow-89081"
  value: {
-  dps: 386833.75486
-  tps: 360203.91832
+  dps: 386883.16534
+  tps: 360253.3288
   hps: 4358.74702
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BottleofInfiniteStars-87057"
  value: {
-  dps: 390680.2812
-  tps: 364644.55368
+  dps: 390487.4531
+  tps: 364451.72558
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BraidofTenSongs-84072"
  value: {
-  dps: 387676.57119
-  tps: 361521.27928
+  dps: 387897.85097
+  tps: 361742.55907
   hps: 4294.50981
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Brawler'sStatue-257885"
  value: {
-  dps: 382333.22111
-  tps: 356333.09171
+  dps: 382391.85587
+  tps: 356391.72647
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BreathoftheHydra-96827"
  value: {
-  dps: 389266.82853
-  tps: 362909.84688
+  dps: 389048.8585
+  tps: 362691.87684
   hps: 4297.19729
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BroochofMunificentDeeds-87500"
  value: {
-  dps: 382320.76675
-  tps: 356340.99181
+  dps: 382418.16231
+  tps: 356438.38737
   hps: 4395.8047
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BrutalTalismanoftheShado-PanAssault-94508"
  value: {
-  dps: 399099.54084
-  tps: 370564.74227
+  dps: 399140.60561
+  tps: 370605.80703
   hps: 4262.82482
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BurningPrimalDiamond"
  value: {
-  dps: 431340.94123
-  tps: 398707.86772
+  dps: 431187.33328
+  tps: 398554.25977
   hps: 4330.83046
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CapacitivePrimalDiamond"
  value: {
-  dps: 439197.46041
-  tps: 406336.29317
+  dps: 439133.39803
+  tps: 406272.23079
   hps: 4373.9791
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CarbonicCarbuncle-81138"
  value: {
-  dps: 396185.19621
-  tps: 368621.68527
+  dps: 395985.5586
+  tps: 368422.04766
   hps: 4357.65945
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Cha-Ye'sEssenceofBrilliance-96888"
  value: {
-  dps: 391521.24658
-  tps: 364924.74473
+  dps: 391318.60442
+  tps: 364722.10257
   hps: 4395.56613
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CharmofTenSongs-84071"
  value: {
-  dps: 386320.15239
-  tps: 359784.523
+  dps: 386106.31287
+  tps: 359570.68348
   hps: 4344.67765
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CommunalIdolofDestruction-101168"
  value: {
-  dps: 390010.21777
-  tps: 363452.92693
+  dps: 389968.5795
+  tps: 363411.28866
   hps: 4251.58894
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CommunalStoneofDestruction-101171"
  value: {
-  dps: 390873.4971
-  tps: 364881.01962
+  dps: 390685.32658
+  tps: 364692.8491
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CommunalStoneofWisdom-101183"
  value: {
-  dps: 384531.97008
-  tps: 358539.4926
+  dps: 384340.91287
+  tps: 358348.43539
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-ContemplationofChi-Ji-103988"
  value: {
-  dps: 383839.1515
-  tps: 357810.37916
+  dps: 383581.77064
+  tps: 357552.99831
   hps: 4293.99289
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Coren'sColdChromiumCoaster-257880"
  value: {
-  dps: 396594.24929
-  tps: 369174.44681
+  dps: 396389.88577
+  tps: 368970.08328
   hps: 4346.90222
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CoreofDecency-87497"
  value: {
-  dps: 384531.97008
-  tps: 358539.4926
+  dps: 384340.91287
+  tps: 358348.43539
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CourageousPrimalDiamond"
  value: {
-  dps: 424606.20752
-  tps: 392022.42036
+  dps: 424459.21035
+  tps: 391875.42319
   hps: 4293.48791
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedDreadfulGladiator'sBadgeofConquest-93419"
  value: {
-  dps: 382495.18609
-  tps: 356476.19427
+  dps: 382553.31701
+  tps: 356534.32518
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedDreadfulGladiator'sBadgeofDominance-93600"
  value: {
-  dps: 382333.22111
-  tps: 356333.09171
+  dps: 382391.85587
+  tps: 356391.72647
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedDreadfulGladiator'sBadgeofVictory-93606"
  value: {
-  dps: 389246.71875
-  tps: 362380.94797
+  dps: 389305.80493
+  tps: 362440.03415
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedDreadfulGladiator'sEmblemofCruelty-93485"
  value: {
-  dps: 385207.12394
-  tps: 358926.89802
+  dps: 385108.36036
+  tps: 358828.13444
   hps: 4323.05556
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedDreadfulGladiator'sEmblemofMeditation-93487"
  value: {
-  dps: 382205.5248
-  tps: 356213.93504
+  dps: 382106.51838
+  tps: 356114.92863
   hps: 4270.87882
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedDreadfulGladiator'sEmblemofTenacity-93486"
  value: {
-  dps: 382320.76675
-  tps: 356340.99181
+  dps: 382418.16231
+  tps: 356438.38737
   hps: 4383.17242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedDreadfulGladiator'sInsigniaofConquest-93424"
  value: {
-  dps: 384776.64085
-  tps: 358750.14218
+  dps: 384588.00946
+  tps: 358561.51079
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedDreadfulGladiator'sInsigniaofDominance-93601"
  value: {
-  dps: 384531.97008
-  tps: 358539.4926
+  dps: 384340.91287
+  tps: 358348.43539
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedDreadfulGladiator'sInsigniaofVictory-93611"
  value: {
-  dps: 394225.72024
-  tps: 366971.92252
+  dps: 393970.2529
+  tps: 366716.45519
   hps: 4268.53469
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedMalevolentGladiator'sBadgeofConquest-98755"
  value: {
-  dps: 382502.05674
-  tps: 356478.07455
+  dps: 382560.18765
+  tps: 356536.20546
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedMalevolentGladiator'sBadgeofDominance-98910"
  value: {
-  dps: 382333.22111
-  tps: 356333.09171
+  dps: 382391.85587
+  tps: 356391.72647
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedMalevolentGladiator'sBadgeofVictory-98912"
  value: {
-  dps: 390509.00505
-  tps: 363485.18298
+  dps: 390568.17366
+  tps: 363544.35159
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedMalevolentGladiator'sEmblemofCruelty-98811"
  value: {
-  dps: 385768.50803
-  tps: 359435.30946
+  dps: 385660.87285
+  tps: 359327.67428
   hps: 4327.20865
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedMalevolentGladiator'sEmblemofMeditation-98813"
  value: {
-  dps: 382205.5248
-  tps: 356213.93504
+  dps: 382106.51838
+  tps: 356114.92863
   hps: 4270.87882
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedMalevolentGladiator'sEmblemofTenacity-98812"
  value: {
-  dps: 382666.67499
-  tps: 356680.71355
+  dps: 382750.80192
+  tps: 356764.84049
   hps: 4398.49973
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedMalevolentGladiator'sInsigniaofConquest-98760"
  value: {
-  dps: 384770.72785
-  tps: 358735.58563
+  dps: 384583.05084
+  tps: 358547.90862
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedMalevolentGladiator'sInsigniaofDominance-98911"
  value: {
-  dps: 384531.97008
-  tps: 358539.4926
+  dps: 384340.91287
+  tps: 358348.43539
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedMalevolentGladiator'sInsigniaofVictory-98917"
  value: {
-  dps: 396372.89348
-  tps: 368926.69983
+  dps: 396222.30544
+  tps: 368776.1118
   hps: 4268.53469
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CurseofHubris-105645"
  value: {
-  dps: 394209.95692
-  tps: 366282.69656
+  dps: 394336.51876
+  tps: 366409.25841
   hps: 4922.31137
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CutstitcherMedallion-93255"
  value: {
-  dps: 382333.22111
-  tps: 356333.09171
+  dps: 382391.85587
+  tps: 356391.72647
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Daelo'sFinalWords-87496"
  value: {
-  dps: 391017.0073
-  tps: 363627.9925
+  dps: 391667.68134
+  tps: 364278.66654
   hps: 4294.405
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DarkglowEmbroidery(Rank3)-4893"
  value: {
-  dps: 438271.55649
-  tps: 405472.90888
+  dps: 438208.8418
+  tps: 405410.19419
   hps: 4353.72283
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DarkmistVortex-87172"
  value: {
-  dps: 397346.73473
-  tps: 368586.8482
+  dps: 397138.91688
+  tps: 368379.03036
   hps: 4306.04925
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DeadeyeBadgeoftheShieldwall-93346"
  value: {
-  dps: 386381.0818
-  tps: 360363.78896
+  dps: 386439.20071
+  tps: 360421.90787
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DelicateVialoftheSanguinaire-96895"
  value: {
-  dps: 384531.97008
-  tps: 358539.4926
+  dps: 384340.91287
+  tps: 358348.43539
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DestructivePrimalDiamond"
  value: {
-  dps: 426455.88513
-  tps: 393636.65139
+  dps: 426314.10674
+  tps: 393494.873
   hps: 4325.89796
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DisciplineofXuen-103986"
  value: {
-  dps: 396371.99639
-  tps: 370346.00134
+  dps: 396192.93662
+  tps: 370166.94157
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Dominator'sArcaneBadge-93342"
  value: {
-  dps: 384072.54366
-  tps: 357885.78245
+  dps: 383912.15726
+  tps: 357725.39606
   hps: 4291.27651
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Dominator'sDeadeyeBadge-93341"
  value: {
-  dps: 386381.0818
-  tps: 360363.78896
+  dps: 386439.20071
+  tps: 360421.90787
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Dominator'sDurableBadge-93345"
  value: {
-  dps: 386207.94829
-  tps: 360207.81888
+  dps: 386267.97168
+  tps: 360267.84227
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Dominator'sKnightlyBadge-93344"
  value: {
-  dps: 392808.81061
-  tps: 366229.56377
+  dps: 392869.08693
+  tps: 366289.84009
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Dominator'sMendingBadge-93343"
  value: {
-  dps: 382333.22111
-  tps: 356333.09171
+  dps: 382391.85587
+  tps: 356391.72647
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DreadfulGladiator'sBadgeofConquest-84344"
  value: {
-  dps: 382495.18609
-  tps: 356476.19427
+  dps: 382553.31701
+  tps: 356534.32518
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DreadfulGladiator'sBadgeofDominance-84488"
  value: {
-  dps: 382333.22111
-  tps: 356333.09171
+  dps: 382391.85587
+  tps: 356391.72647
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DreadfulGladiator'sBadgeofVictory-84490"
  value: {
-  dps: 389246.71875
-  tps: 362380.94797
+  dps: 389305.80493
+  tps: 362440.03415
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DreadfulGladiator'sEmblemofCruelty-84399"
  value: {
-  dps: 385207.12394
-  tps: 358926.89802
+  dps: 385108.36036
+  tps: 358828.13444
   hps: 4323.05556
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DreadfulGladiator'sEmblemofMeditation-84401"
  value: {
-  dps: 382205.5248
-  tps: 356213.93504
+  dps: 382106.51838
+  tps: 356114.92863
   hps: 4270.87882
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DreadfulGladiator'sEmblemofTenacity-84400"
  value: {
-  dps: 382320.76675
-  tps: 356340.99181
+  dps: 382418.16231
+  tps: 356438.38737
   hps: 4383.17242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DreadfulGladiator'sInsigniaofConquest-84349"
  value: {
-  dps: 384730.09148
-  tps: 358703.59281
+  dps: 384541.53314
+  tps: 358515.03447
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DreadfulGladiator'sInsigniaofDominance-84489"
  value: {
-  dps: 384531.97008
-  tps: 358539.4926
+  dps: 384340.91287
+  tps: 358348.43539
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DreadfulGladiator'sInsigniaofVictory-84495"
  value: {
-  dps: 392919.38541
-  tps: 365729.37338
+  dps: 392942.81682
+  tps: 365752.8048
   hps: 4258.50424
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DurableBadgeoftheShieldwall-93350"
  value: {
-  dps: 386207.94829
-  tps: 360207.81888
+  dps: 386267.97168
+  tps: 360267.84227
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DysmorphicSamophlangeofDiscontinuity-105615"
  value: {
-  dps: 384531.97008
-  tps: 358539.4926
+  dps: 384340.91287
+  tps: 358348.43539
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EffulgentPrimalDiamond"
  value: {
-  dps: 424651.44058
-  tps: 392066.95975
+  dps: 424431.1595
+  tps: 391846.67866
   hps: 4314.03544
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EmberPrimalDiamond"
  value: {
-  dps: 424606.20752
-  tps: 392022.42036
+  dps: 424459.21035
+  tps: 391875.42319
   hps: 4293.48791
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EmblemofKypariZar-84077"
  value: {
-  dps: 387270.43539
-  tps: 360765.01082
+  dps: 387269.97115
+  tps: 360764.54658
   hps: 4359.10133
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EmblemoftheCatacombs-83733"
  value: {
-  dps: 387636.34775
-  tps: 361667.88575
+  dps: 387737.49312
+  tps: 361769.03112
   hps: 4243.17816
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EmptyFruitBarrel-81133"
  value: {
-  dps: 384531.97008
-  tps: 358539.4926
+  dps: 384340.91287
+  tps: 358348.43539
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EnchantWeapon-BloodyDancingSteel-5125"
  value: {
-  dps: 410978.97116
-  tps: 380853.15511
+  dps: 410819.15284
+  tps: 380693.33678
   hps: 16.21842
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EnchantWeapon-Colossus-4445"
  value: {
-  dps: 404395.41495
-  tps: 374964.80572
+  dps: 404621.79463
+  tps: 375191.18541
   hps: 16.77088
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EnchantWeapon-DancingSteel-4444"
  value: {
-  dps: 409829.32622
-  tps: 379504.77119
+  dps: 409797.42986
+  tps: 379472.87482
   hps: 16.99141
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EnchantWeapon-ElementalForce-4443"
  value: {
-  dps: 404661.48718
-  tps: 375236.26173
+  dps: 404834.75212
+  tps: 375409.52667
   hps: 16.52179
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EnchantWeapon-JadeSpirit-4442"
  value: {
-  dps: 403835.89868
-  tps: 374317.40704
+  dps: 403698.15877
+  tps: 374179.66712
   hps: 16.52384
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EnchantWeapon-River'sSong-4446"
  value: {
-  dps: 403835.89868
-  tps: 374317.40704
+  dps: 403698.15877
+  tps: 374179.66712
   hps: 16.52384
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EnchantWeapon-SpiritofConquest-5124"
  value: {
-  dps: 403835.89868
-  tps: 374317.40704
+  dps: 403698.15877
+  tps: 374179.66712
   hps: 16.52384
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EnchantWeapon-Windsong-4441"
  value: {
-  dps: 407716.18985
-  tps: 377950.40984
+  dps: 407789.24465
+  tps: 378023.46464
   hps: 16.52384
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EnigmaticPrimalDiamond"
  value: {
-  dps: 426455.88513
-  tps: 393636.65139
+  dps: 426314.10674
+  tps: 393494.873
   hps: 4325.89796
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EssenceofTerror-87175"
  value: {
-  dps: 388498.38155
-  tps: 361255.87706
-  hps: 4307.79396
+  dps: 388451.2165
+  tps: 361210.18583
+  hps: 4311.51057
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EternalPrimalDiamond"
  value: {
-  dps: 424606.20752
-  tps: 392022.42036
+  dps: 424459.21035
+  tps: 391875.42319
   hps: 4293.48791
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EvilEyeofGalakras-105491"
  value: {
-  dps: 423366.17632
-  tps: 393709.59728
+  dps: 423627.85254
+  tps: 393971.2735
   hps: 4886.82859
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-FabledFeatherofJi-Kun-96842"
  value: {
-  dps: 410737.4657
-  tps: 381369.5497
+  dps: 411050.49628
+  tps: 381682.58028
   hps: 4372.86294
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-FearwurmBadge-84074"
  value: {
-  dps: 387331.22526
-  tps: 361010.49774
+  dps: 387406.77356
+  tps: 361086.04604
   hps: 4302.74345
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-FearwurmRelic-84070"
  value: {
-  dps: 387379.56951
-  tps: 360921.58007
+  dps: 387579.8123
+  tps: 361121.82286
   hps: 4378.12618
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-FelsoulIdolofDestruction-101263"
  value: {
-  dps: 391535.08118
-  tps: 364929.37196
+  dps: 391305.84053
+  tps: 364700.1313
   hps: 4281.40592
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-FelsoulStoneofDestruction-101266"
  value: {
-  dps: 390900.31265
-  tps: 364907.83517
+  dps: 390709.61895
+  tps: 364717.14147
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Fen-Yu,FuryofXuen-102248"
  value: {
-  dps: 415373.09166
-  tps: 384358.36144
+  dps: 415379.86336
+  tps: 384365.13314
   hps: 4282.64887
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-FlashfrozenResinGlobule-100951"
  value: {
-  dps: 386227.84892
-  tps: 360236.56785
+  dps: 386516.30751
+  tps: 360525.02643
   hps: 4308.81885
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-FlashingSteelTalisman-81265"
  value: {
-  dps: 386418.45018
-  tps: 360306.21792
+  dps: 386750.85677
+  tps: 360638.62451
   hps: 4327.85256
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-FleetPrimalDiamond"
  value: {
-  dps: 427095.18897
-  tps: 394511.40181
+  dps: 426946.58088
+  tps: 394362.79372
   hps: 4293.48791
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-ForlornPrimalDiamond"
  value: {
-  dps: 424606.20752
-  tps: 392022.42036
+  dps: 424459.21035
+  tps: 391875.42319
   hps: 4293.48791
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-FortitudeoftheZandalari-96793"
  value: {
-  dps: 390606.5314
-  tps: 364614.94164
+  dps: 390503.13887
+  tps: 364511.54912
   hps: 4270.87882
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-FrenziedCrystalofRage-105572"
  value: {
-  dps: 384531.97008
-  tps: 358539.4926
+  dps: 384340.91287
+  tps: 358348.43539
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Fusion-FireCore-105459"
  value: {
-  dps: 411242.06523
-  tps: 380843.39903
+  dps: 411100.21477
+  tps: 380701.54857
   hps: 4254.74695
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-GazeoftheTwins-96915"
  value: {
-  dps: 405503.5733
-  tps: 377333.7428
+  dps: 405319.70449
+  tps: 377149.87399
   hps: 4390.36564
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Gerp'sPerfectArrow-87495"
  value: {
-  dps: 384946.87742
-  tps: 358670.87484
+  dps: 384999.7083
+  tps: 358723.70573
   hps: 4306.27798
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-GrievousGladiator'sBadgeofConquest-103145"
  value: {
-  dps: 382577.61841
-  tps: 356540.30631
+  dps: 382636.13987
+  tps: 356598.82776
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-GrievousGladiator'sBadgeofDominance-103308"
  value: {
-  dps: 382333.22111
-  tps: 356333.09171
+  dps: 382391.85587
+  tps: 356391.72647
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-GrievousGladiator'sBadgeofVictory-103314"
  value: {
-  dps: 394887.66759
-  tps: 367315.5917
+  dps: 394947.1221
+  tps: 367375.04621
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-GrievousGladiator'sEmblemofCruelty-103210"
  value: {
-  dps: 387871.46511
-  tps: 361343.33548
+  dps: 387770.92201
+  tps: 361242.79237
   hps: 4353.33298
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-GrievousGladiator'sEmblemofMeditation-103212"
  value: {
-  dps: 382205.5248
-  tps: 356213.93504
+  dps: 382106.51838
+  tps: 356114.92863
   hps: 4270.87882
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-GrievousGladiator'sEmblemofTenacity-103211"
  value: {
-  dps: 383274.23787
-  tps: 357259.73665
+  dps: 383431.34191
+  tps: 357416.84068
   hps: 4460.68398
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-GrievousGladiator'sInsigniaofConquest-103150"
  value: {
-  dps: 384959.32233
-  tps: 358906.17502
+  dps: 384768.62125
+  tps: 358715.47394
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-GrievousGladiator'sInsigniaofDominance-103309"
  value: {
-  dps: 384531.97008
-  tps: 358539.4926
+  dps: 384340.91287
+  tps: 358348.43539
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-GrievousGladiator'sInsigniaofVictory-103319"
  value: {
-  dps: 402541.48139
-  tps: 374395.05216
+  dps: 402359.21065
+  tps: 374212.78142
   hps: 4278.033
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Haromm'sTalisman-105527"
  value: {
-  dps: 403340.13686
-  tps: 377252.72938
+  dps: 403204.5395
+  tps: 377117.13202
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Hawkmaster'sTalon-89082"
  value: {
-  dps: 384415.96964
-  tps: 358003.34433
+  dps: 383995.93687
+  tps: 357583.31156
   hps: 4299.96319
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Heart-LesionDefenderIdol-100999"
  value: {
-  dps: 383690.75897
-  tps: 357651.60545
+  dps: 383483.06397
+  tps: 357443.91045
   hps: 4429.37134
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Heart-LesionDefenderStone-101002"
  value: {
-  dps: 390058.62928
-  tps: 364019.47575
+  dps: 389845.95866
+  tps: 363806.80513
   hps: 4429.37134
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Heart-LesionIdolofBattle-100991"
  value: {
-  dps: 398984.60935
-  tps: 371249.29344
+  dps: 398800.04373
+  tps: 371064.72782
   hps: 4294.71952
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Heart-LesionStoneofBattle-100990"
  value: {
-  dps: 399289.20485
-  tps: 372566.06349
+  dps: 399107.84683
+  tps: 372384.70548
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-HeartofFire-81181"
  value: {
-  dps: 386396.33773
-  tps: 360396.20833
+  dps: 386454.87733
+  tps: 360454.74793
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-HeartwarmerMedallion-93260"
  value: {
-  dps: 382333.22111
-  tps: 356333.09171
+  dps: 382391.85587
+  tps: 356391.72647
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-HelmbreakerMedallion-93261"
  value: {
-  dps: 396586.12211
-  tps: 369052.65753
+  dps: 396632.50919
+  tps: 369099.04461
   hps: 4358.89618
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Horridon'sLastGasp-96757"
  value: {
-  dps: 384531.97008
-  tps: 358539.4926
+  dps: 384340.91287
+  tps: 358348.43539
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-ImpassivePrimalDiamond"
  value: {
-  dps: 426455.88513
-  tps: 393636.65139
+  dps: 426314.10674
+  tps: 393494.873
   hps: 4325.89796
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-IndomitablePrimalDiamond"
  value: {
-  dps: 424651.44058
-  tps: 392066.95975
+  dps: 424431.1595
+  tps: 391846.67866
   hps: 4314.03544
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-InscribedBagofHydra-Spawn-96828"
  value: {
-  dps: 382707.59585
-  tps: 356789.03482
+  dps: 382974.57065
+  tps: 357056.00962
   hps: 4260.86438
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-InsigniaofKypariZar-84078"
  value: {
-  dps: 384531.97008
-  tps: 358539.4926
+  dps: 384340.91287
+  tps: 358348.43539
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-IronBellyWok-89083"
  value: {
-  dps: 392987.96012
-  tps: 365823.1517
+  dps: 392568.94548
+  tps: 365404.13706
   hps: 4299.96319
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-IronProtectorTalisman-85181"
  value: {
-  dps: 383239.27073
-  tps: 357208.96771
+  dps: 383057.71188
+  tps: 357027.40886
   hps: 4382.06746
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-JadeBanditFigurine-86772"
  value: {
-  dps: 385744.37104
-  tps: 359324.03144
+  dps: 385584.00558
+  tps: 359163.66598
   hps: 4295.40833
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-JadeCharioteerFigurine-86771"
  value: {
-  dps: 393293.59614
-  tps: 366213.19324
+  dps: 393135.19399
+  tps: 366054.79109
   hps: 4295.40833
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-JadeCourtesanFigurine-86774"
  value: {
-  dps: 382333.22111
-  tps: 356333.09171
+  dps: 382391.85587
+  tps: 356391.72647
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-JadeMagistrateFigurine-86773"
  value: {
-  dps: 386214.51004
-  tps: 359662.03006
+  dps: 386260.92126
+  tps: 359708.44128
   hps: 4333.47406
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-JadeWarlordFigurine-86775"
  value: {
-  dps: 387597.34135
-  tps: 361586.6052
+  dps: 387632.8218
+  tps: 361622.08565
   hps: 4375.8384
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Ji-Kun'sRisingWinds-96843"
  value: {
-  dps: 384531.97008
-  tps: 358539.4926
+  dps: 384340.91287
+  tps: 358348.43539
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Juggernaut'sFocusingCrystal-105514"
  value: {
-  dps: 384531.97008
-  tps: 358539.4926
-  hps: 15614.7598
+  dps: 384340.91287
+  tps: 358348.43539
+  hps: 15608.37761
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Kardris'ToxicTotem-105540"
  value: {
-  dps: 403201.06422
-  tps: 377208.58675
+  dps: 402958.31603
+  tps: 376965.83856
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-KnightlyBadgeoftheShieldwall-93349"
  value: {
-  dps: 392808.81061
-  tps: 366229.56377
+  dps: 392869.08693
+  tps: 366289.84009
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-KnotofTenSongs-84073"
  value: {
-  dps: 384531.97008
-  tps: 358539.4926
+  dps: 384340.91287
+  tps: 358348.43539
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Kor'kronBookofHurting-92785"
  value: {
-  dps: 382333.22111
-  tps: 356333.09171
+  dps: 382391.85587
+  tps: 356391.72647
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Lao-Chin'sLiquidCourage-89079"
  value: {
-  dps: 388320.46103
-  tps: 362317.64434
+  dps: 388362.82664
+  tps: 362360.00995
   hps: 4402.88966
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-LeiShen'sFinalOrders-87072"
  value: {
-  dps: 399488.03434
-  tps: 371701.32453
+  dps: 399908.36443
+  tps: 372121.65463
   hps: 4297.69977
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-LessonsoftheDarkmaster-81268"
  value: {
-  dps: 391791.04168
-  tps: 363978.49287
+  dps: 391850.595
+  tps: 364038.04619
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-LightdrinkerIdolofRage-101200"
  value: {
-  dps: 389701.80467
-  tps: 363667.87792
+  dps: 389509.50358
+  tps: 363475.57683
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-LightdrinkerStoneofRage-101203"
  value: {
-  dps: 391193.14359
-  tps: 365185.29815
+  dps: 391004.62385
+  tps: 364996.77841
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-LightoftheCosmos-87065"
  value: {
-  dps: 386468.58497
-  tps: 360258.00262
+  dps: 386386.55043
+  tps: 360175.96808
   hps: 4283.10801
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-LightweaveEmbroidery(Rank3)-4892"
  value: {
-  dps: 438271.55649
-  tps: 405472.90888
+  dps: 438208.8418
+  tps: 405410.19419
   hps: 4353.72283
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-LordBlastington'sScopeofDoom-4699"
  value: {
-  dps: 403835.89868
-  tps: 374317.40704
+  dps: 403698.15877
+  tps: 374179.66712
   hps: 16.52384
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MalevolentGladiator'sBadgeofConquest-91452"
  value: {
-  dps: 382502.05674
-  tps: 356478.07455
+  dps: 382560.18765
+  tps: 356536.20546
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MalevolentGladiator'sBadgeofDominance-91753"
  value: {
-  dps: 382333.22111
-  tps: 356333.09171
+  dps: 382391.85587
+  tps: 356391.72647
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MalevolentGladiator'sBadgeofVictory-91763"
  value: {
-  dps: 390509.00505
-  tps: 363485.18298
+  dps: 390568.17366
+  tps: 363544.35159
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MalevolentGladiator'sEmblemofCruelty-91562"
  value: {
-  dps: 385768.50803
-  tps: 359435.30946
+  dps: 385660.87285
+  tps: 359327.67428
   hps: 4327.20865
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MalevolentGladiator'sEmblemofMeditation-91564"
  value: {
-  dps: 382205.5248
-  tps: 356213.93504
+  dps: 382106.51838
+  tps: 356114.92863
   hps: 4270.87882
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MalevolentGladiator'sEmblemofTenacity-91563"
  value: {
-  dps: 382666.67499
-  tps: 356680.71355
+  dps: 382750.80192
+  tps: 356764.84049
   hps: 4398.49973
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MalevolentGladiator'sInsigniaofConquest-91457"
  value: {
-  dps: 384780.86531
-  tps: 358747.95251
+  dps: 384592.70062
+  tps: 358559.78783
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MalevolentGladiator'sInsigniaofDominance-91754"
  value: {
-  dps: 384531.97008
-  tps: 358539.4926
+  dps: 384340.91287
+  tps: 358348.43539
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MalevolentGladiator'sInsigniaofVictory-91768"
  value: {
-  dps: 397335.45541
-  tps: 369858.2133
+  dps: 397257.09551
+  tps: 369779.8534
   hps: 4297.52426
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MarkoftheCatacombs-83731"
  value: {
-  dps: 390650.22004
-  tps: 364434.06478
+  dps: 390448.54502
+  tps: 364232.38976
   hps: 4337.54588
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MarkoftheHardenedGrunt-92783"
  value: {
-  dps: 382333.22111
-  tps: 356333.09171
+  dps: 382391.85587
+  tps: 356391.72647
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MedallionofMystifyingVapors-93257"
  value: {
-  dps: 387855.39077
-  tps: 361855.26137
+  dps: 387916.00457
+  tps: 361915.87517
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MedallionoftheCatacombs-83734"
  value: {
-  dps: 387507.08485
-  tps: 361514.60737
+  dps: 387313.60142
+  tps: 361321.12394
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MendingBadgeoftheShieldwall-93348"
  value: {
-  dps: 382333.22111
-  tps: 356333.09171
+  dps: 382391.85587
+  tps: 356391.72647
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MirrorScope-4700"
  value: {
-  dps: 403835.89868
-  tps: 374317.40704
+  dps: 403698.15877
+  tps: 374179.66712
   hps: 16.52384
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MistdancerDefenderIdol-101089"
  value: {
-  dps: 383690.75897
-  tps: 357651.60545
+  dps: 383483.06397
+  tps: 357443.91045
   hps: 4429.37134
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MistdancerDefenderStone-101087"
  value: {
-  dps: 390016.64397
-  tps: 363977.49045
+  dps: 389818.20038
+  tps: 363779.04686
   hps: 4429.37134
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MistdancerIdolofRage-101113"
  value: {
-  dps: 389660.61338
-  tps: 363626.68664
+  dps: 389468.70425
+  tps: 363434.7775
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MistdancerStoneofRage-101117"
  value: {
-  dps: 391069.92327
-  tps: 365062.07784
+  dps: 390886.76551
+  tps: 364878.92008
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MistdancerStoneofWisdom-101107"
  value: {
-  dps: 384531.97008
-  tps: 358539.4926
+  dps: 384340.91287
+  tps: 358348.43539
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MithrilWristwatch-257884"
  value: {
-  dps: 388513.30602
-  tps: 362122.71852
+  dps: 388308.45431
+  tps: 361917.8668
   hps: 4346.90222
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MountainsageIdolofDestruction-101069"
  value: {
-  dps: 392420.81706
-  tps: 365913.50034
+  dps: 392475.46328
+  tps: 365968.14656
   hps: 4333.70071
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MountainsageStoneofDestruction-101072"
  value: {
-  dps: 390898.93091
-  tps: 364906.45343
+  dps: 390709.9962
+  tps: 364717.51872
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-NitroBoosts-4223"
  value: {
-  dps: 438842.52232
-  tps: 405961.35949
+  dps: 439168.54949
+  tps: 406287.38666
   hps: 4359.40079
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-OathswornDefenderIdol-101303"
  value: {
-  dps: 383690.75897
-  tps: 357651.60545
+  dps: 383483.06397
+  tps: 357443.91045
   hps: 4429.37134
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-OathswornDefenderStone-101306"
  value: {
-  dps: 389960.45749
-  tps: 363921.30397
+  dps: 389756.57349
+  tps: 363717.41997
   hps: 4429.37134
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-OathswornIdolofBattle-101295"
  value: {
-  dps: 398685.67064
-  tps: 370978.97823
+  dps: 398636.44891
+  tps: 370929.75651
   hps: 4312.39438
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-OathswornStoneofBattle-101294"
  value: {
-  dps: 399281.78638
-  tps: 372558.64502
+  dps: 399092.1073
+  tps: 372368.96594
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PhaseFingers-4697"
  value: {
-  dps: 436880.13646
-  tps: 404036.03866
+  dps: 436916.68438
+  tps: 404072.58658
   hps: 4330.10146
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PlateofCyclopeanDread"
  value: {
-  dps: 318249.49181
-  tps: 292862.5427
+  dps: 318218.95301
+  tps: 292832.0039
   hps: 2556.59698
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PlateoftheAll-ConsumingMaw"
  value: {
-  dps: 307779.37544
-  tps: 282336.55967
+  dps: 307890.46521
+  tps: 282447.64945
   hps: 2625.57528
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PlateoftheLostCatacomb"
  value: {
-  dps: 292682.775
-  tps: 268562.76272
+  dps: 292611.38432
+  tps: 268491.37205
   hps: 2411.45541
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PouchofWhiteAsh-103639"
  value: {
-  dps: 382333.22111
-  tps: 356333.09171
+  dps: 382391.85587
+  tps: 356391.72647
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PowerfulPrimalDiamond"
  value: {
-  dps: 424651.44058
-  tps: 392066.95975
+  dps: 424431.1595
+  tps: 391846.67866
   hps: 4314.03544
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PriceofProgress-81266"
  value: {
-  dps: 384531.97008
-  tps: 358539.4926
+  dps: 384340.91287
+  tps: 358348.43539
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PridefulGladiator'sBadgeofConquest-103342"
  value: {
-  dps: 382723.78033
-  tps: 356677.86524
+  dps: 382780.47257
+  tps: 356734.55748
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PridefulGladiator'sBadgeofDominance-103505"
  value: {
-  dps: 382333.22111
-  tps: 356333.09171
+  dps: 382391.85587
+  tps: 356391.72647
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PridefulGladiator'sBadgeofVictory-103511"
  value: {
-  dps: 398633.47655
-  tps: 370592.38665
+  dps: 398693.17565
+  tps: 370652.08575
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PridefulGladiator'sEmblemofCruelty-103407"
  value: {
-  dps: 389620.07359
-  tps: 362946.13864
+  dps: 389518.61214
+  tps: 362844.67719
   hps: 4377.22733
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PridefulGladiator'sEmblemofMeditation-103409"
  value: {
-  dps: 382205.5248
-  tps: 356213.93504
+  dps: 382106.51838
+  tps: 356114.92863
   hps: 4270.87882
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PridefulGladiator'sEmblemofTenacity-103408"
  value: {
-  dps: 383227.2268
-  tps: 357224.04452
+  dps: 383221.63358
+  tps: 357218.45129
   hps: 4512.52651
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PridefulGladiator'sInsigniaofConquest-103347"
  value: {
-  dps: 385044.63989
-  tps: 358983.91724
+  dps: 384853.64328
+  tps: 358792.92062
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PridefulGladiator'sInsigniaofDominance-103506"
  value: {
-  dps: 384531.97008
-  tps: 358539.4926
+  dps: 384340.91287
+  tps: 358348.43539
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PridefulGladiator'sInsigniaofVictory-103516"
  value: {
-  dps: 408389.12279
-  tps: 379533.09405
+  dps: 408191.57256
+  tps: 379335.54382
   hps: 4263.33143
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Primordius'TalismanofRage-96873"
  value: {
-  dps: 404741.14579
-  tps: 376815.71381
+  dps: 404393.16784
+  tps: 376467.73587
   hps: 4346.40168
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PrismaticPrisonofPride-105474"
  value: {
-  dps: 401924.7015
-  tps: 375593.53147
+  dps: 401700.51583
+  tps: 375369.34581
   hps: 4311.81746
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PurifiedBindingsofImmerseus-105422"
  value: {
-  dps: 401924.7015
-  tps: 375593.53147
+  dps: 401700.51583
+  tps: 375369.34581
   hps: 4311.81746
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Qian-Le,CourageofNiuzao-102245"
  value: {
-  dps: 405354.06052
-  tps: 374226.39339
+  dps: 405128.60549
+  tps: 374000.93837
   hps: 4296.00657
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Qian-Ying,FortitudeofNiuzao-102250"
  value: {
-  dps: 414983.04693
-  tps: 383060.68282
+  dps: 414752.56888
+  tps: 382830.20477
   hps: 4223.08095
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Qin-xi'sPolarizingSeal-87075"
  value: {
-  dps: 384531.97008
-  tps: 358539.4926
+  dps: 384340.91287
+  tps: 358348.43539
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RelicofChi-Ji-79330"
  value: {
-  dps: 384531.97008
-  tps: 358539.4926
+  dps: 384340.91287
+  tps: 358348.43539
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RelicofKypariZar-84075"
  value: {
-  dps: 386427.4672
-  tps: 360135.09474
+  dps: 386600.16595
+  tps: 360307.7935
   hps: 4317.97918
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RelicofNiuzao-79329"
  value: {
-  dps: 383018.26058
-  tps: 357007.52444
+  dps: 383050.80594
+  tps: 357040.0698
   hps: 4375.8384
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RelicofXuen-79327"
  value: {
-  dps: 397877.65728
-  tps: 370216.06443
+  dps: 397602.00796
+  tps: 369940.41511
   hps: 4241.65367
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RelicofXuen-79328"
  value: {
-  dps: 384865.65427
-  tps: 358831.16804
+  dps: 384680.95229
+  tps: 358646.46606
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RelicofYu'lon-79331"
  value: {
-  dps: 384531.97008
-  tps: 358539.4926
+  dps: 384340.91287
+  tps: 358348.43539
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Renataki'sSoulCharm-96741"
  value: {
-  dps: 384957.6199
-  tps: 358910.55077
+  dps: 384764.64531
+  tps: 358717.57618
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-ResolveofNiuzao-103990"
  value: {
-  dps: 390281.96284
-  tps: 364281.83343
+  dps: 390340.41143
+  tps: 364340.28203
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-ReverberatingPrimalDiamond"
  value: {
-  dps: 433106.51278
-  tps: 400318.16745
+  dps: 432952.94937
+  tps: 400164.60404
   hps: 4330.83046
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RevitalizingPrimalDiamond"
  value: {
-  dps: 431340.94123
-  tps: 398707.86772
+  dps: 431187.33328
+  tps: 398554.25977
   hps: 4330.83046
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RuneofCinderglacier-3369"
  value: {
-  dps: 409791.07489
-  tps: 380272.58324
+  dps: 409635.91832
+  tps: 380117.42668
   hps: 16.52384
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RuneofRe-Origination-96918"
  value: {
-  dps: 402827.71511
-  tps: 378787.94755
+  dps: 402892.17306
+  tps: 378852.4055
   hps: 4142.93591
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RuneofSpellbreaking-3595"
  value: {
-  dps: 404476.82725
-  tps: 374976.48621
+  dps: 404263.04703
+  tps: 374762.706
   hps: 16.21842
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RuneofSpellshattering-3367"
  value: {
-  dps: 403950.10288
-  tps: 374478.2332
+  dps: 403845.72759
+  tps: 374373.85791
   hps: 16.46546
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RuneofSwordbreaking-3594"
  value: {
-  dps: 403835.89868
-  tps: 374317.40704
+  dps: 403698.15877
+  tps: 374179.66712
   hps: 16.52384
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RuneofSwordshattering-3365"
  value: {
-  dps: 403835.89868
-  tps: 374317.40704
+  dps: 403698.15877
+  tps: 374179.66712
   hps: 16.52384
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RuneoftheNerubianCarapace-3883"
  value: {
-  dps: 403745.83519
-  tps: 374225.00852
+  dps: 403510.05751
+  tps: 373989.23084
   hps: 16.52384
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RuneoftheStoneskinGargoyle-3847"
  value: {
-  dps: 403935.89562
-  tps: 374435.4673
+  dps: 403625.52683
+  tps: 374125.09851
   hps: 16.21842
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SI:7Operative'sManual-92784"
  value: {
-  dps: 382333.22111
-  tps: 356333.09171
+  dps: 382391.85587
+  tps: 356391.72647
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-ScrollofReveredAncestors-89080"
  value: {
-  dps: 382333.22111
-  tps: 356333.09171
+  dps: 382391.85587
+  tps: 356391.72647
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SearingWords-81267"
  value: {
-  dps: 387871.30931
-  tps: 361525.77204
+  dps: 387669.11468
+  tps: 361323.57741
   hps: 4343.18561
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Shock-ChargerMedallion-93259"
  value: {
-  dps: 386291.71574
-  tps: 360059.72092
+  dps: 386188.52864
+  tps: 359956.53382
   hps: 4289.14861
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SigilofCompassion-83736"
  value: {
-  dps: 387507.08485
-  tps: 361514.60737
+  dps: 387313.60142
+  tps: 361321.12394
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SigilofDevotion-83740"
  value: {
-  dps: 390633.84061
-  tps: 364417.68536
+  dps: 390433.70635
+  tps: 364217.55109
   hps: 4337.54588
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SigilofFidelity-83737"
  value: {
-  dps: 386898.46151
-  tps: 360535.07708
+  dps: 387004.81217
+  tps: 360641.42774
   hps: 4295.95405
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SigilofGrace-83738"
  value: {
-  dps: 388169.34787
-  tps: 361971.50089
+  dps: 388254.47884
+  tps: 362056.63187
   hps: 4322.79546
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SigilofKypariZar-84076"
  value: {
-  dps: 390683.42927
-  tps: 364454.21774
+  dps: 390483.16472
+  tps: 364253.95319
   hps: 4342.74913
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SigilofPatience-83739"
  value: {
-  dps: 388178.71997
-  tps: 362186.24249
+  dps: 387987.40814
+  tps: 361994.93066
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SigilofRampage-105580"
  value: {
-  dps: 385038.23512
-  tps: 358943.62565
+  dps: 384851.03288
+  tps: 358756.42341
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SigiloftheCatacombs-83732"
  value: {
-  dps: 387789.8426
-  tps: 361340.2848
+  dps: 387988.05788
+  tps: 361538.50008
   hps: 4355.72602
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SinisterPrimalDiamond"
  value: {
-  dps: 426080.41549
-  tps: 393312.00819
+  dps: 425940.35351
+  tps: 393171.94621
   hps: 4321.8467
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Skeer'sBloodsoakedTalisman-105632"
  value: {
-  dps: 415941.29619
-  tps: 386143.29349
+  dps: 415761.34816
+  tps: 385963.34546
   hps: 4563.59348
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SkullrenderMedallion-93256"
  value: {
-  dps: 396586.12211
-  tps: 369052.65753
+  dps: 396632.50919
+  tps: 369099.04461
   hps: 4358.89618
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SoothingTalismanoftheShado-PanAssault-94509"
  value: {
-  dps: 383052.98357
-  tps: 357026.66313
+  dps: 383131.96349
+  tps: 357105.64304
   hps: 4255.84383
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SoulBarrier-96927"
  value: {
-  dps: 382728.71415
-  tps: 356717.10872
+  dps: 382788.55401
+  tps: 356776.94858
   hps: 4494.37542
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SparkofZandalar-96770"
  value: {
-  dps: 401666.23624
-  tps: 374842.32582
+  dps: 401448.46638
+  tps: 374624.55596
   hps: 4297.19729
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SpiritsoftheSun-87163"
  value: {
-  dps: 384531.97008
-  tps: 358539.4926
+  dps: 384340.91287
+  tps: 358348.43539
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SpringrainIdolofDestruction-101023"
  value: {
-  dps: 388677.75723
-  tps: 362346.31853
+  dps: 388964.43124
+  tps: 362632.99254
   hps: 4276.36573
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SpringrainIdolofRage-101009"
  value: {
-  dps: 389698.48105
-  tps: 363666.91086
+  dps: 389506.56155
+  tps: 363474.99137
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SpringrainStoneofDestruction-101026"
  value: {
-  dps: 390911.59449
-  tps: 364919.11702
+  dps: 390726.61171
+  tps: 364734.13423
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SpringrainStoneofRage-101012"
  value: {
-  dps: 391129.0663
-  tps: 365121.22086
+  dps: 390944.03348
+  tps: 364936.18804
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SpringrainStoneofWisdom-101041"
  value: {
-  dps: 384531.97008
-  tps: 358539.4926
+  dps: 384340.91287
+  tps: 358348.43539
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Static-Caster'sMedallion-93254"
  value: {
-  dps: 386291.71574
-  tps: 360059.72092
+  dps: 386188.52864
+  tps: 359956.53382
   hps: 4289.14861
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SteadfastFootman'sMedallion-92782"
  value: {
-  dps: 382333.22111
-  tps: 356333.09171
+  dps: 382391.85587
+  tps: 356391.72647
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SteadfastTalismanoftheShado-PanAssault-94507"
  value: {
-  dps: 389370.51991
-  tps: 363370.39051
+  dps: 389428.98985
+  tps: 363428.86045
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-StreamtalkerIdolofDestruction-101222"
  value: {
-  dps: 389494.71042
-  tps: 362962.03032
+  dps: 389211.92788
+  tps: 362679.24778
   hps: 4279.70638
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-StreamtalkerIdolofRage-101217"
  value: {
-  dps: 389659.94295
-  tps: 363629.91151
+  dps: 389468.17919
+  tps: 363438.14775
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-StreamtalkerStoneofDestruction-101225"
  value: {
-  dps: 390941.93875
-  tps: 364949.46127
+  dps: 390750.47448
+  tps: 364757.997
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-StreamtalkerStoneofRage-101220"
  value: {
-  dps: 391059.48174
-  tps: 365051.63631
+  dps: 390877.14012
+  tps: 364869.29469
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-StreamtalkerStoneofWisdom-101250"
  value: {
-  dps: 384531.97008
-  tps: 358539.4926
+  dps: 384340.91287
+  tps: 358348.43539
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-StuffofNightmares-87160"
  value: {
-  dps: 390800.44527
-  tps: 364807.96779
+  dps: 390604.27609
+  tps: 364611.79861
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SunsoulDefenderIdol-101160"
  value: {
-  dps: 383690.75897
-  tps: 357651.60545
+  dps: 383483.06397
+  tps: 357443.91045
   hps: 4429.37134
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SunsoulDefenderStone-101163"
  value: {
-  dps: 390047.55167
-  tps: 364008.39815
+  dps: 389849.13504
+  tps: 363809.98152
   hps: 4429.37134
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SunsoulIdolofBattle-101152"
  value: {
-  dps: 398377.62792
-  tps: 370694.16788
+  dps: 398316.18523
+  tps: 370632.72519
   hps: 4309.74595
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SunsoulStoneofBattle-101151"
  value: {
-  dps: 399255.76182
-  tps: 372532.62046
+  dps: 399071.9279
+  tps: 372348.78654
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SunsoulStoneofWisdom-101138"
  value: {
-  dps: 384531.97008
-  tps: 358539.4926
+  dps: 384340.91287
+  tps: 358348.43539
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SwordguardEmbroidery(Rank3)-4894"
  value: {
-  dps: 442062.42188
-  tps: 408803.81638
+  dps: 441999.7771
+  tps: 408741.1716
   hps: 4353.72283
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SymboloftheCatacombs-83735"
  value: {
-  dps: 390626.21422
-  tps: 364256.8717
+  dps: 390419.73911
+  tps: 364050.39658
   hps: 4329.80857
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SynapseSprings(MarkII)-4898"
  value: {
-  dps: 441419.17081
-  tps: 408153.89522
+  dps: 441355.13803
+  tps: 408089.86245
   hps: 4373.9791
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TalismanofBloodlust-96864"
  value: {
-  dps: 387719.49599
-  tps: 361357.46949
+  dps: 388008.54145
+  tps: 361646.51495
   hps: 4342.73478
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TerrorintheMists-87167"
  value: {
-  dps: 392329.41798
-  tps: 364716.09693
+  dps: 392135.48456
+  tps: 364522.16351
   hps: 4424.78414
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Thok'sAcid-GroovedTooth-105607"
  value: {
-  dps: 384531.97008
-  tps: 358539.4926
+  dps: 384340.91287
+  tps: 358348.43539
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Thok'sTailTip-105609"
  value: {
-  dps: 433673.79281
-  tps: 401230.10767
+  dps: 433833.87498
+  tps: 401390.18984
   hps: 4363.49544
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Thousand-YearPickledEgg-257881"
  value: {
-  dps: 383875.95581
-  tps: 357379.71604
+  dps: 384134.79089
+  tps: 357638.55112
   hps: 4287.47398
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TickingEbonDetonator-105612"
  value: {
-  dps: 396355.47581
-  tps: 370231.98578
+  dps: 396155.73758
+  tps: 370032.24754
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Time-LostArtifact-103678"
  value: {
-  dps: 392449.22334
-  tps: 365790.01761
+  dps: 392544.4524
+  tps: 365885.24667
   hps: 4287.08142
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TrailseekerIdolofRage-101054"
  value: {
-  dps: 389646.60958
-  tps: 363617.19992
+  dps: 389452.40967
+  tps: 363423
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TrailseekerStoneofRage-101057"
  value: {
-  dps: 391082.17076
-  tps: 365074.32532
+  dps: 390897.76207
+  tps: 364889.91664
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TyrannicalGladiator'sBadgeofConquest-100043"
  value: {
-  dps: 382519.1605
-  tps: 356487.68979
+  dps: 382577.29141
+  tps: 356545.8207
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TyrannicalGladiator'sBadgeofDominance-100016"
  value: {
-  dps: 382333.22111
-  tps: 356333.09171
+  dps: 382391.85587
+  tps: 356391.72647
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TyrannicalGladiator'sBadgeofVictory-100019"
  value: {
-  dps: 392188.63263
-  tps: 364954.50382
+  dps: 392247.91091
+  tps: 365013.7821
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TyrannicalGladiator'sEmblemofCruelty-100066"
  value: {
-  dps: 386618.61949
-  tps: 360208.20357
+  dps: 386499.51611
+  tps: 360089.10019
   hps: 4338.35849
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TyrannicalGladiator'sEmblemofMeditation-99990"
  value: {
-  dps: 382205.5248
-  tps: 356213.93504
+  dps: 382106.51838
+  tps: 356114.92863
   hps: 4270.87882
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TyrannicalGladiator'sEmblemofTenacity-100092"
  value: {
-  dps: 382590.88964
-  tps: 356582.57536
+  dps: 382589.62337
+  tps: 356581.30908
   hps: 4415.00655
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TyrannicalGladiator'sInsigniaofConquest-100026"
  value: {
-  dps: 384772.39046
-  tps: 358735.40416
+  dps: 384584.38061
+  tps: 358547.39431
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TyrannicalGladiator'sInsigniaofDominance-100152"
  value: {
-  dps: 384531.97008
-  tps: 358539.4926
+  dps: 384340.91287
+  tps: 358348.43539
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TyrannicalGladiator'sInsigniaofVictory-100085"
  value: {
-  dps: 397788.39212
-  tps: 370060.96111
+  dps: 397736.48975
+  tps: 370009.05874
   hps: 4247.04492
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TyrannicalPrimalDiamond"
  value: {
-  dps: 424606.20752
-  tps: 392022.42036
+  dps: 424459.21035
+  tps: 391875.42319
   hps: 4293.48791
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-UnerringVisionofLeiShen-96930"
  value: {
-  dps: 384531.97008
-  tps: 358539.4926
+  dps: 384340.91287
+  tps: 358348.43539
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-VaporshieldMedallion-93262"
  value: {
-  dps: 387855.39077
-  tps: 361855.26137
+  dps: 387916.00457
+  tps: 361915.87517
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-VialofDragon'sBlood-87063"
  value: {
-  dps: 390405.04915
-  tps: 364412.57167
+  dps: 390209.20241
+  tps: 364216.72493
   hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-VialofIchorousBlood-100963"
  value: {
-  dps: 382333.22111
-  tps: 356333.09171
+  dps: 382391.85587
+  tps: 356391.72647
   hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-VialofLivingCorruption-105568"
  value: {
-  dps: 382781.72224
-  tps: 356743.17186
+  dps: 382671.5379
+  tps: 356632.98752
   hps: 4589.75247
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-ViciousTalismanoftheShado-PanAssault-94511"
  value: {
-  dps: 388527.80365
-  tps: 362396.12846
+  dps: 388696.65111
+  tps: 362564.97592
   hps: 4362.10647
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-VisionofthePredator-81192"
  value: {
-  dps: 389005.32693
-  tps: 362238.44121
+  dps: 388786.31481
+  tps: 362019.4291
   hps: 4346.16167
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-VolatileTalismanoftheShado-PanAssault-94510"
  value: {
-  dps: 384908.00309
-  tps: 358250.1705
+  dps: 385273.11778
+  tps: 358615.28519
   hps: 4318.91853
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-WindsweptPages-81125"
  value: {
-  dps: 385821.5161
-  tps: 359208.26773
+  dps: 385933.74313
+  tps: 359320.49476
   hps: 4294.01932
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-WoundripperMedallion-93253"
  value: {
-  dps: 387378.6909
-  tps: 360664.30008
+  dps: 387423.90751
+  tps: 360709.51668
   hps: 4358.89618
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Wushoolay'sFinalChoice-96785"
  value: {
-  dps: 390313.80023
-  tps: 364427.92739
+  dps: 390243.39239
+  tps: 364357.51955
   hps: 4387.35299
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Xing-Ho,BreathofYu'lon-102246"
  value: {
-  dps: 406027.95235
-  tps: 375257.35456
+  dps: 406079.71152
+  tps: 375309.11373
   hps: 4272.32448
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-YaungolFireCarrier-86518"
  value: {
-  dps: 439197.46041
-  tps: 406336.29317
+  dps: 439133.39803
+  tps: 406272.23079
   hps: 4373.9791
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Yu'lon'sBite-103987"
  value: {
-  dps: 393846.20266
-  tps: 365844.89986
+  dps: 393666.98483
+  tps: 365665.68203
   hps: 4477.27439
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-ZenAlchemistStone-75274"
  value: {
-  dps: 397160.71395
-  tps: 369669.95413
+  dps: 396862.5916
+  tps: 369371.83178
   hps: 4237.93706
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Average-Default"
  value: {
-  dps: 447204.91314
-  tps: 413951.7448
+  dps: 447193.43951
+  tps: 413940.27117
   hps: 4157.3196
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.00269227115e+06
-  tps: 1.97015869395e+06
+  dps: 2.0026021477e+06
+  tps: 1.9700685705e+06
   hps: 9871.56025
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 441118.49977
-  tps: 408586.88061
+  dps: 441204.47025
+  tps: 408672.85109
   hps: 4300.92563
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 608708.78272
-  tps: 479225.90036
+  dps: 608572.60229
+  tps: 479089.71993
   hps: 5220.95149
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-DefaultTalents-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.5249997798e+06
-  tps: 1.50504071988e+06
+  dps: 1.52513622693e+06
+  tps: 1.50517716701e+06
   hps: 8573.9363
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-DefaultTalents-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 346863.62976
-  tps: 326837.42806
+  dps: 346989.27097
+  tps: 326963.06928
   hps: 3804.16293
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-DefaultTalents-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 424084.39076
-  tps: 351371.09086
+  dps: 424129.13707
+  tps: 351415.83716
   hps: 4100.9461
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RoilingBlood-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.90874691222e+06
-  tps: 1.87608713933e+06
+  dps: 1.90863265038e+06
+  tps: 1.8759728775e+06
   hps: 9541.30714
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RoilingBlood-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 449775.54887
-  tps: 417156.67702
+  dps: 449715.42506
+  tps: 417096.55322
   hps: 4449.43494
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RoilingBlood-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 619772.38321
-  tps: 490087.98995
+  dps: 619443.83589
+  tps: 489759.44264
   hps: 5354.37934
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RoilingBlood-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.46691928297e+06
-  tps: 1.4470236101e+06
+  dps: 1.46691550115e+06
+  tps: 1.44701982828e+06
   hps: 8450.15037
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RoilingBlood-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 354648.76919
-  tps: 334632.06439
+  dps: 354366.20578
+  tps: 334349.50098
   hps: 3928.81362
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RoilingBlood-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 438964.35095
-  tps: 366143.74299
+  dps: 439379.82132
+  tps: 366559.21336
   hps: 4241.85964
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicCorruption-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.78976044565e+06
-  tps: 1.75718659286e+06
+  dps: 1.78993782293e+06
+  tps: 1.75736397014e+06
   hps: 9193.6899
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicCorruption-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 438130.44389
-  tps: 405603.79486
+  dps: 438213.15973
+  tps: 405686.5107
   hps: 4494.89428
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicCorruption-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 604818.29194
-  tps: 475099.67304
+  dps: 604773.24175
+  tps: 475054.62286
   hps: 5395.66779
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicCorruption-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.38046090788e+06
-  tps: 1.36045169842e+06
+  dps: 1.38048837981e+06
+  tps: 1.36047917035e+06
   hps: 8130.08202
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicCorruption-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 344919.48363
-  tps: 324977.83676
+  dps: 345169.59393
+  tps: 325227.94706
   hps: 3944.79919
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicCorruption-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 423674.00261
-  tps: 351048.84084
+  dps: 423483.74329
+  tps: 350858.58152
   hps: 4274.76142
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicEmpowerment-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.83459839966e+06
-  tps: 1.80202817593e+06
+  dps: 1.83465871291e+06
+  tps: 1.80208848918e+06
   hps: 9379.05497
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicEmpowerment-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 438900.43212
-  tps: 406493.87774
+  dps: 438772.34737
+  tps: 406365.79299
   hps: 4424.24312
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicEmpowerment-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 603059.57089
-  tps: 473773.14841
+  dps: 603204.83432
+  tps: 473918.41184
   hps: 5341.59182
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicEmpowerment-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.4096402504e+06
-  tps: 1.38970139925e+06
+  dps: 1.40944224117e+06
+  tps: 1.38950339003e+06
   hps: 8079.33339
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicEmpowerment-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 347088.98605
-  tps: 327162.83338
+  dps: 347230.03688
+  tps: 327303.88421
   hps: 3905.97042
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicEmpowerment-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 428690.64337
-  tps: 356049.21465
+  dps: 428852.51624
+  tps: 356211.08752
   hps: 4274.76142
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-UnholyBlight-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.97282808635e+06
-  tps: 1.94003842914e+06
+  dps: 1.97261458044e+06
+  tps: 1.93982492323e+06
   hps: 9585.51202
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-UnholyBlight-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 451287.27455
-  tps: 418657.04357
+  dps: 451144.07437
+  tps: 418513.84339
   hps: 4452.20744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-UnholyBlight-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 626249.08289
-  tps: 496506.11429
+  dps: 626001.68239
+  tps: 496258.71378
   hps: 5374.63562
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-UnholyBlight-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.52065182277e+06
-  tps: 1.50064141674e+06
+  dps: 1.52090623884e+06
+  tps: 1.50089583281e+06
   hps: 8378.1096
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-UnholyBlight-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 352657.39588
-  tps: 332619.06113
+  dps: 352644.6889
+  tps: 332606.35415
   hps: 3877.13434
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-UnholyBlight-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 440197.64305
-  tps: 367425.63513
+  dps: 440047.94328
+  tps: 367275.93535
   hps: 4262.18819
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 407498.42587
-  tps: 376914.27227
+  dps: 407408.0675
+  tps: 376823.9139
   hps: 3966.92832
  }
 }

--- a/sim/death_knight/frost/TestFrostMasterfrost.results
+++ b/sim/death_knight/frost/TestFrostMasterfrost.results
@@ -33,65 +33,65 @@ character_stats_results: {
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-AgilePrimalDiamond"
  value: {
-  dps: 427415.8759
-  tps: 396046.07318
-  hps: 3140.35231
+  dps: 431391.39964
+  tps: 398754.93604
+  hps: 4330.83046
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-AlacrityofXuen-103989"
  value: {
-  dps: 397824.17111
-  tps: 369231.24565
-  hps: 3136.15625
+  dps: 401532.05064
+  tps: 372145.00623
+  hps: 4339.18096
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-ArcaneBadgeoftheShieldwall-93347"
  value: {
-  dps: 380493.3235
-  tps: 355272.82099
-  hps: 3075.58927
+  dps: 384072.54366
+  tps: 357885.78245
+  hps: 4291.27651
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-ArrowflightMedallion-93258"
  value: {
-  dps: 382827.81625
-  tps: 357127.41871
-  hps: 3090.60745
+  dps: 387378.6909
+  tps: 360664.30008
+  hps: 4358.89618
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-AssuranceofConsequence-105472"
  value: {
-  dps: 379324.30061
-  tps: 354173.56441
-  hps: 3047.99124
+  dps: 385223.30987
+  tps: 359096.95229
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-AusterePrimalDiamond"
  value: {
-  dps: 420740.95757
-  tps: 389426.83063
-  hps: 3135.23034
+  dps: 424651.44058
+  tps: 392066.95975
+  hps: 4314.03544
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BadJuju-96781"
  value: {
-  dps: 387442.04851
-  tps: 362365.07463
-  hps: 3047.99124
+  dps: 393372.70935
+  tps: 367309.54975
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BadgeofKypariZar-84079"
  value: {
-  dps: 385013.66493
-  tps: 359625.39772
-  hps: 3079.41962
+  dps: 390796.25541
+  tps: 364432.83967
+  hps: 4333.52519
  }
 }
 dps_results: {
@@ -105,9 +105,9 @@ dps_results: {
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BattleplateofCyclopeanDread"
  value: {
-  dps: 344817.58746
-  tps: 317963.89634
-  hps: 2741.00386
+  dps: 347063.77333
+  tps: 319239.9153
+  hps: 3817.21123
  }
 }
 dps_results: {
@@ -121,1345 +121,1345 @@ dps_results: {
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BlackBloodofY'Shaarj-105648"
  value: {
-  dps: 386102.03521
-  tps: 360419.65152
-  hps: 3120.29837
+  dps: 389255.80612
+  tps: 362774.16277
+  hps: 4327.8508
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BlossomofPureSnow-89081"
  value: {
-  dps: 382302.64259
-  tps: 356697.06804
-  hps: 3090.60745
+  dps: 386833.75486
+  tps: 360203.91832
+  hps: 4358.74702
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BottleofInfiniteStars-87057"
  value: {
-  dps: 384766.34912
-  tps: 359726.29349
-  hps: 3047.99124
+  dps: 390680.2812
+  tps: 364644.55368
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BraidofTenSongs-84072"
  value: {
-  dps: 383298.37675
-  tps: 357993.18483
-  hps: 3054.06244
+  dps: 387676.57119
+  tps: 361521.27928
+  hps: 4294.50981
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Brawler'sStatue-257885"
  value: {
-  dps: 377755.94079
-  tps: 352752.77763
-  hps: 3037.62549
+  dps: 382333.22111
+  tps: 356333.09171
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BreathoftheHydra-96827"
  value: {
-  dps: 382823.99527
-  tps: 357385.35725
-  hps: 3086.39694
+  dps: 389266.82853
+  tps: 362909.84688
+  hps: 4297.19729
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BroochofMunificentDeeds-87500"
  value: {
-  dps: 378555.53428
-  tps: 353494.98225
-  hps: 3108.49977
+  dps: 382320.76675
+  tps: 356340.99181
+  hps: 4395.8047
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BrutalTalismanoftheShado-PanAssault-94508"
  value: {
-  dps: 394999.56417
-  tps: 367580.65974
-  hps: 3082.88697
+  dps: 399099.54084
+  tps: 370564.74227
+  hps: 4262.82482
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BurningPrimalDiamond"
  value: {
-  dps: 427380.19461
-  tps: 396014.79098
-  hps: 3140.35231
+  dps: 431340.94123
+  tps: 398707.86772
+  hps: 4330.83046
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CapacitivePrimalDiamond"
  value: {
-  dps: 433470.38658
-  tps: 401745.87986
-  hps: 3112.39065
+  dps: 439197.46041
+  tps: 406336.29317
+  hps: 4373.9791
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CarbonicCarbuncle-81138"
  value: {
-  dps: 390247.64732
-  tps: 363713.28264
-  hps: 3114.35577
+  dps: 396185.19621
+  tps: 368621.68527
+  hps: 4357.65945
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Cha-Ye'sEssenceofBrilliance-96888"
  value: {
-  dps: 385679.30891
-  tps: 360012.21388
-  hps: 3150.7758
+  dps: 391521.24658
+  tps: 364924.74473
+  hps: 4395.56613
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CharmofTenSongs-84071"
  value: {
-  dps: 384192.59993
-  tps: 358726.89756
-  hps: 3093.06931
+  dps: 386320.15239
+  tps: 359784.523
+  hps: 4344.67765
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CommunalIdolofDestruction-101168"
  value: {
-  dps: 386167.27259
-  tps: 360558.03139
-  hps: 3046.30598
+  dps: 390010.21777
+  tps: 363452.92693
+  hps: 4251.58894
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CommunalStoneofDestruction-101171"
  value: {
-  dps: 384942.63328
-  tps: 359945.36467
-  hps: 3047.99124
+  dps: 390873.4971
+  tps: 364881.01962
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CommunalStoneofWisdom-101183"
  value: {
-  dps: 378726.28257
-  tps: 353729.01397
-  hps: 3047.99124
+  dps: 384531.97008
+  tps: 358539.4926
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-ContemplationofChi-Ji-103988"
  value: {
-  dps: 377243.20277
-  tps: 352237.15039
-  hps: 3021.20019
+  dps: 383839.1515
+  tps: 357810.37916
+  hps: 4293.99289
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Coren'sColdChromiumCoaster-257880"
  value: {
-  dps: 390794.83275
-  tps: 364377.37422
-  hps: 3095.02662
+  dps: 396594.24929
+  tps: 369174.44681
+  hps: 4346.90222
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CoreofDecency-87497"
  value: {
-  dps: 378726.28257
-  tps: 353729.01397
-  hps: 3047.99124
+  dps: 384531.97008
+  tps: 358539.4926
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CourageousPrimalDiamond"
  value: {
-  dps: 420705.98366
-  tps: 389380.6097
-  hps: 3114.43428
+  dps: 424606.20752
+  tps: 392022.42036
+  hps: 4293.48791
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedDreadfulGladiator'sBadgeofConquest-93419"
  value: {
-  dps: 377868.10951
-  tps: 352845.89013
-  hps: 3037.62549
+  dps: 382495.18609
+  tps: 356476.19427
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedDreadfulGladiator'sBadgeofDominance-93600"
  value: {
-  dps: 377755.94079
-  tps: 352752.77763
-  hps: 3037.62549
+  dps: 382333.22111
+  tps: 356333.09171
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedDreadfulGladiator'sBadgeofVictory-93606"
  value: {
-  dps: 384382.68289
-  tps: 358559.95216
-  hps: 3037.62549
+  dps: 389246.71875
+  tps: 362380.94797
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedDreadfulGladiator'sEmblemofCruelty-93485"
  value: {
-  dps: 381432.59835
-  tps: 356079.04622
-  hps: 3100.69007
+  dps: 385207.12394
+  tps: 358926.89802
+  hps: 4323.05556
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedDreadfulGladiator'sEmblemofMeditation-93487"
  value: {
-  dps: 378317.93493
-  tps: 353292.86095
-  hps: 3050.00721
+  dps: 382205.5248
+  tps: 356213.93504
+  hps: 4270.87882
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedDreadfulGladiator'sEmblemofTenacity-93486"
  value: {
-  dps: 378555.53428
-  tps: 353494.98225
-  hps: 3106.63679
+  dps: 382320.76675
+  tps: 356340.99181
+  hps: 4383.17242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedDreadfulGladiator'sInsigniaofConquest-93424"
  value: {
-  dps: 378915.93114
-  tps: 353881.58046
-  hps: 3047.99124
+  dps: 384776.64085
+  tps: 358750.14218
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedDreadfulGladiator'sInsigniaofDominance-93601"
  value: {
-  dps: 378726.28257
-  tps: 353729.01397
-  hps: 3047.99124
+  dps: 384531.97008
+  tps: 358539.4926
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedDreadfulGladiator'sInsigniaofVictory-93611"
  value: {
-  dps: 391206.19245
-  tps: 365064.34087
-  hps: 3090.77258
+  dps: 394225.72024
+  tps: 366971.92252
+  hps: 4268.53469
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedMalevolentGladiator'sBadgeofConquest-98755"
  value: {
-  dps: 377888.11684
-  tps: 352857.1835
-  hps: 3037.62549
+  dps: 382502.05674
+  tps: 356478.07455
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedMalevolentGladiator'sBadgeofDominance-98910"
  value: {
-  dps: 377755.94079
-  tps: 352752.77763
-  hps: 3037.62549
+  dps: 382333.22111
+  tps: 356333.09171
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedMalevolentGladiator'sBadgeofVictory-98912"
  value: {
-  dps: 385592.61255
-  tps: 359620.24281
-  hps: 3037.62549
+  dps: 390509.00505
+  tps: 363485.18298
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedMalevolentGladiator'sEmblemofCruelty-98811"
  value: {
-  dps: 382087.67476
-  tps: 356653.45024
-  hps: 3101.12655
+  dps: 385768.50803
+  tps: 359435.30946
+  hps: 4327.20865
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedMalevolentGladiator'sEmblemofMeditation-98813"
  value: {
-  dps: 378317.93493
-  tps: 353292.86095
-  hps: 3050.00721
+  dps: 382205.5248
+  tps: 356213.93504
+  hps: 4270.87882
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedMalevolentGladiator'sEmblemofTenacity-98812"
  value: {
-  dps: 378555.53428
-  tps: 353494.98225
-  hps: 3117.51061
+  dps: 382666.67499
+  tps: 356680.71355
+  hps: 4398.49973
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedMalevolentGladiator'sInsigniaofConquest-98760"
  value: {
-  dps: 378932.62395
-  tps: 353894.37481
-  hps: 3047.99124
+  dps: 384770.72785
+  tps: 358735.58563
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedMalevolentGladiator'sInsigniaofDominance-98911"
  value: {
-  dps: 378726.28257
-  tps: 353729.01397
-  hps: 3047.99124
+  dps: 384531.97008
+  tps: 358539.4926
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedMalevolentGladiator'sInsigniaofVictory-98917"
  value: {
-  dps: 391070.79311
-  tps: 364706.24609
-  hps: 3084.53538
+  dps: 396372.89348
+  tps: 368926.69983
+  hps: 4268.53469
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CurseofHubris-105645"
  value: {
-  dps: 388519.79998
-  tps: 361726.24393
-  hps: 3411.98763
+  dps: 394209.95692
+  tps: 366282.69656
+  hps: 4922.31137
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CutstitcherMedallion-93255"
  value: {
-  dps: 377755.94079
-  tps: 352752.77763
-  hps: 3037.62549
+  dps: 382333.22111
+  tps: 356333.09171
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Daelo'sFinalWords-87496"
  value: {
-  dps: 388741.89893
-  tps: 362475.61827
-  hps: 3066.90886
+  dps: 391017.0073
+  tps: 363627.9925
+  hps: 4294.405
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DarkglowEmbroidery(Rank3)-4893"
  value: {
-  dps: 432581.91824
-  tps: 400933.42981
-  hps: 3104.28814
+  dps: 438271.55649
+  tps: 405472.90888
+  hps: 4353.72283
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DarkmistVortex-87172"
  value: {
-  dps: 392006.96603
-  tps: 364165.51949
-  hps: 3126.52681
+  dps: 397346.73473
+  tps: 368586.8482
+  hps: 4306.04925
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DeadeyeBadgeoftheShieldwall-93346"
  value: {
-  dps: 381641.03606
-  tps: 356622.54197
-  hps: 3037.62549
+  dps: 386381.0818
+  tps: 360363.78896
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DelicateVialoftheSanguinaire-96895"
  value: {
-  dps: 378726.28257
-  tps: 353729.01397
-  hps: 3047.99124
+  dps: 384531.97008
+  tps: 358539.4926
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DestructivePrimalDiamond"
  value: {
-  dps: 422714.16474
-  tps: 391187.39447
-  hps: 3148.39789
+  dps: 426455.88513
+  tps: 393636.65139
+  hps: 4325.89796
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DisciplineofXuen-103986"
  value: {
-  dps: 390174.47649
-  tps: 365140.73099
-  hps: 3047.99124
+  dps: 396371.99639
+  tps: 370346.00134
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Dominator'sArcaneBadge-93342"
  value: {
-  dps: 380493.3235
-  tps: 355272.82099
-  hps: 3075.58927
+  dps: 384072.54366
+  tps: 357885.78245
+  hps: 4291.27651
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Dominator'sDeadeyeBadge-93341"
  value: {
-  dps: 381641.03606
-  tps: 356622.54197
-  hps: 3037.62549
+  dps: 386381.0818
+  tps: 360363.78896
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Dominator'sDurableBadge-93345"
  value: {
-  dps: 381512.91966
-  tps: 356509.7565
-  hps: 3037.62549
+  dps: 386207.94829
+  tps: 360207.81888
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Dominator'sKnightlyBadge-93344"
  value: {
-  dps: 387995.09123
-  tps: 362435.96078
-  hps: 3037.62549
+  dps: 392808.81061
+  tps: 366229.56377
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Dominator'sMendingBadge-93343"
  value: {
-  dps: 377755.94079
-  tps: 352752.77763
-  hps: 3037.62549
+  dps: 382333.22111
+  tps: 356333.09171
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DreadfulGladiator'sBadgeofConquest-84344"
  value: {
-  dps: 377868.10951
-  tps: 352845.89013
-  hps: 3037.62549
+  dps: 382495.18609
+  tps: 356476.19427
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DreadfulGladiator'sBadgeofDominance-84488"
  value: {
-  dps: 377755.94079
-  tps: 352752.77763
-  hps: 3037.62549
+  dps: 382333.22111
+  tps: 356333.09171
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DreadfulGladiator'sBadgeofVictory-84490"
  value: {
-  dps: 384382.68289
-  tps: 358559.95216
-  hps: 3037.62549
+  dps: 389246.71875
+  tps: 362380.94797
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DreadfulGladiator'sEmblemofCruelty-84399"
  value: {
-  dps: 381432.59835
-  tps: 356079.04622
-  hps: 3100.69007
+  dps: 385207.12394
+  tps: 358926.89802
+  hps: 4323.05556
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DreadfulGladiator'sEmblemofMeditation-84401"
  value: {
-  dps: 378317.93493
-  tps: 353292.86095
-  hps: 3050.00721
+  dps: 382205.5248
+  tps: 356213.93504
+  hps: 4270.87882
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DreadfulGladiator'sEmblemofTenacity-84400"
  value: {
-  dps: 378555.53428
-  tps: 353494.98225
-  hps: 3106.63679
+  dps: 382320.76675
+  tps: 356340.99181
+  hps: 4383.17242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DreadfulGladiator'sInsigniaofConquest-84349"
  value: {
-  dps: 378902.42485
-  tps: 353872.90168
-  hps: 3047.99124
+  dps: 384730.09148
+  tps: 358703.59281
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DreadfulGladiator'sInsigniaofDominance-84489"
  value: {
-  dps: 378726.28257
-  tps: 353729.01397
-  hps: 3047.99124
+  dps: 384531.97008
+  tps: 358539.4926
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DreadfulGladiator'sInsigniaofVictory-84495"
  value: {
-  dps: 389409.31917
-  tps: 363342.98631
-  hps: 3084.53802
+  dps: 392919.38541
+  tps: 365729.37338
+  hps: 4258.50424
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DurableBadgeoftheShieldwall-93350"
  value: {
-  dps: 381512.91966
-  tps: 356509.7565
-  hps: 3037.62549
+  dps: 386207.94829
+  tps: 360207.81888
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DysmorphicSamophlangeofDiscontinuity-105615"
  value: {
-  dps: 378726.28257
-  tps: 353729.01397
-  hps: 3047.99124
+  dps: 384531.97008
+  tps: 358539.4926
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EffulgentPrimalDiamond"
  value: {
-  dps: 420740.95757
-  tps: 389426.83063
-  hps: 3135.23034
+  dps: 424651.44058
+  tps: 392066.95975
+  hps: 4314.03544
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EmberPrimalDiamond"
  value: {
-  dps: 420705.98366
-  tps: 389380.6097
-  hps: 3114.43428
+  dps: 424606.20752
+  tps: 392022.42036
+  hps: 4293.48791
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EmblemofKypariZar-84077"
  value: {
-  dps: 383794.78432
-  tps: 358255.03323
-  hps: 3093.6472
+  dps: 387270.43539
+  tps: 360765.01082
+  hps: 4359.10133
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EmblemoftheCatacombs-83733"
  value: {
-  dps: 386545.85514
-  tps: 361317.14388
-  hps: 3081.01396
+  dps: 387636.34775
+  tps: 361667.88575
+  hps: 4243.17816
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EmptyFruitBarrel-81133"
  value: {
-  dps: 378726.28257
-  tps: 353729.01397
-  hps: 3047.99124
+  dps: 384531.97008
+  tps: 358539.4926
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EnchantWeapon-BloodyDancingSteel-5125"
  value: {
-  dps: 410631.57164
-  tps: 380827.68121
-  hps: 17.22573
+  dps: 410978.97116
+  tps: 380853.15511
+  hps: 16.21842
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EnchantWeapon-Colossus-4445"
  value: {
-  dps: 404169.55227
-  tps: 375103.4128
-  hps: 16.87674
+  dps: 404395.41495
+  tps: 374964.80572
+  hps: 16.77088
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EnchantWeapon-DancingSteel-4444"
  value: {
-  dps: 412249.26779
-  tps: 382460.47915
-  hps: 17.00692
+  dps: 409829.32622
+  tps: 379504.77119
+  hps: 16.99141
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EnchantWeapon-ElementalForce-4443"
  value: {
-  dps: 405031.66223
-  tps: 375969.80974
-  hps: 16.87674
+  dps: 404661.48718
+  tps: 375236.26173
+  hps: 16.52179
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EnchantWeapon-JadeSpirit-4442"
  value: {
-  dps: 403727.44267
-  tps: 374658.00143
-  hps: 16.87256
+  dps: 403835.89868
+  tps: 374317.40704
+  hps: 16.52384
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EnchantWeapon-River'sSong-4446"
  value: {
-  dps: 403727.44267
-  tps: 374658.00143
-  hps: 16.87256
+  dps: 403835.89868
+  tps: 374317.40704
+  hps: 16.52384
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EnchantWeapon-SpiritofConquest-5124"
  value: {
-  dps: 403727.44267
-  tps: 374658.00143
-  hps: 16.87256
+  dps: 403835.89868
+  tps: 374317.40704
+  hps: 16.52384
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EnchantWeapon-Windsong-4441"
  value: {
-  dps: 406743.1044
-  tps: 377525.67697
-  hps: 16.83857
+  dps: 407716.18985
+  tps: 377950.40984
+  hps: 16.52384
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EnigmaticPrimalDiamond"
  value: {
-  dps: 422714.16474
-  tps: 391187.39447
-  hps: 3148.39789
+  dps: 426455.88513
+  tps: 393636.65139
+  hps: 4325.89796
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EssenceofTerror-87175"
  value: {
-  dps: 383894.25356
-  tps: 357554.04293
-  hps: 3135.85052
+  dps: 388498.38155
+  tps: 361255.87706
+  hps: 4307.79396
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EternalPrimalDiamond"
  value: {
-  dps: 420705.98366
-  tps: 389380.6097
-  hps: 3114.43428
+  dps: 424606.20752
+  tps: 392022.42036
+  hps: 4293.48791
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EvilEyeofGalakras-105491"
  value: {
-  dps: 417909.88186
-  tps: 389372.88088
-  hps: 3110.11904
+  dps: 423366.17632
+  tps: 393709.59728
+  hps: 4886.82859
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-FabledFeatherofJi-Kun-96842"
  value: {
-  dps: 404481.01661
-  tps: 376555.45616
-  hps: 3132.31672
+  dps: 410737.4657
+  tps: 381369.5497
+  hps: 4372.86294
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-FearwurmBadge-84074"
  value: {
-  dps: 384751.70036
-  tps: 359191.49256
-  hps: 3095.10308
+  dps: 387331.22526
+  tps: 361010.49774
+  hps: 4302.74345
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-FearwurmRelic-84070"
  value: {
-  dps: 383274.97284
-  tps: 357741.13814
-  hps: 3080.31263
+  dps: 387379.56951
+  tps: 360921.58007
+  hps: 4378.12618
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-FelsoulIdolofDestruction-101263"
  value: {
-  dps: 387210.78074
-  tps: 361315.17902
-  hps: 3051.92592
+  dps: 391535.08118
+  tps: 364929.37196
+  hps: 4281.40592
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-FelsoulStoneofDestruction-101266"
  value: {
-  dps: 384984.4281
-  tps: 359987.1595
-  hps: 3047.99124
+  dps: 390900.31265
+  tps: 364907.83517
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Fen-Yu,FuryofXuen-102248"
  value: {
-  dps: 410942.15629
-  tps: 380926.92237
-  hps: 3091.75337
+  dps: 415373.09166
+  tps: 384358.36144
+  hps: 4282.64887
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-FlashfrozenResinGlobule-100951"
  value: {
-  dps: 379412.41179
-  tps: 354467.50438
-  hps: 3039.04522
+  dps: 386227.84892
+  tps: 360236.56785
+  hps: 4308.81885
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-FlashingSteelTalisman-81265"
  value: {
-  dps: 381067.90333
-  tps: 355959.61695
-  hps: 3087.65916
+  dps: 386418.45018
+  tps: 360306.21792
+  hps: 4327.85256
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-FleetPrimalDiamond"
  value: {
-  dps: 423176.69158
-  tps: 391851.31762
-  hps: 3114.43428
+  dps: 427095.18897
+  tps: 394511.40181
+  hps: 4293.48791
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-ForlornPrimalDiamond"
  value: {
-  dps: 420705.98366
-  tps: 389380.6097
-  hps: 3114.43428
+  dps: 424606.20752
+  tps: 392022.42036
+  hps: 4293.48791
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-FortitudeoftheZandalari-96793"
  value: {
-  dps: 386645.49682
-  tps: 361620.42284
-  hps: 3050.00721
+  dps: 390606.5314
+  tps: 364614.94164
+  hps: 4270.87882
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-FrenziedCrystalofRage-105572"
  value: {
-  dps: 378726.28257
-  tps: 353729.01397
-  hps: 3047.99124
+  dps: 384531.97008
+  tps: 358539.4926
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Fusion-FireCore-105459"
  value: {
-  dps: 405922.06086
-  tps: 376892.87309
-  hps: 3067.75475
+  dps: 411242.06523
+  tps: 380843.39903
+  hps: 4254.74695
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-GazeoftheTwins-96915"
  value: {
-  dps: 399379.47382
-  tps: 372228.29577
-  hps: 3155.02966
+  dps: 405503.5733
+  tps: 377333.7428
+  hps: 4390.36564
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Gerp'sPerfectArrow-87495"
  value: {
-  dps: 380595.2332
-  tps: 355267.64092
-  hps: 3076.79117
+  dps: 384946.87742
+  tps: 358670.87484
+  hps: 4306.27798
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-GrievousGladiator'sBadgeofConquest-103145"
  value: {
-  dps: 377993.40879
-  tps: 352944.8711
-  hps: 3037.62549
+  dps: 382577.61841
+  tps: 356540.30631
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-GrievousGladiator'sBadgeofDominance-103308"
  value: {
-  dps: 377755.94079
-  tps: 352752.77763
-  hps: 3037.62549
+  dps: 382333.22111
+  tps: 356333.09171
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-GrievousGladiator'sBadgeofVictory-103314"
  value: {
-  dps: 389789.65851
-  tps: 363298.21579
-  hps: 3037.62549
+  dps: 394887.66759
+  tps: 367315.5917
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-GrievousGladiator'sEmblemofCruelty-103210"
  value: {
-  dps: 384024.01469
-  tps: 358426.80985
-  hps: 3130.85944
+  dps: 387871.46511
+  tps: 361343.33548
+  hps: 4353.33298
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-GrievousGladiator'sEmblemofMeditation-103212"
  value: {
-  dps: 378317.93493
-  tps: 353292.86095
-  hps: 3050.00721
+  dps: 382205.5248
+  tps: 356213.93504
+  hps: 4270.87882
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-GrievousGladiator'sEmblemofTenacity-103211"
  value: {
-  dps: 378367.08819
-  tps: 353324.53334
-  hps: 3170.82817
+  dps: 383274.23787
+  tps: 357259.73665
+  hps: 4460.68398
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-GrievousGladiator'sInsigniaofConquest-103150"
  value: {
-  dps: 379092.26455
-  tps: 354033.58825
-  hps: 3047.99124
+  dps: 384959.32233
+  tps: 358906.17502
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-GrievousGladiator'sInsigniaofDominance-103309"
  value: {
-  dps: 378726.28257
-  tps: 353729.01397
-  hps: 3047.99124
+  dps: 384531.97008
+  tps: 358539.4926
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-GrievousGladiator'sInsigniaofVictory-103319"
  value: {
-  dps: 397790.36462
-  tps: 370786.09748
-  hps: 3075.32754
+  dps: 402541.48139
+  tps: 374395.05216
+  hps: 4278.033
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Haromm'sTalisman-105527"
  value: {
-  dps: 397061.57083
-  tps: 371944.87231
-  hps: 3047.99124
+  dps: 403340.13686
+  tps: 377252.72938
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Hawkmaster'sTalon-89082"
  value: {
-  dps: 382628.87877
-  tps: 356981.70515
-  hps: 3066.59834
+  dps: 384415.96964
+  tps: 358003.34433
+  hps: 4299.96319
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Heart-LesionDefenderIdol-100999"
  value: {
-  dps: 379625.48261
-  tps: 354659.97823
-  hps: 3149.6842
+  dps: 383690.75897
+  tps: 357651.60545
+  hps: 4429.37134
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Heart-LesionDefenderStone-101002"
  value: {
-  dps: 385881.95944
-  tps: 360916.45506
-  hps: 3149.6842
+  dps: 390058.62928
+  tps: 364019.47575
+  hps: 4429.37134
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Heart-LesionIdolofBattle-100991"
  value: {
-  dps: 394482.80369
-  tps: 367830.19587
-  hps: 3116.41634
+  dps: 398984.60935
+  tps: 371249.29344
+  hps: 4294.71952
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Heart-LesionStoneofBattle-100990"
  value: {
-  dps: 393147.57398
-  tps: 367448.88992
-  hps: 3047.99124
+  dps: 399289.20485
+  tps: 372566.06349
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-HeartofFire-81181"
  value: {
-  dps: 381777.0809
-  tps: 356773.91774
-  hps: 3037.62549
+  dps: 386396.33773
+  tps: 360396.20833
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-HeartwarmerMedallion-93260"
  value: {
-  dps: 377755.94079
-  tps: 352752.77763
-  hps: 3037.62549
+  dps: 382333.22111
+  tps: 356333.09171
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-HelmbreakerMedallion-93261"
  value: {
-  dps: 391864.02072
-  tps: 365383.19343
-  hps: 3090.60745
+  dps: 396586.12211
+  tps: 369052.65753
+  hps: 4358.89618
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Horridon'sLastGasp-96757"
  value: {
-  dps: 378726.28257
-  tps: 353729.01397
-  hps: 3047.99124
+  dps: 384531.97008
+  tps: 358539.4926
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-ImpassivePrimalDiamond"
  value: {
-  dps: 422714.16474
-  tps: 391187.39447
-  hps: 3148.39789
+  dps: 426455.88513
+  tps: 393636.65139
+  hps: 4325.89796
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-IndomitablePrimalDiamond"
  value: {
-  dps: 420740.95757
-  tps: 389426.83063
-  hps: 3135.23034
+  dps: 424651.44058
+  tps: 392066.95975
+  hps: 4314.03544
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-InscribedBagofHydra-Spawn-96828"
  value: {
-  dps: 377997.04002
-  tps: 352955.91179
-  hps: 3047.27364
+  dps: 382707.59585
+  tps: 356789.03482
+  hps: 4260.86438
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-InsigniaofKypariZar-84078"
  value: {
-  dps: 378726.28257
-  tps: 353729.01397
-  hps: 3047.99124
+  dps: 384531.97008
+  tps: 358539.4926
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-IronBellyWok-89083"
  value: {
-  dps: 391129.64657
-  tps: 364746.00898
-  hps: 3066.59834
+  dps: 392987.96012
+  tps: 365823.1517
+  hps: 4299.96319
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-IronProtectorTalisman-85181"
  value: {
-  dps: 379016.14216
-  tps: 354036.09399
-  hps: 3120.39651
+  dps: 383239.27073
+  tps: 357208.96771
+  hps: 4382.06746
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-JadeBanditFigurine-86772"
  value: {
-  dps: 380914.66665
-  tps: 355410.10642
-  hps: 3059.94331
+  dps: 385744.37104
+  tps: 359324.03144
+  hps: 4295.40833
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-JadeCharioteerFigurine-86771"
  value: {
-  dps: 388392.18204
-  tps: 362235.70051
-  hps: 3059.94331
+  dps: 393293.59614
+  tps: 366213.19324
+  hps: 4295.40833
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-JadeCourtesanFigurine-86774"
  value: {
-  dps: 377755.94079
-  tps: 352752.77763
-  hps: 3037.62549
+  dps: 382333.22111
+  tps: 356333.09171
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-JadeMagistrateFigurine-86773"
  value: {
-  dps: 381805.33856
-  tps: 356270.88185
-  hps: 3081.68758
+  dps: 386214.51004
+  tps: 359662.03006
+  hps: 4333.47406
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-JadeWarlordFigurine-86775"
  value: {
-  dps: 382204.87216
-  tps: 357174.15367
-  hps: 3129.36345
+  dps: 387597.34135
+  tps: 361586.6052
+  hps: 4375.8384
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Ji-Kun'sRisingWinds-96843"
  value: {
-  dps: 378726.28257
-  tps: 353729.01397
-  hps: 3047.99124
+  dps: 384531.97008
+  tps: 358539.4926
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Juggernaut'sFocusingCrystal-105514"
  value: {
-  dps: 378726.28257
-  tps: 353729.01397
-  hps: 13989.28081
+  dps: 384531.97008
+  tps: 358539.4926
+  hps: 15614.7598
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Kardris'ToxicTotem-105540"
  value: {
-  dps: 396232.71502
-  tps: 371235.44642
-  hps: 3047.99124
+  dps: 403201.06422
+  tps: 377208.58675
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-KnightlyBadgeoftheShieldwall-93349"
  value: {
-  dps: 387995.09123
-  tps: 362435.96078
-  hps: 3037.62549
+  dps: 392808.81061
+  tps: 366229.56377
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-KnotofTenSongs-84073"
  value: {
-  dps: 378726.28257
-  tps: 353729.01397
-  hps: 3047.99124
+  dps: 384531.97008
+  tps: 358539.4926
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Kor'kronBookofHurting-92785"
  value: {
-  dps: 377755.94079
-  tps: 352752.77763
-  hps: 3037.62549
+  dps: 382333.22111
+  tps: 356333.09171
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Lao-Chin'sLiquidCourage-89079"
  value: {
-  dps: 382945.88302
-  tps: 357912.96268
-  hps: 3152.47701
+  dps: 388320.46103
+  tps: 362317.64434
+  hps: 4402.88966
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-LeiShen'sFinalOrders-87072"
  value: {
-  dps: 394036.86625
-  tps: 367059.54023
-  hps: 3067.4782
+  dps: 399488.03434
+  tps: 371701.32453
+  hps: 4297.69977
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-LessonsoftheDarkmaster-81268"
  value: {
-  dps: 386809.07909
-  tps: 360090.15175
-  hps: 3037.62549
+  dps: 391791.04168
+  tps: 363978.49287
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-LightdrinkerIdolofRage-101200"
  value: {
-  dps: 383794.26465
-  tps: 358761.29404
-  hps: 3047.99124
+  dps: 389701.80467
+  tps: 363667.87792
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-LightdrinkerStoneofRage-101203"
  value: {
-  dps: 385233.66114
-  tps: 360217.298
-  hps: 3047.99124
+  dps: 391193.14359
+  tps: 365185.29815
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-LightoftheCosmos-87065"
  value: {
-  dps: 382225.16394
-  tps: 356795.51855
-  hps: 3055.2834
+  dps: 386468.58497
+  tps: 360258.00262
+  hps: 4283.10801
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-LightweaveEmbroidery(Rank3)-4892"
  value: {
-  dps: 432581.91824
-  tps: 400933.42981
-  hps: 3104.28814
+  dps: 438271.55649
+  tps: 405472.90888
+  hps: 4353.72283
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-LordBlastington'sScopeofDoom-4699"
  value: {
-  dps: 403727.44267
-  tps: 374658.00143
-  hps: 16.87256
+  dps: 403835.89868
+  tps: 374317.40704
+  hps: 16.52384
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MalevolentGladiator'sBadgeofConquest-91452"
  value: {
-  dps: 377888.11684
-  tps: 352857.1835
-  hps: 3037.62549
+  dps: 382502.05674
+  tps: 356478.07455
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MalevolentGladiator'sBadgeofDominance-91753"
  value: {
-  dps: 377755.94079
-  tps: 352752.77763
-  hps: 3037.62549
+  dps: 382333.22111
+  tps: 356333.09171
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MalevolentGladiator'sBadgeofVictory-91763"
  value: {
-  dps: 385592.61255
-  tps: 359620.24281
-  hps: 3037.62549
+  dps: 390509.00505
+  tps: 363485.18298
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MalevolentGladiator'sEmblemofCruelty-91562"
  value: {
-  dps: 382087.67476
-  tps: 356653.45024
-  hps: 3101.12655
+  dps: 385768.50803
+  tps: 359435.30946
+  hps: 4327.20865
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MalevolentGladiator'sEmblemofMeditation-91564"
  value: {
-  dps: 378317.93493
-  tps: 353292.86095
-  hps: 3050.00721
+  dps: 382205.5248
+  tps: 356213.93504
+  hps: 4270.87882
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MalevolentGladiator'sEmblemofTenacity-91563"
  value: {
-  dps: 378555.53428
-  tps: 353494.98225
-  hps: 3117.51061
+  dps: 382666.67499
+  tps: 356680.71355
+  hps: 4398.49973
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MalevolentGladiator'sInsigniaofConquest-91457"
  value: {
-  dps: 378985.53254
-  tps: 353948.13574
-  hps: 3047.99124
+  dps: 384780.86531
+  tps: 358747.95251
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MalevolentGladiator'sInsigniaofDominance-91754"
  value: {
-  dps: 378726.28257
-  tps: 353729.01397
-  hps: 3047.99124
+  dps: 384531.97008
+  tps: 358539.4926
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MalevolentGladiator'sInsigniaofVictory-91768"
  value: {
-  dps: 392419.78645
-  tps: 366067.51307
-  hps: 3075.61551
+  dps: 397335.45541
+  tps: 369858.2133
+  hps: 4297.52426
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MarkoftheCatacombs-83731"
  value: {
-  dps: 384681.38551
-  tps: 359439.73758
-  hps: 3079.7237
+  dps: 390650.22004
+  tps: 364434.06478
+  hps: 4337.54588
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MarkoftheHardenedGrunt-92783"
  value: {
-  dps: 377755.94079
-  tps: 352752.77763
-  hps: 3037.62549
+  dps: 382333.22111
+  tps: 356333.09171
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MedallionofMystifyingVapors-93257"
  value: {
-  dps: 383110.29835
-  tps: 358107.13519
-  hps: 3037.62549
+  dps: 387855.39077
+  tps: 361855.26137
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MedallionoftheCatacombs-83734"
  value: {
-  dps: 381660.61178
-  tps: 356663.34317
-  hps: 3047.99124
+  dps: 387507.08485
+  tps: 361514.60737
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MendingBadgeoftheShieldwall-93348"
  value: {
-  dps: 377755.94079
-  tps: 352752.77763
-  hps: 3037.62549
+  dps: 382333.22111
+  tps: 356333.09171
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MirrorScope-4700"
  value: {
-  dps: 403727.44267
-  tps: 374658.00143
-  hps: 16.87256
+  dps: 403835.89868
+  tps: 374317.40704
+  hps: 16.52384
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MistdancerDefenderIdol-101089"
  value: {
-  dps: 379625.48261
-  tps: 354659.97823
-  hps: 3149.6842
+  dps: 383690.75897
+  tps: 357651.60545
+  hps: 4429.37134
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MistdancerDefenderStone-101087"
  value: {
-  dps: 385854.81006
-  tps: 360889.30568
-  hps: 3149.6842
+  dps: 390016.64397
+  tps: 363977.49045
+  hps: 4429.37134
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MistdancerIdolofRage-101113"
  value: {
-  dps: 383773.28758
-  tps: 358740.83757
-  hps: 3047.99124
+  dps: 389660.61338
+  tps: 363626.68664
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MistdancerStoneofRage-101117"
  value: {
-  dps: 385096.24254
-  tps: 360079.8794
-  hps: 3047.99124
+  dps: 391069.92327
+  tps: 365062.07784
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MistdancerStoneofWisdom-101107"
  value: {
-  dps: 378726.28257
-  tps: 353729.01397
-  hps: 3047.99124
+  dps: 384531.97008
+  tps: 358539.4926
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MithrilWristwatch-257884"
  value: {
-  dps: 382908.45165
-  tps: 357471.69426
-  hps: 3095.02662
+  dps: 388513.30602
+  tps: 362122.71852
+  hps: 4346.90222
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MountainsageIdolofDestruction-101069"
  value: {
-  dps: 387456.76269
-  tps: 361648.55418
-  hps: 3107.21834
+  dps: 392420.81706
+  tps: 365913.50034
+  hps: 4333.70071
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MountainsageStoneofDestruction-101072"
  value: {
-  dps: 384887.20735
-  tps: 359889.93874
-  hps: 3047.99124
+  dps: 390898.93091
+  tps: 364906.45343
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-NitroBoosts-4223"
  value: {
-  dps: 434820.12644
-  tps: 403140.93986
-  hps: 3109.62225
+  dps: 438842.52232
+  tps: 405961.35949
+  hps: 4359.40079
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-OathswornDefenderIdol-101303"
  value: {
-  dps: 379625.48261
-  tps: 354659.97823
-  hps: 3149.6842
+  dps: 383690.75897
+  tps: 357651.60545
+  hps: 4429.37134
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-OathswornDefenderStone-101306"
  value: {
-  dps: 385793.19217
-  tps: 360827.68779
-  hps: 3149.6842
+  dps: 389960.45749
+  tps: 363921.30397
+  hps: 4429.37134
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-OathswornIdolofBattle-101295"
  value: {
-  dps: 395739.03104
-  tps: 369087.10696
-  hps: 3121.6196
+  dps: 398685.67064
+  tps: 370978.97823
+  hps: 4312.39438
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-OathswornStoneofBattle-101294"
  value: {
-  dps: 393089.1056
-  tps: 367390.42154
-  hps: 3047.99124
+  dps: 399281.78638
+  tps: 372558.64502
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PhaseFingers-4697"
  value: {
-  dps: 433002.8488
-  tps: 401437.38993
-  hps: 3133.49329
+  dps: 436880.13646
+  tps: 404036.03866
+  hps: 4330.10146
  }
 }
 dps_results: {
@@ -1489,1144 +1489,1144 @@ dps_results: {
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PouchofWhiteAsh-103639"
  value: {
-  dps: 377755.94079
-  tps: 352752.77763
-  hps: 3037.62549
+  dps: 382333.22111
+  tps: 356333.09171
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PowerfulPrimalDiamond"
  value: {
-  dps: 420740.95757
-  tps: 389426.83063
-  hps: 3135.23034
+  dps: 424651.44058
+  tps: 392066.95975
+  hps: 4314.03544
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PriceofProgress-81266"
  value: {
-  dps: 378726.28257
-  tps: 353729.01397
-  hps: 3047.99124
+  dps: 384531.97008
+  tps: 358539.4926
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PridefulGladiator'sBadgeofConquest-103342"
  value: {
-  dps: 378060.95496
-  tps: 353003.47935
-  hps: 3037.62549
+  dps: 382723.78033
+  tps: 356677.86524
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PridefulGladiator'sBadgeofDominance-103505"
  value: {
-  dps: 377755.94079
-  tps: 352752.77763
-  hps: 3037.62549
+  dps: 382333.22111
+  tps: 356333.09171
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PridefulGladiator'sBadgeofVictory-103511"
  value: {
-  dps: 393380.10017
-  tps: 366444.60675
-  hps: 3037.62549
+  dps: 398633.47655
+  tps: 370592.38665
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PridefulGladiator'sEmblemofCruelty-103407"
  value: {
-  dps: 385728.16283
-  tps: 359983.46545
-  hps: 3154.79702
+  dps: 389620.07359
+  tps: 362946.13864
+  hps: 4377.22733
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PridefulGladiator'sEmblemofMeditation-103409"
  value: {
-  dps: 378317.93493
-  tps: 353292.86095
-  hps: 3050.00721
+  dps: 382205.5248
+  tps: 356213.93504
+  hps: 4270.87882
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PridefulGladiator'sEmblemofTenacity-103408"
  value: {
-  dps: 377476.55607
-  tps: 352432.00602
-  hps: 3178.67818
+  dps: 383227.2268
+  tps: 357224.04452
+  hps: 4512.52651
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PridefulGladiator'sInsigniaofConquest-103347"
  value: {
-  dps: 379225.23156
-  tps: 354142.18591
-  hps: 3047.99124
+  dps: 385044.63989
+  tps: 358983.91724
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PridefulGladiator'sInsigniaofDominance-103506"
  value: {
-  dps: 378726.28257
-  tps: 353729.01397
-  hps: 3047.99124
+  dps: 384531.97008
+  tps: 358539.4926
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PridefulGladiator'sInsigniaofVictory-103516"
  value: {
-  dps: 403035.78667
-  tps: 375473.68669
-  hps: 3081.27411
+  dps: 408389.12279
+  tps: 379533.09405
+  hps: 4263.33143
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Primordius'TalismanofRage-96873"
  value: {
-  dps: 401375.06665
-  tps: 374299.25415
-  hps: 3110.34907
+  dps: 404741.14579
+  tps: 376815.71381
+  hps: 4346.40168
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PrismaticPrisonofPride-105474"
  value: {
-  dps: 398247.63677
-  tps: 372975.83278
-  hps: 3086.32275
+  dps: 401924.7015
+  tps: 375593.53147
+  hps: 4311.81746
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PurifiedBindingsofImmerseus-105422"
  value: {
-  dps: 398249.28497
-  tps: 372977.48099
-  hps: 3086.32275
+  dps: 401924.7015
+  tps: 375593.53147
+  hps: 4311.81746
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Qian-Le,CourageofNiuzao-102245"
  value: {
-  dps: 400124.80089
-  tps: 370405.83934
-  hps: 2997.16106
+  dps: 405354.06052
+  tps: 374226.39339
+  hps: 4296.00657
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Qian-Ying,FortitudeofNiuzao-102250"
  value: {
-  dps: 409497.67063
-  tps: 379034.154
-  hps: 2972.64101
+  dps: 414983.04693
+  tps: 383060.68282
+  hps: 4223.08095
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Qin-xi'sPolarizingSeal-87075"
  value: {
-  dps: 378726.28257
-  tps: 353729.01397
-  hps: 3047.99124
+  dps: 384531.97008
+  tps: 358539.4926
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RelicofChi-Ji-79330"
  value: {
-  dps: 378726.28257
-  tps: 353729.01397
-  hps: 3047.99124
+  dps: 384531.97008
+  tps: 358539.4926
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RelicofKypariZar-84075"
  value: {
-  dps: 385250.94895
-  tps: 359779.78807
-  hps: 3098.28428
+  dps: 386427.4672
+  tps: 360135.09474
+  hps: 4317.97918
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RelicofNiuzao-79329"
  value: {
-  dps: 377775.83488
-  tps: 352745.11639
-  hps: 3129.36345
+  dps: 383018.26058
+  tps: 357007.52444
+  hps: 4375.8384
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RelicofXuen-79327"
  value: {
-  dps: 395202.10041
-  tps: 368597.44581
-  hps: 3064.1777
+  dps: 397877.65728
+  tps: 370216.06443
+  hps: 4241.65367
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RelicofXuen-79328"
  value: {
-  dps: 379062.992
-  tps: 354017.23766
-  hps: 3047.99124
+  dps: 384865.65427
+  tps: 358831.16804
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RelicofYu'lon-79331"
  value: {
-  dps: 378726.28257
-  tps: 353729.01397
-  hps: 3047.99124
+  dps: 384531.97008
+  tps: 358539.4926
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Renataki'sSoulCharm-96741"
  value: {
-  dps: 379088.21024
-  tps: 354024.72433
-  hps: 3047.99124
+  dps: 384957.6199
+  tps: 358910.55077
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-ResolveofNiuzao-103990"
  value: {
-  dps: 385622.56318
-  tps: 360619.40002
-  hps: 3037.62549
+  dps: 390281.96284
+  tps: 364281.83343
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-ReverberatingPrimalDiamond"
  value: {
-  dps: 429127.09001
-  tps: 397612.35965
-  hps: 3140.35231
+  dps: 433106.51278
+  tps: 400318.16745
+  hps: 4330.83046
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RevitalizingPrimalDiamond"
  value: {
-  dps: 427380.19461
-  tps: 396014.79098
-  hps: 3140.35231
+  dps: 431340.94123
+  tps: 398707.86772
+  hps: 4330.83046
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RuneofCinderglacier-3369"
  value: {
-  dps: 409110.71564
-  tps: 380041.2744
-  hps: 16.87256
+  dps: 409791.07489
+  tps: 380272.58324
+  hps: 16.52384
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RuneofRe-Origination-96918"
  value: {
-  dps: 397453.69549
-  tps: 374355.14612
-  hps: 2977.69501
+  dps: 402827.71511
+  tps: 378787.94755
+  hps: 4142.93591
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RuneofSpellbreaking-3595"
  value: {
-  dps: 403724.79024
-  tps: 374646.43177
-  hps: 16.87674
+  dps: 404476.82725
+  tps: 374976.48621
+  hps: 16.21842
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RuneofSpellshattering-3367"
  value: {
-  dps: 404316.91582
-  tps: 375247.50831
-  hps: 16.87674
+  dps: 403950.10288
+  tps: 374478.2332
+  hps: 16.46546
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RuneofSwordbreaking-3594"
  value: {
-  dps: 403727.44267
-  tps: 374658.00143
-  hps: 16.87256
+  dps: 403835.89868
+  tps: 374317.40704
+  hps: 16.52384
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RuneofSwordshattering-3365"
  value: {
-  dps: 403727.44267
-  tps: 374658.00143
-  hps: 16.87256
+  dps: 403835.89868
+  tps: 374317.40704
+  hps: 16.52384
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RuneoftheNerubianCarapace-3883"
  value: {
-  dps: 403521.44024
-  tps: 374465.48449
-  hps: 16.87256
+  dps: 403745.83519
+  tps: 374225.00852
+  hps: 16.52384
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RuneoftheStoneskinGargoyle-3847"
  value: {
-  dps: 403815.80537
-  tps: 374756.68759
-  hps: 16.87256
+  dps: 403935.89562
+  tps: 374435.4673
+  hps: 16.21842
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SI:7Operative'sManual-92784"
  value: {
-  dps: 377755.94079
-  tps: 352752.77763
-  hps: 3037.62549
+  dps: 382333.22111
+  tps: 356333.09171
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-ScrollofReveredAncestors-89080"
  value: {
-  dps: 377755.94079
-  tps: 352752.77763
-  hps: 3037.62549
+  dps: 382333.22111
+  tps: 356333.09171
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SearingWords-81267"
  value: {
-  dps: 382145.84163
-  tps: 356768.96747
-  hps: 3091.31001
+  dps: 387871.30931
+  tps: 361525.77204
+  hps: 4343.18561
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Shock-ChargerMedallion-93259"
  value: {
-  dps: 381038.80613
-  tps: 355652.70481
-  hps: 3084.0057
+  dps: 386291.71574
+  tps: 360059.72092
+  hps: 4289.14861
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SigilofCompassion-83736"
  value: {
-  dps: 381660.61178
-  tps: 356663.34317
-  hps: 3047.99124
+  dps: 387507.08485
+  tps: 361514.60737
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SigilofDevotion-83740"
  value: {
-  dps: 384656.62334
-  tps: 359414.97542
-  hps: 3079.7237
+  dps: 390633.84061
+  tps: 364417.68536
+  hps: 4337.54588
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SigilofFidelity-83737"
  value: {
-  dps: 386068.71006
-  tps: 360477.64378
-  hps: 3117.6456
+  dps: 386898.46151
+  tps: 360535.07708
+  hps: 4295.95405
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SigilofGrace-83738"
  value: {
-  dps: 384954.43404
-  tps: 359766.21147
-  hps: 3059.45705
+  dps: 388169.34787
+  tps: 361971.50089
+  hps: 4322.79546
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SigilofKypariZar-84076"
  value: {
-  dps: 384809.72298
-  tps: 359550.32455
-  hps: 3087.15692
+  dps: 390683.42927
+  tps: 364454.21774
+  hps: 4342.74913
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SigilofPatience-83739"
  value: {
-  dps: 382304.92028
-  tps: 357307.65168
-  hps: 3047.99124
+  dps: 388178.71997
+  tps: 362186.24249
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SigilofRampage-105580"
  value: {
-  dps: 379264.54813
-  tps: 354157.7238
-  hps: 3047.99124
+  dps: 385038.23512
+  tps: 358943.62565
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SigiloftheCatacombs-83732"
  value: {
-  dps: 382251.5974
-  tps: 356761.43287
-  hps: 3060.75554
+  dps: 387789.8426
+  tps: 361340.2848
+  hps: 4355.72602
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SinisterPrimalDiamond"
  value: {
-  dps: 422426.83118
-  tps: 390940.51376
-  hps: 3144.34664
+  dps: 426080.41549
+  tps: 393312.00819
+  hps: 4321.8467
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Skeer'sBloodsoakedTalisman-105632"
  value: {
-  dps: 410390.70763
-  tps: 381921.50409
-  hps: 3216.04537
+  dps: 415941.29619
+  tps: 386143.29349
+  hps: 4563.59348
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SkullrenderMedallion-93256"
  value: {
-  dps: 391864.02072
-  tps: 365383.19343
-  hps: 3090.60745
+  dps: 396586.12211
+  tps: 369052.65753
+  hps: 4358.89618
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SoothingTalismanoftheShado-PanAssault-94509"
  value: {
-  dps: 377637.46146
-  tps: 352701.66382
-  hps: 3044.18014
+  dps: 383052.98357
+  tps: 357026.66313
+  hps: 4255.84383
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SoulBarrier-96927"
  value: {
-  dps: 378854.75461
-  tps: 353915.95436
-  hps: 3226.99152
+  dps: 382728.71415
+  tps: 356717.10872
+  hps: 4494.37542
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SparkofZandalar-96770"
  value: {
-  dps: 395627.04859
-  tps: 369696.18128
-  hps: 3086.39694
+  dps: 401666.23624
+  tps: 374842.32582
+  hps: 4297.19729
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SpiritsoftheSun-87163"
  value: {
-  dps: 378726.28257
-  tps: 353729.01397
-  hps: 3047.99124
+  dps: 384531.97008
+  tps: 358539.4926
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SpringrainIdolofDestruction-101023"
  value: {
-  dps: 386094.86181
-  tps: 360581.32636
-  hps: 3037.4939
+  dps: 388677.75723
+  tps: 362346.31853
+  hps: 4276.36573
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SpringrainIdolofRage-101009"
  value: {
-  dps: 383800.60248
-  tps: 358766.20249
-  hps: 3047.99124
+  dps: 389698.48105
+  tps: 363666.91086
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SpringrainStoneofDestruction-101026"
  value: {
-  dps: 384891.49724
-  tps: 359894.22864
-  hps: 3047.99124
+  dps: 390911.59449
+  tps: 364919.11702
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SpringrainStoneofRage-101012"
  value: {
-  dps: 385160.50139
-  tps: 360144.13825
-  hps: 3047.99124
+  dps: 391129.0663
+  tps: 365121.22086
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SpringrainStoneofWisdom-101041"
  value: {
-  dps: 378726.28257
-  tps: 353729.01397
-  hps: 3047.99124
+  dps: 384531.97008
+  tps: 358539.4926
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Static-Caster'sMedallion-93254"
  value: {
-  dps: 381038.80613
-  tps: 355652.70481
-  hps: 3084.0057
+  dps: 386291.71574
+  tps: 360059.72092
+  hps: 4289.14861
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SteadfastFootman'sMedallion-92782"
  value: {
-  dps: 377755.94079
-  tps: 352752.77763
-  hps: 3037.62549
+  dps: 382333.22111
+  tps: 356333.09171
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SteadfastTalismanoftheShado-PanAssault-94507"
  value: {
-  dps: 384720.53648
-  tps: 359717.37331
-  hps: 3037.62549
+  dps: 389370.51991
+  tps: 363370.39051
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-StreamtalkerIdolofDestruction-101222"
  value: {
-  dps: 386919.28025
-  tps: 361087.4936
-  hps: 3132.28234
+  dps: 389494.71042
+  tps: 362962.03032
+  hps: 4279.70638
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-StreamtalkerIdolofRage-101217"
  value: {
-  dps: 383817.65844
-  tps: 358787.08233
-  hps: 3047.99124
+  dps: 389659.94295
+  tps: 363629.91151
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-StreamtalkerStoneofDestruction-101225"
  value: {
-  dps: 384976.64646
-  tps: 359979.37785
-  hps: 3047.99124
+  dps: 390941.93875
+  tps: 364949.46127
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-StreamtalkerStoneofRage-101220"
  value: {
-  dps: 385083.45162
-  tps: 360067.08848
-  hps: 3047.99124
+  dps: 391059.48174
+  tps: 365051.63631
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-StreamtalkerStoneofWisdom-101250"
  value: {
-  dps: 378726.28257
-  tps: 353729.01397
-  hps: 3047.99124
+  dps: 384531.97008
+  tps: 358539.4926
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-StuffofNightmares-87160"
  value: {
-  dps: 384908.82385
-  tps: 359911.55525
-  hps: 3047.99124
+  dps: 390800.44527
+  tps: 364807.96779
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SunsoulDefenderIdol-101160"
  value: {
-  dps: 379625.48261
-  tps: 354659.97823
-  hps: 3149.6842
+  dps: 383690.75897
+  tps: 357651.60545
+  hps: 4429.37134
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SunsoulDefenderStone-101163"
  value: {
-  dps: 385855.48709
-  tps: 360889.98271
-  hps: 3149.6842
+  dps: 390047.55167
+  tps: 364008.39815
+  hps: 4429.37134
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SunsoulIdolofBattle-101152"
  value: {
-  dps: 394435.14674
-  tps: 367752.4617
-  hps: 3127.56618
+  dps: 398377.62792
+  tps: 370694.16788
+  hps: 4309.74595
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SunsoulStoneofBattle-101151"
  value: {
-  dps: 393146.62152
-  tps: 367447.93747
-  hps: 3047.99124
+  dps: 399255.76182
+  tps: 372532.62046
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SunsoulStoneofWisdom-101138"
  value: {
-  dps: 378726.28257
-  tps: 353729.01397
-  hps: 3047.99124
+  dps: 384531.97008
+  tps: 358539.4926
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SwordguardEmbroidery(Rank3)-4894"
  value: {
-  dps: 436282.55729
-  tps: 404208.35101
-  hps: 3104.28814
+  dps: 442062.42188
+  tps: 408803.81638
+  hps: 4353.72283
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SymboloftheCatacombs-83735"
  value: {
-  dps: 385022.28563
-  tps: 359635.3392
-  hps: 3079.41962
+  dps: 390626.21422
+  tps: 364256.8717
+  hps: 4329.80857
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SynapseSprings(MarkII)-4898"
  value: {
-  dps: 435622.61403
-  tps: 403530.37133
-  hps: 3112.39065
+  dps: 441419.17081
+  tps: 408153.89522
+  hps: 4373.9791
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TalismanofBloodlust-96864"
  value: {
-  dps: 382012.79491
-  tps: 356575.87496
-  hps: 3070.42242
+  dps: 387719.49599
+  tps: 361357.46949
+  hps: 4342.73478
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TerrorintheMists-87167"
  value: {
-  dps: 387180.36612
-  tps: 360656.24042
-  hps: 3156.71356
+  dps: 392329.41798
+  tps: 364716.09693
+  hps: 4424.78414
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Thok'sAcid-GroovedTooth-105607"
  value: {
-  dps: 378726.28257
-  tps: 353729.01397
-  hps: 3047.99124
+  dps: 384531.97008
+  tps: 358539.4926
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Thok'sTailTip-105609"
  value: {
-  dps: 429451.90597
-  tps: 398473.41216
-  hps: 3129.11414
+  dps: 433673.79281
+  tps: 401230.10767
+  hps: 4363.49544
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Thousand-YearPickledEgg-257881"
  value: {
-  dps: 379683.38357
-  tps: 354126.00357
-  hps: 3020.98277
+  dps: 383875.95581
+  tps: 357379.71604
+  hps: 4287.47398
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TickingEbonDetonator-105612"
  value: {
-  dps: 390438.9474
-  tps: 365322.51785
-  hps: 3047.99124
+  dps: 396355.47581
+  tps: 370231.98578
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Time-LostArtifact-103678"
  value: {
-  dps: 387950.07153
-  tps: 362210.96435
-  hps: 3107.43682
+  dps: 392449.22334
+  tps: 365790.01761
+  hps: 4287.08142
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TrailseekerIdolofRage-101054"
  value: {
-  dps: 383790.76098
-  tps: 358759.31592
-  hps: 3047.99124
+  dps: 389646.60958
+  tps: 363617.19992
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TrailseekerStoneofRage-101057"
  value: {
-  dps: 385131.46917
-  tps: 360115.10603
-  hps: 3047.99124
+  dps: 391082.17076
+  tps: 365074.32532
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TyrannicalGladiator'sBadgeofConquest-100043"
  value: {
-  dps: 377927.68255
-  tps: 352889.27995
-  hps: 3037.62549
+  dps: 382519.1605
+  tps: 356487.68979
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TyrannicalGladiator'sBadgeofDominance-100016"
  value: {
-  dps: 377755.94079
-  tps: 352752.77763
-  hps: 3037.62549
+  dps: 382333.22111
+  tps: 356333.09171
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TyrannicalGladiator'sBadgeofVictory-100019"
  value: {
-  dps: 387202.57314
-  tps: 361031.09026
-  hps: 3037.62549
+  dps: 392188.63263
+  tps: 364954.50382
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TyrannicalGladiator'sEmblemofCruelty-100066"
  value: {
-  dps: 382853.83221
-  tps: 357353.63083
-  hps: 3108.55977
+  dps: 386618.61949
+  tps: 360208.20357
+  hps: 4338.35849
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TyrannicalGladiator'sEmblemofMeditation-99990"
  value: {
-  dps: 378317.93493
-  tps: 353292.86095
-  hps: 3050.00721
+  dps: 382205.5248
+  tps: 356213.93504
+  hps: 4270.87882
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TyrannicalGladiator'sEmblemofTenacity-100092"
  value: {
-  dps: 378502.45733
-  tps: 353469.23791
-  hps: 3143.79784
+  dps: 382590.88964
+  tps: 356582.57536
+  hps: 4415.00655
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TyrannicalGladiator'sInsigniaofConquest-100026"
  value: {
-  dps: 379033.69019
-  tps: 353985.16169
-  hps: 3047.99124
+  dps: 384772.39046
+  tps: 358735.40416
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TyrannicalGladiator'sInsigniaofDominance-100152"
  value: {
-  dps: 378726.28257
-  tps: 353729.01397
-  hps: 3047.99124
+  dps: 384531.97008
+  tps: 358539.4926
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TyrannicalGladiator'sInsigniaofVictory-100085"
  value: {
-  dps: 393108.00446
-  tps: 366488.2514
-  hps: 3069.67157
+  dps: 397788.39212
+  tps: 370060.96111
+  hps: 4247.04492
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TyrannicalPrimalDiamond"
  value: {
-  dps: 420705.98366
-  tps: 389380.6097
-  hps: 3114.43428
+  dps: 424606.20752
+  tps: 392022.42036
+  hps: 4293.48791
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-UnerringVisionofLeiShen-96930"
  value: {
-  dps: 378726.28257
-  tps: 353729.01397
-  hps: 3047.99124
+  dps: 384531.97008
+  tps: 358539.4926
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-VaporshieldMedallion-93262"
  value: {
-  dps: 383110.29835
-  tps: 358107.13519
-  hps: 3037.62549
+  dps: 387855.39077
+  tps: 361855.26137
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-VialofDragon'sBlood-87063"
  value: {
-  dps: 384518.84817
-  tps: 359521.57957
-  hps: 3047.99124
+  dps: 390405.04915
+  tps: 364412.57167
+  hps: 4294.87242
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-VialofIchorousBlood-100963"
  value: {
-  dps: 377755.94079
-  tps: 352752.77763
-  hps: 3037.62549
+  dps: 382333.22111
+  tps: 356333.09171
+  hps: 4254.68465
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-VialofLivingCorruption-105568"
  value: {
-  dps: 379881.518
-  tps: 354892.41045
-  hps: 3316.55062
+  dps: 382781.72224
+  tps: 356743.17186
+  hps: 4589.75247
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-ViciousTalismanoftheShado-PanAssault-94511"
  value: {
-  dps: 385004.78938
-  tps: 359691.95955
-  hps: 3128.0681
+  dps: 388527.80365
+  tps: 362396.12846
+  hps: 4362.10647
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-VisionofthePredator-81192"
  value: {
-  dps: 382800.76218
-  tps: 356989.44921
-  hps: 3126.99225
+  dps: 389005.32693
+  tps: 362238.44121
+  hps: 4346.16167
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-VolatileTalismanoftheShado-PanAssault-94510"
  value: {
-  dps: 380359.40407
-  tps: 354509.63025
-  hps: 3064.90279
+  dps: 384908.00309
+  tps: 358250.1705
+  hps: 4318.91853
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-WindsweptPages-81125"
  value: {
-  dps: 380828.43165
-  tps: 355053.96848
-  hps: 3123.99779
+  dps: 385821.5161
+  tps: 359208.26773
+  hps: 4294.01932
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-WoundripperMedallion-93253"
  value: {
-  dps: 382827.81625
-  tps: 357127.41871
-  hps: 3090.60745
+  dps: 387378.6909
+  tps: 360664.30008
+  hps: 4358.89618
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Wushoolay'sFinalChoice-96785"
  value: {
-  dps: 384711.88539
-  tps: 359707.79342
-  hps: 3109.5388
+  dps: 390313.80023
+  tps: 364427.92739
+  hps: 4387.35299
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Xing-Ho,BreathofYu'lon-102246"
  value: {
-  dps: 401167.01133
-  tps: 371157.74588
-  hps: 3082.58946
+  dps: 406027.95235
+  tps: 375257.35456
+  hps: 4272.32448
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-YaungolFireCarrier-86518"
  value: {
-  dps: 433470.38658
-  tps: 401745.87986
-  hps: 3112.39065
+  dps: 439197.46041
+  tps: 406336.29317
+  hps: 4373.9791
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Yu'lon'sBite-103987"
  value: {
-  dps: 388175.84633
-  tps: 361270.9963
-  hps: 3198.14236
+  dps: 393846.20266
+  tps: 365844.89986
+  hps: 4477.27439
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-ZenAlchemistStone-75274"
  value: {
-  dps: 394817.70524
-  tps: 368390.91707
-  hps: 3070.41226
+  dps: 397160.71395
+  tps: 369669.95413
+  hps: 4237.93706
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Average-Default"
  value: {
-  dps: 442487.56629
-  tps: 410400.44305
-  hps: 2924.11344
+  dps: 447204.91314
+  tps: 413951.7448
+  hps: 4157.3196
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.9608180061e+06
-  tps: 1.92964790519e+06
-  hps: 2856.04606
+  dps: 2.00269227115e+06
+  tps: 1.97015869395e+06
+  hps: 9871.56025
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 435351.81744
-  tps: 404215.83283
-  hps: 3109.89925
+  dps: 441118.49977
+  tps: 408586.88061
+  hps: 4300.92563
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 597510.73127
-  tps: 474080.22771
-  hps: 3699.16913
+  dps: 608708.78272
+  tps: 479225.90036
+  hps: 5220.95149
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-DefaultTalents-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.50893682667e+06
-  tps: 1.48959006391e+06
-  hps: 2476.3089
+  dps: 1.5249997798e+06
+  tps: 1.50504071988e+06
+  hps: 8573.9363
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-DefaultTalents-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 342219.13528
-  tps: 322839.18624
-  hps: 2703.3875
+  dps: 346863.62976
+  tps: 326837.42806
+  hps: 3804.16293
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-DefaultTalents-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 415780.3879
-  tps: 345688.87999
-  hps: 2885.95466
+  dps: 424084.39076
+  tps: 351371.09086
+  hps: 4100.9461
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RoilingBlood-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.87811015086e+06
-  tps: 1.84691726838e+06
-  hps: 2972.47996
+  dps: 1.90874691222e+06
+  tps: 1.87608713933e+06
+  hps: 9541.30714
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RoilingBlood-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 444696.43726
-  tps: 413479.38379
-  hps: 3190.38596
+  dps: 449775.54887
+  tps: 417156.67702
+  hps: 4449.43494
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RoilingBlood-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 606517.18451
-  tps: 483102.94446
-  hps: 3714.40576
+  dps: 619772.38321
+  tps: 490087.98995
+  hps: 5354.37934
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RoilingBlood-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.44565936145e+06
-  tps: 1.42618347094e+06
-  hps: 2560.26954
+  dps: 1.46691928297e+06
+  tps: 1.4470236101e+06
+  hps: 8450.15037
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RoilingBlood-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 351312.41268
-  tps: 331773.14199
-  hps: 2810.46861
+  dps: 354648.76919
+  tps: 334632.06439
+  hps: 3928.81362
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RoilingBlood-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 431078.98031
-  tps: 360802.37866
-  hps: 3031.52139
+  dps: 438964.35095
+  tps: 366143.74299
+  hps: 4241.85964
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicCorruption-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.76191545326e+06
-  tps: 1.73065945598e+06
-  hps: 3023.96289
+  dps: 1.78976044565e+06
+  tps: 1.75718659286e+06
+  hps: 9193.6899
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicCorruption-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 433476.48859
-  tps: 402283.81311
-  hps: 3214.17939
+  dps: 438130.44389
+  tps: 405603.79486
+  hps: 4494.89428
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicCorruption-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 592379.05507
-  tps: 468813.00994
-  hps: 3676.94053
+  dps: 604818.29194
+  tps: 475099.67304
+  hps: 5395.66779
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicCorruption-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.35923704296e+06
-  tps: 1.33994596528e+06
-  hps: 2641.68258
+  dps: 1.38046090788e+06
+  tps: 1.36045169842e+06
+  hps: 8130.08202
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicCorruption-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 343547.16313
-  tps: 324116.49793
-  hps: 2884.37066
+  dps: 344919.48363
+  tps: 324977.83676
+  hps: 3944.79919
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicCorruption-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 418371.24814
-  tps: 348075.57638
-  hps: 3029.97033
+  dps: 423674.00261
+  tps: 351048.84084
+  hps: 4274.76142
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicEmpowerment-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.82700951481e+06
-  tps: 1.79563919668e+06
-  hps: 3023.13842
+  dps: 1.83459839966e+06
+  tps: 1.80202817593e+06
+  hps: 9379.05497
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicEmpowerment-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 432304.1328
-  tps: 401024.66727
-  hps: 3147.00555
+  dps: 438900.43212
+  tps: 406493.87774
+  hps: 4424.24312
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicEmpowerment-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 586502.18912
-  tps: 462869.40355
-  hps: 3644.19584
+  dps: 603059.57089
+  tps: 473773.14841
+  hps: 5341.59182
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicEmpowerment-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.40600767428e+06
-  tps: 1.38672609991e+06
-  hps: 2563.71482
+  dps: 1.4096402504e+06
+  tps: 1.38970139925e+06
+  hps: 8079.33339
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicEmpowerment-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 343964.02183
-  tps: 324543.2924
-  hps: 2794.51598
+  dps: 347088.98605
+  tps: 327162.83338
+  hps: 3905.97042
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicEmpowerment-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 419080.34938
-  tps: 348458.24401
-  hps: 2956.41143
+  dps: 428690.64337
+  tps: 356049.21465
+  hps: 4274.76142
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-UnholyBlight-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.9374380807e+06
-  tps: 1.90626388944e+06
-  hps: 2951.27958
+  dps: 1.97282808635e+06
+  tps: 1.94003842914e+06
+  hps: 9585.51202
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-UnholyBlight-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 446059.78938
-  tps: 415094.78022
-  hps: 3185.45042
+  dps: 451287.27455
+  tps: 418657.04357
+  hps: 4452.20744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-UnholyBlight-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 612355.02861
-  tps: 489843.0388
-  hps: 3639.77441
+  dps: 626249.08289
+  tps: 496506.11429
+  hps: 5374.63562
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-UnholyBlight-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.49306001394e+06
-  tps: 1.47361418704e+06
-  hps: 2618.80644
+  dps: 1.52065182277e+06
+  tps: 1.50064141674e+06
+  hps: 8378.1096
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-UnholyBlight-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 351300.92487
-  tps: 331818.10865
-  hps: 2804.54162
+  dps: 352657.39588
+  tps: 332619.06113
+  hps: 3877.13434
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-UnholyBlight-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 433402.73063
-  tps: 363162.90267
-  hps: 3048.74782
+  dps: 440197.64305
+  tps: 367425.63513
+  hps: 4262.18819
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 405105.00772
-  tps: 375612.9789
-  hps: 2879.28952
+  dps: 407498.42587
+  tps: 376914.27227
+  hps: 3966.92832
  }
 }

--- a/sim/death_knight/frost/TestFrostTwoHand.results
+++ b/sim/death_knight/frost/TestFrostTwoHand.results
@@ -1721,8 +1721,8 @@ dps_results: {
 dps_results: {
  key: "TestFrostTwoHand-AllItems-RuneofRazorice-3370"
  value: {
-  dps: 418305.36868
-  tps: 381782.90402
+  dps: 417513.93978
+  tps: 380991.47511
   hps: 18.92445
  }
 }

--- a/sim/death_knight/frost/TestFrostTwoHand.results
+++ b/sim/death_knight/frost/TestFrostTwoHand.results
@@ -33,65 +33,65 @@ character_stats_results: {
 dps_results: {
  key: "TestFrostTwoHand-AllItems-AgilePrimalDiamond"
  value: {
-  dps: 407132.77633
-  tps: 367503.40044
-  hps: 5965.7558
+  dps: 411945.92089
+  tps: 371289.4601
+  hps: 7140.28046
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-AlacrityofXuen-103989"
  value: {
-  dps: 392279.66062
-  tps: 357103.19091
-  hps: 5785.17876
+  dps: 395702.55311
+  tps: 359807.77806
+  hps: 6994.96045
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-ArcaneBadgeoftheShieldwall-93347"
  value: {
-  dps: 377187.6168
-  tps: 345362.41174
-  hps: 5797.97661
+  dps: 379005.18658
+  tps: 346169.6803
+  hps: 6937.13914
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-ArrowflightMedallion-93258"
  value: {
-  dps: 378450.87963
-  tps: 346424.68891
-  hps: 5734.25124
+  dps: 381879.84978
+  tps: 349053.34158
+  hps: 6961.74382
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-AssuranceofConsequence-105472"
  value: {
-  dps: 374891.66105
-  tps: 343402.11007
-  hps: 5656.02799
+  dps: 378103.87448
+  tps: 345849.38849
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-AusterePrimalDiamond"
  value: {
-  dps: 399935.87109
-  tps: 360302.4385
-  hps: 5912.82577
+  dps: 404690.2577
+  tps: 364090.96122
+  hps: 7104.07841
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-BadJuju-96781"
  value: {
-  dps: 380115.7212
-  tps: 348726.33138
-  hps: 5656.02799
+  dps: 383226.06788
+  tps: 351053.76385
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-BadgeofKypariZar-84079"
  value: {
-  dps: 379021.35012
-  tps: 347327.31535
-  hps: 5720.18709
+  dps: 381892.55492
+  tps: 349422.75629
+  hps: 6876.75125
  }
 }
 dps_results: {
@@ -105,9 +105,9 @@ dps_results: {
 dps_results: {
  key: "TestFrostTwoHand-AllItems-BattleplateofCyclopeanDread"
  value: {
-  dps: 344315.78143
-  tps: 312603.67056
-  hps: 4824.89922
+  dps: 349282.4766
+  tps: 316829.018
+  hps: 5714.08537
  }
 }
 dps_results: {
@@ -121,1345 +121,1345 @@ dps_results: {
 dps_results: {
  key: "TestFrostTwoHand-AllItems-BlackBloodofY'Shaarj-105648"
  value: {
-  dps: 379233.72871
-  tps: 346857.95989
-  hps: 5765.77403
+  dps: 383860.29678
+  tps: 350673.64313
+  hps: 7031.48477
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-BlossomofPureSnow-89081"
  value: {
-  dps: 378085.9762
-  tps: 346139.64173
-  hps: 5725.22548
+  dps: 381460.27917
+  tps: 348696.96534
+  hps: 6942.94015
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-BottleofInfiniteStars-87057"
  value: {
-  dps: 378312.02822
-  tps: 346945.72238
-  hps: 5656.02799
+  dps: 381509.94668
+  tps: 349374.34321
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-BraidofTenSongs-84072"
  value: {
-  dps: 376826.73199
-  tps: 344998.19615
-  hps: 5716.4248
+  dps: 380698.46302
+  tps: 348016.17748
+  hps: 6917.23809
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Brawler'sStatue-257885"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-BreathoftheHydra-96827"
  value: {
-  dps: 378747.06058
-  tps: 346799.29653
-  hps: 5783.42144
+  dps: 381511.12489
+  tps: 348564.44604
+  hps: 6911.1206
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-BroochofMunificentDeeds-87500"
  value: {
-  dps: 375384.50462
-  tps: 343994.98
-  hps: 5841.96729
+  dps: 376687.9159
+  tps: 344577.35209
+  hps: 7037.77946
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-BrutalTalismanoftheShado-PanAssault-94508"
  value: {
-  dps: 387783.67826
-  tps: 353405.37078
-  hps: 5656.02799
+  dps: 391594.45019
+  tps: 356211.87212
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-BurningPrimalDiamond"
  value: {
-  dps: 407122.97786
-  tps: 367501.33241
-  hps: 5965.7558
+  dps: 411936.73556
+  tps: 371282.95247
+  hps: 7140.28046
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CapacitivePrimalDiamond"
  value: {
-  dps: 419991.22055
-  tps: 380392.83268
-  hps: 5856.61871
+  dps: 425903.11477
+  tps: 385126.55692
+  hps: 7191.96087
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CarbonicCarbuncle-81138"
  value: {
-  dps: 383652.11518
-  tps: 350628.50838
-  hps: 5726.72978
+  dps: 387177.32596
+  tps: 353281.4741
+  hps: 6917.92357
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Cha-Ye'sEssenceofBrilliance-96888"
  value: {
-  dps: 380534.7903
-  tps: 348534.07729
-  hps: 5802.93122
+  dps: 383469.97696
+  tps: 350709.65167
+  hps: 6969.61431
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CharmofTenSongs-84071"
  value: {
-  dps: 380083.09953
-  tps: 348044.94617
-  hps: 5837.37691
+  dps: 380381.55094
+  tps: 347467.56633
+  hps: 7017.52487
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CommunalIdolofDestruction-101168"
  value: {
-  dps: 378742.16257
-  tps: 347052.62171
-  hps: 5742.46184
+  dps: 380918.19912
+  tps: 348484.515
+  hps: 6914.31874
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CommunalStoneofDestruction-101171"
  value: {
-  dps: 378291.82691
-  tps: 346968.22543
-  hps: 5656.02799
+  dps: 381470.47484
+  tps: 349383.61307
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CommunalStoneofWisdom-101183"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-ContemplationofChi-Ji-103988"
  value: {
-  dps: 373255.16466
-  tps: 341889.21154
-  hps: 5672.61439
+  dps: 377011.19516
+  tps: 344846.40381
+  hps: 6852.50816
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Coren'sColdChromiumCoaster-257880"
  value: {
-  dps: 384023.96365
-  tps: 351266.34721
-  hps: 5749.55152
+  dps: 387369.87335
+  tps: 353698.5653
+  hps: 6907.4355
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CoreofDecency-87497"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CourageousPrimalDiamond"
  value: {
-  dps: 399885.52373
-  tps: 360309.96058
-  hps: 5881.80466
+  dps: 404631.04518
+  tps: 364041.23633
+  hps: 7041.16898
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedDreadfulGladiator'sBadgeofConquest-93419"
  value: {
-  dps: 374211.4573
-  tps: 342853.43165
-  hps: 5656.02799
+  dps: 377367.57974
+  tps: 345239.41342
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedDreadfulGladiator'sBadgeofDominance-93600"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedDreadfulGladiator'sBadgeofVictory-93606"
  value: {
-  dps: 379691.84214
-  tps: 347352.6837
-  hps: 5656.02799
+  dps: 383001.9157
+  tps: 349860.31584
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedDreadfulGladiator'sEmblemofCruelty-93485"
  value: {
-  dps: 376432.07794
-  tps: 344847.3264
-  hps: 5767.47815
+  dps: 379443.92533
+  tps: 347090.88409
+  hps: 6956.3755
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedDreadfulGladiator'sEmblemofMeditation-93487"
  value: {
-  dps: 373753.95992
-  tps: 342449.10992
-  hps: 5686.84721
+  dps: 376731.55284
+  tps: 344690.41008
+  hps: 6881.05336
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedDreadfulGladiator'sEmblemofTenacity-93486"
  value: {
-  dps: 374687.25526
-  tps: 343300.44508
-  hps: 5840.73161
+  dps: 376355.52034
+  tps: 344228.19853
+  hps: 7014.34634
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedDreadfulGladiator'sInsigniaofConquest-93424"
  value: {
-  dps: 374341.51868
-  tps: 342975.85887
-  hps: 5656.02799
+  dps: 377533.27757
+  tps: 345406.21139
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedDreadfulGladiator'sInsigniaofDominance-93601"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedDreadfulGladiator'sInsigniaofVictory-93611"
  value: {
-  dps: 381763.38736
-  tps: 349122.43488
-  hps: 5656.02799
+  dps: 385320.42422
+  tps: 351838.02551
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedMalevolentGladiator'sBadgeofConquest-98755"
  value: {
-  dps: 374295.78353
-  tps: 342928.63808
-  hps: 5656.02799
+  dps: 377431.13749
+  tps: 345298.4283
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedMalevolentGladiator'sBadgeofDominance-98910"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedMalevolentGladiator'sBadgeofVictory-98912"
  value: {
-  dps: 380710.59729
-  tps: 348186.01553
-  hps: 5656.02799
+  dps: 384054.72229
+  tps: 350720.54531
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedMalevolentGladiator'sEmblemofCruelty-98811"
  value: {
-  dps: 377096.08611
-  tps: 345451.23539
-  hps: 5775.25697
+  dps: 379946.44405
+  tps: 347524.04117
+  hps: 6960.39358
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedMalevolentGladiator'sEmblemofMeditation-98813"
  value: {
-  dps: 373753.95992
-  tps: 342449.10992
-  hps: 5686.84721
+  dps: 376731.55284
+  tps: 344690.41008
+  hps: 6881.05336
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedMalevolentGladiator'sEmblemofTenacity-98812"
  value: {
-  dps: 374884.59502
-  tps: 343472.14129
-  hps: 5865.04525
+  dps: 376355.52034
+  tps: 344228.19853
+  hps: 7038.65031
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedMalevolentGladiator'sInsigniaofConquest-98760"
  value: {
-  dps: 374395.21833
-  tps: 343020.32866
-  hps: 5656.02799
+  dps: 377484.06011
+  tps: 345347.53207
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedMalevolentGladiator'sInsigniaofDominance-98911"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedMalevolentGladiator'sInsigniaofVictory-98917"
  value: {
-  dps: 383460.57495
-  tps: 350479.69175
-  hps: 5656.02799
+  dps: 386918.46868
+  tps: 353123.91368
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CurseofHubris-105645"
  value: {
-  dps: 383738.60023
-  tps: 350839.57414
-  hps: 6318.28514
+  dps: 387020.53382
+  tps: 353168.56969
+  hps: 7597.71251
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CutstitcherMedallion-93255"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Daelo'sFinalWords-87496"
  value: {
-  dps: 379494.00467
-  tps: 346710.15777
-  hps: 5672.61439
+  dps: 383519.05911
+  tps: 349826.90369
+  hps: 6852.50816
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DarkglowEmbroidery(Rank3)-4893"
  value: {
-  dps: 419240.82495
-  tps: 379709.55522
-  hps: 5840.22132
+  dps: 425178.15865
+  tps: 384466.88163
+  hps: 7179.66283
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DarkmistVortex-87172"
  value: {
-  dps: 386617.93614
-  tps: 352397.28902
-  hps: 5817.22089
+  dps: 390941.65322
+  tps: 355737.47549
+  hps: 6979.92754
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DeadeyeBadgeoftheShieldwall-93346"
  value: {
-  dps: 376836.19864
-  tps: 345489.64735
-  hps: 5656.02799
+  dps: 380070.31156
+  tps: 347956.55549
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DelicateVialoftheSanguinaire-96895"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DestructivePrimalDiamond"
  value: {
-  dps: 401268.09095
-  tps: 361493.15651
-  hps: 5922.79815
+  dps: 406067.30484
+  tps: 365277.2444
+  hps: 7090.97787
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DisciplineofXuen-103986"
  value: {
-  dps: 381801.96095
-  tps: 350435.51518
-  hps: 5656.02799
+  dps: 385266.55946
+  tps: 353131.9383
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Dominator'sArcaneBadge-93342"
  value: {
-  dps: 377187.6168
-  tps: 345362.41174
-  hps: 5797.97661
+  dps: 379005.18658
+  tps: 346169.6803
+  hps: 6937.13914
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Dominator'sDeadeyeBadge-93341"
  value: {
-  dps: 376836.19864
-  tps: 345489.64735
-  hps: 5656.02799
+  dps: 380070.31156
+  tps: 347956.55549
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Dominator'sDurableBadge-93345"
  value: {
-  dps: 376740.93637
-  tps: 345417.33489
-  hps: 5656.02799
+  dps: 379986.20295
+  tps: 347899.34118
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Dominator'sKnightlyBadge-93344"
  value: {
-  dps: 381986.45983
-  tps: 349969.99488
-  hps: 5656.02799
+  dps: 385309.00061
+  tps: 352511.46415
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Dominator'sMendingBadge-93343"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DreadfulGladiator'sBadgeofConquest-84344"
  value: {
-  dps: 374211.4573
-  tps: 342853.43165
-  hps: 5656.02799
+  dps: 377367.57974
+  tps: 345239.41342
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DreadfulGladiator'sBadgeofDominance-84488"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DreadfulGladiator'sBadgeofVictory-84490"
  value: {
-  dps: 379691.84214
-  tps: 347352.6837
-  hps: 5656.02799
+  dps: 383001.9157
+  tps: 349860.31584
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DreadfulGladiator'sEmblemofCruelty-84399"
  value: {
-  dps: 376432.07794
-  tps: 344847.3264
-  hps: 5767.47815
+  dps: 379443.92533
+  tps: 347090.88409
+  hps: 6956.3755
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DreadfulGladiator'sEmblemofMeditation-84401"
  value: {
-  dps: 373753.95992
-  tps: 342449.10992
-  hps: 5686.84721
+  dps: 376731.55284
+  tps: 344690.41008
+  hps: 6881.05336
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DreadfulGladiator'sEmblemofTenacity-84400"
  value: {
-  dps: 374687.25526
-  tps: 343300.44508
-  hps: 5840.73161
+  dps: 376355.52034
+  tps: 344228.19853
+  hps: 7014.34634
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DreadfulGladiator'sInsigniaofConquest-84349"
  value: {
-  dps: 374305.9405
-  tps: 342940.9154
-  hps: 5656.02799
+  dps: 377501.98464
+  tps: 345376.13587
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DreadfulGladiator'sInsigniaofDominance-84489"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DreadfulGladiator'sInsigniaofVictory-84495"
  value: {
-  dps: 381908.36777
-  tps: 349216.45801
-  hps: 5656.02799
+  dps: 385342.17744
+  tps: 351836.04352
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DurableBadgeoftheShieldwall-93350"
  value: {
-  dps: 376740.93637
-  tps: 345417.33489
-  hps: 5656.02799
+  dps: 379986.20295
+  tps: 347899.34118
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DysmorphicSamophlangeofDiscontinuity-105615"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EffulgentPrimalDiamond"
  value: {
-  dps: 399935.87109
-  tps: 360302.4385
-  hps: 5912.82577
+  dps: 404690.2577
+  tps: 364090.96122
+  hps: 7104.07841
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EmberPrimalDiamond"
  value: {
-  dps: 399885.52373
-  tps: 360309.96058
-  hps: 5881.80466
+  dps: 404631.04518
+  tps: 364041.23633
+  hps: 7041.16898
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EmblemofKypariZar-84077"
  value: {
-  dps: 376966.7831
-  tps: 345016.66916
-  hps: 5823.04163
+  dps: 381220.03647
+  tps: 348337.99498
+  hps: 6987.874
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EmblemoftheCatacombs-83733"
  value: {
-  dps: 376852.26117
-  tps: 345262.62863
-  hps: 5751.42738
+  dps: 381904.97449
+  tps: 349588.28431
+  hps: 6937.79726
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EmptyFruitBarrel-81133"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EnchantWeapon-BloodyDancingSteel-5125"
  value: {
-  dps: 396242.90841
-  tps: 359805.38623
-  hps: 19.33643
+  dps: 400461.30057
+  tps: 363151.49569
+  hps: 18.92445
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EnchantWeapon-Colossus-4445"
  value: {
-  dps: 391464.38159
-  tps: 355724.95303
-  hps: 18.99489
+  dps: 395111.65816
+  tps: 358539.36282
+  hps: 18.83425
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EnchantWeapon-DancingSteel-4444"
  value: {
-  dps: 396232.42192
-  tps: 359770.39688
-  hps: 19.33643
+  dps: 400791.36047
+  tps: 363423.22152
+  hps: 18.92445
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EnchantWeapon-ElementalForce-4443"
  value: {
-  dps: 394545.28503
-  tps: 358759.92758
-  hps: 19.51284
+  dps: 397213.46668
+  tps: 360630.22972
+  hps: 19.33935
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EnchantWeapon-JadeSpirit-4442"
  value: {
-  dps: 391448.36233
-  tps: 355794.70656
-  hps: 19.33643
+  dps: 395655.5331
+  tps: 359133.06844
+  hps: 18.92445
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EnchantWeapon-River'sSong-4446"
  value: {
-  dps: 391448.36233
-  tps: 355794.70656
-  hps: 19.33643
+  dps: 395659.07838
+  tps: 359152.67469
+  hps: 18.92445
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EnchantWeapon-SpiritofConquest-5124"
  value: {
-  dps: 391448.36233
-  tps: 355794.70656
-  hps: 19.33643
+  dps: 395655.5331
+  tps: 359133.06844
+  hps: 18.92445
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EnchantWeapon-Windsong-4441"
  value: {
-  dps: 394918.0052
-  tps: 358881.89867
-  hps: 18.99489
+  dps: 396237.94169
+  tps: 359195.33155
+  hps: 19.32997
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EnigmaticPrimalDiamond"
  value: {
-  dps: 401268.09095
-  tps: 361493.15651
-  hps: 5922.79815
+  dps: 406067.30484
+  tps: 365277.2444
+  hps: 7090.97787
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EssenceofTerror-87175"
  value: {
-  dps: 376774.87492
-  tps: 344510.68557
-  hps: 5732.40465
+  dps: 380614.04981
+  tps: 347703.37852
+  hps: 6961.09825
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EternalPrimalDiamond"
  value: {
-  dps: 399885.52373
-  tps: 360309.96058
-  hps: 5881.80466
+  dps: 404631.04518
+  tps: 364041.23633
+  hps: 7041.16898
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EvilEyeofGalakras-105491"
  value: {
-  dps: 402316.65517
-  tps: 366889.896
-  hps: 5711.80529
+  dps: 409461.43076
+  tps: 372914.36
+  hps: 7468.54904
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-FabledFeatherofJi-Kun-96842"
  value: {
-  dps: 390364.88755
-  tps: 355756.1446
-  hps: 5656.02799
+  dps: 394036.30664
+  tps: 358205.5153
+  hps: 6828.61387
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-FearwurmBadge-84074"
  value: {
-  dps: 376327.24288
-  tps: 344259.19459
-  hps: 5802.30657
+  dps: 381322.76654
+  tps: 348532.06902
+  hps: 7002.8229
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-FearwurmRelic-84070"
  value: {
-  dps: 376115.54633
-  tps: 344164.1364
-  hps: 5809.19351
+  dps: 380655.29347
+  tps: 347769.95774
+  hps: 7014.44274
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-FelsoulIdolofDestruction-101263"
  value: {
-  dps: 379441.44985
-  tps: 347540.9633
-  hps: 5749.77491
+  dps: 382882.40903
+  tps: 350204.13244
+  hps: 6920.57517
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-FelsoulStoneofDestruction-101266"
  value: {
-  dps: 378387.53742
-  tps: 347063.93594
-  hps: 5656.02799
+  dps: 381629.52503
+  tps: 349542.66327
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Fen-Yu,FuryofXuen-102248"
  value: {
-  dps: 399957.82686
-  tps: 362593.16361
-  hps: 5769.53391
+  dps: 404102.53664
+  tps: 365899.51796
+  hps: 6874.87467
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-FlashfrozenResinGlobule-100951"
  value: {
-  dps: 372293.71852
-  tps: 341034.26212
-  hps: 5644.28645
+  dps: 377050.25209
+  tps: 344897.00561
+  hps: 6871.50585
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-FlashingSteelTalisman-81265"
  value: {
-  dps: 373460.79408
-  tps: 342051.91934
-  hps: 5672.61439
+  dps: 377192.45068
+  tps: 344978.52973
+  hps: 6852.50816
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-FleetPrimalDiamond"
  value: {
-  dps: 401510.98894
-  tps: 361935.42579
-  hps: 5881.80466
+  dps: 406278.8068
+  tps: 365688.99795
+  hps: 7041.16898
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-ForlornPrimalDiamond"
  value: {
-  dps: 399885.52373
-  tps: 360309.96058
-  hps: 5881.80466
+  dps: 404631.04518
+  tps: 364041.23633
+  hps: 7041.16898
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-FortitudeoftheZandalari-96793"
  value: {
-  dps: 379261.20983
-  tps: 347956.35982
-  hps: 5686.84721
+  dps: 382368.15157
+  tps: 350327.00881
+  hps: 6881.05336
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-FrenziedCrystalofRage-105572"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Fusion-FireCore-105459"
  value: {
-  dps: 395766.28776
-  tps: 359722.84965
-  hps: 5656.02799
+  dps: 399855.79812
+  tps: 362676.64342
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-GazeoftheTwins-96915"
  value: {
-  dps: 392647.74458
-  tps: 358728.60524
-  hps: 5832.93161
+  dps: 394926.0173
+  tps: 360228.67611
+  hps: 6990.32539
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Gerp'sPerfectArrow-87495"
  value: {
-  dps: 376764.50292
-  tps: 345154.97177
-  hps: 5728.98622
+  dps: 379826.97327
+  tps: 347426.71416
+  hps: 6892.13521
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-GrievousGladiator'sBadgeofConquest-103145"
  value: {
-  dps: 374484.27732
-  tps: 343104.85387
-  hps: 5656.02799
+  dps: 377564.76746
+  tps: 345417.75732
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-GrievousGladiator'sBadgeofDominance-103308"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-GrievousGladiator'sBadgeofVictory-103314"
  value: {
-  dps: 384244.49046
-  tps: 351076.70588
-  hps: 5656.02799
+  dps: 387706.7343
+  tps: 353704.53914
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-GrievousGladiator'sEmblemofCruelty-103210"
  value: {
-  dps: 378897.83662
-  tps: 347026.72319
-  hps: 5815.23872
+  dps: 381812.25014
+  tps: 349193.67099
+  hps: 7006.13321
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-GrievousGladiator'sEmblemofMeditation-103212"
  value: {
-  dps: 373753.95992
-  tps: 342449.10992
-  hps: 5686.84721
+  dps: 376731.55284
+  tps: 344690.41008
+  hps: 6881.05336
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-GrievousGladiator'sEmblemofTenacity-103211"
  value: {
-  dps: 375089.07369
-  tps: 343771.58739
-  hps: 5928.7746
+  dps: 376105.97217
+  tps: 343926.99156
+  hps: 7135.42536
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-GrievousGladiator'sInsigniaofConquest-103150"
  value: {
-  dps: 374503.47553
-  tps: 343110.7971
-  hps: 5656.02799
+  dps: 377616.62472
+  tps: 345459.53888
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-GrievousGladiator'sInsigniaofDominance-103309"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-GrievousGladiator'sInsigniaofVictory-103319"
  value: {
-  dps: 388215.45746
-  tps: 354485.82636
-  hps: 5656.02799
+  dps: 391917.81218
+  tps: 357281.10482
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Haromm'sTalisman-105527"
  value: {
-  dps: 392548.1306
-  tps: 361128.87159
-  hps: 5656.02799
+  dps: 395336.11751
+  tps: 363156.99483
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Hawkmaster'sTalon-89082"
  value: {
-  dps: 377422.89377
-  tps: 345250.35907
-  hps: 5717.82579
+  dps: 380503.9461
+  tps: 347603.76679
+  hps: 6931.33743
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Heart-LesionDefenderIdol-100999"
  value: {
-  dps: 373571.61909
-  tps: 342235.34669
-  hps: 5836.1363
+  dps: 376331.2062
+  tps: 344200.94915
+  hps: 7045.2337
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Heart-LesionDefenderStone-101002"
  value: {
-  dps: 377778.18462
-  tps: 346441.91222
-  hps: 5836.1363
+  dps: 380620.51879
+  tps: 348490.26175
+  hps: 7045.2337
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Heart-LesionIdolofBattle-100991"
  value: {
-  dps: 385981.99297
-  tps: 352904.43835
-  hps: 5744.2865
+  dps: 389371.88989
+  tps: 355394.60719
+  hps: 6907.4355
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Heart-LesionStoneofBattle-100990"
  value: {
-  dps: 384952.09352
-  tps: 352754.06238
-  hps: 5656.02799
+  dps: 388283.26997
+  tps: 355299.49985
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-HeartofFire-81181"
  value: {
-  dps: 376778.35069
-  tps: 345454.74921
-  hps: 5656.02799
+  dps: 379962.99709
+  tps: 347876.13533
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-HeartwarmerMedallion-93260"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-HelmbreakerMedallion-93261"
  value: {
-  dps: 385861.36002
-  tps: 352843.92773
-  hps: 5734.25124
+  dps: 389346.37258
+  tps: 355510.44545
+  hps: 6961.74382
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Horridon'sLastGasp-96757"
  value: {
-  dps: 374067.68619
-  tps: 342755.02569
-  hps: 5656.02799
+  dps: 377073.99188
+  tps: 344978.27013
+  hps: 6806.04947
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-ImpassivePrimalDiamond"
  value: {
-  dps: 401268.09095
-  tps: 361493.15651
-  hps: 5922.79815
+  dps: 406067.30484
+  tps: 365277.2444
+  hps: 7090.97787
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-IndomitablePrimalDiamond"
  value: {
-  dps: 399935.87109
-  tps: 360302.4385
-  hps: 5912.82577
+  dps: 404690.2577
+  tps: 364090.96122
+  hps: 7104.07841
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-InscribedBagofHydra-Spawn-96828"
  value: {
-  dps: 372914.98692
-  tps: 341589.11787
-  hps: 5694.99148
+  dps: 376600.67025
+  tps: 344478.11972
+  hps: 6769.78144
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-InsigniaofKypariZar-84078"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-IronBellyWok-89083"
  value: {
-  dps: 384237.81748
-  tps: 351139.20814
-  hps: 5717.82579
+  dps: 387337.8387
+  tps: 353493.82886
+  hps: 6931.33743
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-IronProtectorTalisman-85181"
  value: {
-  dps: 373516.31028
-  tps: 342111.53953
-  hps: 5788.15111
+  dps: 376740.85663
+  tps: 344645.86795
+  hps: 6965.64187
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-JadeBanditFigurine-86772"
  value: {
-  dps: 377472.80987
-  tps: 345446.50554
-  hps: 5742.59349
+  dps: 381554.19108
+  tps: 348687.80616
+  hps: 6876.54031
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-JadeCharioteerFigurine-86771"
  value: {
-  dps: 383488.07225
-  tps: 350643.7849
-  hps: 5742.59349
+  dps: 387666.03277
+  tps: 353970.40648
+  hps: 6876.54031
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-JadeCourtesanFigurine-86774"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-JadeMagistrateFigurine-86773"
  value: {
-  dps: 377609.0334
-  tps: 345720.96753
-  hps: 5725.22548
+  dps: 380816.86649
+  tps: 348120.87641
+  hps: 6924.88863
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-JadeWarlordFigurine-86775"
  value: {
-  dps: 376662.44464
-  tps: 345308.61467
-  hps: 5821.06314
+  dps: 379559.54554
+  tps: 347429.28849
+  hps: 7031.69987
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Ji-Kun'sRisingWinds-96843"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Juggernaut'sFocusingCrystal-105514"
  value: {
-  dps: 374151.40522
-  tps: 342806.444
-  hps: 16363.38706
+  dps: 376695.60225
+  tps: 344637.34294
+  hps: 17792.33057
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Kardris'ToxicTotem-105540"
  value: {
-  dps: 391229.1105
-  tps: 359905.50902
-  hps: 5656.02799
+  dps: 394754.95259
+  tps: 362668.09083
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-KnightlyBadgeoftheShieldwall-93349"
  value: {
-  dps: 381986.45983
-  tps: 349969.99488
-  hps: 5656.02799
+  dps: 385309.00061
+  tps: 352511.46415
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-KnotofTenSongs-84073"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Kor'kronBookofHurting-92785"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Lao-Chin'sLiquidCourage-89079"
  value: {
-  dps: 377129.91371
-  tps: 345813.0962
-  hps: 5854.06974
+  dps: 379855.62695
+  tps: 347718.96121
+  hps: 7053.62641
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-LeiShen'sFinalOrders-87072"
  value: {
-  dps: 387900.66187
-  tps: 354355.71756
-  hps: 5803.92947
+  dps: 390704.45876
+  tps: 356208.86982
+  hps: 6909.1921
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-LessonsoftheDarkmaster-81268"
  value: {
-  dps: 382191.14672
-  tps: 348743.24275
-  hps: 5656.02799
+  dps: 385524.18682
+  tps: 351229.58719
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-LightdrinkerIdolofRage-101200"
  value: {
-  dps: 377579.51891
-  tps: 346214.65023
-  hps: 5656.02799
+  dps: 380731.11485
+  tps: 348600.51802
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-LightdrinkerStoneofRage-101203"
  value: {
-  dps: 378410.23626
-  tps: 347061.54714
-  hps: 5656.02799
+  dps: 381674.54759
+  tps: 349556.54881
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-LightoftheCosmos-87065"
  value: {
-  dps: 377945.16142
-  tps: 346170.70463
-  hps: 5803.92947
+  dps: 380357.55355
+  tps: 347712.8696
+  hps: 6909.1921
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-LightweaveEmbroidery(Rank3)-4892"
  value: {
-  dps: 419240.82495
-  tps: 379709.55522
-  hps: 5840.22132
+  dps: 425178.15865
+  tps: 384466.88163
+  hps: 7179.66283
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-LordBlastington'sScopeofDoom-4699"
  value: {
-  dps: 391448.36233
-  tps: 355794.70656
-  hps: 19.33643
+  dps: 395655.5331
+  tps: 359133.06844
+  hps: 18.92445
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MalevolentGladiator'sBadgeofConquest-91452"
  value: {
-  dps: 374295.78353
-  tps: 342928.63808
-  hps: 5656.02799
+  dps: 377431.13749
+  tps: 345298.4283
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MalevolentGladiator'sBadgeofDominance-91753"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MalevolentGladiator'sBadgeofVictory-91763"
  value: {
-  dps: 380710.59729
-  tps: 348186.01553
-  hps: 5656.02799
+  dps: 384054.72229
+  tps: 350720.54531
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MalevolentGladiator'sEmblemofCruelty-91562"
  value: {
-  dps: 377096.08611
-  tps: 345451.23539
-  hps: 5775.25697
+  dps: 379946.44405
+  tps: 347524.04117
+  hps: 6960.39358
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MalevolentGladiator'sEmblemofMeditation-91564"
  value: {
-  dps: 373753.95992
-  tps: 342449.10992
-  hps: 5686.84721
+  dps: 376731.55284
+  tps: 344690.41008
+  hps: 6881.05336
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MalevolentGladiator'sEmblemofTenacity-91563"
  value: {
-  dps: 374884.59502
-  tps: 343472.14129
-  hps: 5865.04525
+  dps: 376355.52034
+  tps: 344228.19853
+  hps: 7038.65031
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MalevolentGladiator'sInsigniaofConquest-91457"
  value: {
-  dps: 374454.66314
-  tps: 343080.57481
-  hps: 5656.02799
+  dps: 377549.72863
+  tps: 345412.00183
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MalevolentGladiator'sInsigniaofDominance-91754"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MalevolentGladiator'sInsigniaofVictory-91768"
  value: {
-  dps: 383371.71125
-  tps: 350434.45049
-  hps: 5656.02799
+  dps: 386854.93442
+  tps: 353079.45533
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MarkoftheCatacombs-83731"
  value: {
-  dps: 378686.2516
-  tps: 347154.93644
-  hps: 5721.46475
+  dps: 381891.2035
+  tps: 349577.12853
+  hps: 6888.37448
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MarkoftheHardenedGrunt-92783"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MedallionofMystifyingVapors-93257"
  value: {
-  dps: 377858.63165
-  tps: 346535.03017
-  hps: 5656.02799
+  dps: 381155.63862
+  tps: 349068.77685
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MedallionoftheCatacombs-83734"
  value: {
-  dps: 376054.35452
-  tps: 344730.75304
-  hps: 5656.02799
+  dps: 379222.41719
+  tps: 347135.55543
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MendingBadgeoftheShieldwall-93348"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MirrorScope-4700"
  value: {
-  dps: 391448.36233
-  tps: 355794.70656
-  hps: 19.33643
+  dps: 395655.5331
+  tps: 359133.06844
+  hps: 18.92445
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MistdancerDefenderIdol-101089"
  value: {
-  dps: 373571.61909
-  tps: 342235.34669
-  hps: 5836.1363
+  dps: 376329.33003
+  tps: 344199.07298
+  hps: 7045.2337
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MistdancerDefenderStone-101087"
  value: {
-  dps: 377767.09377
-  tps: 346430.82137
-  hps: 5836.1363
+  dps: 380651.76414
+  tps: 348521.50709
+  hps: 7045.2337
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MistdancerIdolofRage-101113"
  value: {
-  dps: 377546.81461
-  tps: 346177.04649
-  hps: 5656.02799
+  dps: 380711.94999
+  tps: 348582.94633
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MistdancerStoneofRage-101117"
  value: {
-  dps: 378350.07973
-  tps: 347001.39061
-  hps: 5656.02799
+  dps: 381557.58032
+  tps: 349439.58153
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MistdancerStoneofWisdom-101107"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MithrilWristwatch-257884"
  value: {
-  dps: 378255.58076
-  tps: 346541.71121
-  hps: 5749.55152
+  dps: 381106.21361
+  tps: 348603.41363
+  hps: 6907.4355
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MountainsageIdolofDestruction-101069"
  value: {
-  dps: 379771.82364
-  tps: 348192.41455
-  hps: 5734.89588
+  dps: 382592.8407
+  tps: 349960.98438
+  hps: 6883.83448
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MountainsageStoneofDestruction-101072"
  value: {
-  dps: 378281.57563
-  tps: 346957.97415
-  hps: 5656.02799
+  dps: 381486.23268
+  tps: 349399.37092
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-NitroBoosts-4223"
  value: {
-  dps: 420508.23818
-  tps: 380768.93562
-  hps: 5901.06603
+  dps: 426052.44665
+  tps: 385231.85846
+  hps: 7176.03462
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-OathswornDefenderIdol-101303"
  value: {
-  dps: 373571.61909
-  tps: 342235.34669
-  hps: 5836.1363
+  dps: 376331.2062
+  tps: 344200.94915
+  hps: 7045.2337
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-OathswornDefenderStone-101306"
  value: {
-  dps: 377720.48246
-  tps: 346384.21006
-  hps: 5836.1363
+  dps: 380674.68514
+  tps: 348544.42809
+  hps: 7045.2337
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-OathswornIdolofBattle-101295"
  value: {
-  dps: 386088.87229
-  tps: 352954.62356
-  hps: 5744.2865
+  dps: 389523.27312
+  tps: 355528.69569
+  hps: 6907.4355
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-OathswornStoneofBattle-101294"
  value: {
-  dps: 384910.52437
-  tps: 352712.49322
-  hps: 5656.02799
+  dps: 388222.25723
+  tps: 355238.48711
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-PhaseFingers-4697"
  value: {
-  dps: 418850.88308
-  tps: 379401.64107
-  hps: 5856.61871
+  dps: 424742.11999
+  tps: 384119.04545
+  hps: 7191.96087
  }
 }
 dps_results: {
@@ -1489,1144 +1489,1144 @@ dps_results: {
 dps_results: {
  key: "TestFrostTwoHand-AllItems-PouchofWhiteAsh-103639"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-PowerfulPrimalDiamond"
  value: {
-  dps: 399935.87109
-  tps: 360302.4385
-  hps: 5912.82577
+  dps: 404690.2577
+  tps: 364090.96122
+  hps: 7104.07841
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-PriceofProgress-81266"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-PridefulGladiator'sBadgeofConquest-103342"
  value: {
-  dps: 374541.04126
-  tps: 343149.21021
-  hps: 5656.02799
+  dps: 377674.70205
+  tps: 345516.35297
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-PridefulGladiator'sBadgeofDominance-103505"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-PridefulGladiator'sBadgeofVictory-103511"
  value: {
-  dps: 387267.62564
-  tps: 353549.60114
-  hps: 5656.02799
+  dps: 390830.91645
+  tps: 356257.2526
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-PridefulGladiator'sEmblemofCruelty-103407"
  value: {
-  dps: 380389.40531
-  tps: 348328.60609
-  hps: 5839.45867
+  dps: 383282.54306
+  tps: 350494.40112
+  hps: 7043.13965
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-PridefulGladiator'sEmblemofMeditation-103409"
  value: {
-  dps: 373753.95992
-  tps: 342449.10992
-  hps: 5686.84721
+  dps: 376731.55284
+  tps: 344690.41008
+  hps: 6881.05336
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-PridefulGladiator'sEmblemofTenacity-103408"
  value: {
-  dps: 374949.10688
-  tps: 343614.25836
-  hps: 5985.52969
+  dps: 375973.95951
+  tps: 343796.1272
+  hps: 7203.85589
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-PridefulGladiator'sInsigniaofConquest-103347"
  value: {
-  dps: 374726.22123
-  tps: 343311.07189
-  hps: 5656.02799
+  dps: 377767.10405
+  tps: 345589.7125
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-PridefulGladiator'sInsigniaofDominance-103506"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-PridefulGladiator'sInsigniaofVictory-103516"
  value: {
-  dps: 392670.90594
-  tps: 358150.91656
-  hps: 5656.02799
+  dps: 396512.82783
+  tps: 361085.44007
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Primordius'TalismanofRage-96873"
  value: {
-  dps: 391679.40023
-  tps: 358032.63581
-  hps: 5802.93122
+  dps: 395348.05098
+  tps: 361080.66215
+  hps: 6969.61431
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-PrismaticPrisonofPride-105474"
  value: {
-  dps: 390865.37311
-  tps: 359015.59039
-  hps: 5849.78087
+  dps: 394643.69981
+  tps: 361605.99999
+  hps: 7140.73751
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-PurifiedBindingsofImmerseus-105422"
  value: {
-  dps: 390865.37311
-  tps: 359015.59039
-  hps: 5849.78087
+  dps: 394643.69981
+  tps: 361605.99999
+  hps: 7140.73751
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Qian-Le,CourageofNiuzao-102245"
  value: {
-  dps: 384317.66927
-  tps: 346818.5994
-  hps: 5797.23794
+  dps: 386860.87089
+  tps: 348433.45875
+  hps: 6838.2544
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Qian-Ying,FortitudeofNiuzao-102250"
  value: {
-  dps: 391374.54592
-  tps: 352880.45109
-  hps: 5742.60804
+  dps: 394215.97328
+  tps: 354865.85766
+  hps: 6783.47883
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Qin-xi'sPolarizingSeal-87075"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-RelicofChi-Ji-79330"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-RelicofKypariZar-84075"
  value: {
-  dps: 376912.98917
-  tps: 345043.14192
-  hps: 5799.15338
+  dps: 381329.94556
+  tps: 348599.11533
+  hps: 6962.69228
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-RelicofNiuzao-79329"
  value: {
-  dps: 373536.78265
-  tps: 342182.95268
-  hps: 5821.06314
+  dps: 376331.2062
+  tps: 344200.94915
+  hps: 7031.69987
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-RelicofXuen-79327"
  value: {
-  dps: 386566.6675
-  tps: 353276.10451
-  hps: 5656.02799
+  dps: 390011.87365
+  tps: 355907.46501
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-RelicofXuen-79328"
  value: {
-  dps: 374403.00304
-  tps: 343023.57388
-  hps: 5656.02799
+  dps: 377582.37872
+  tps: 345435.67788
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-RelicofYu'lon-79331"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Renataki'sSoulCharm-96741"
  value: {
-  dps: 374565.27538
-  tps: 343176.30292
-  hps: 5656.02799
+  dps: 377539.15813
+  tps: 345369.37044
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-ResolveofNiuzao-103990"
  value: {
-  dps: 379328.07631
-  tps: 348004.47483
-  hps: 5656.02799
+  dps: 382571.12631
+  tps: 350484.26455
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-ReverberatingPrimalDiamond"
  value: {
-  dps: 408477.43745
-  tps: 368666.08035
-  hps: 5965.7558
+  dps: 413316.27022
+  tps: 372468.01191
+  hps: 7140.28046
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-RevitalizingPrimalDiamond"
  value: {
-  dps: 407122.97786
-  tps: 367501.33241
-  hps: 5965.7558
+  dps: 411936.73556
+  tps: 371282.95247
+  hps: 7140.28046
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-RuneofCinderglacier-3369"
  value: {
-  dps: 398231.456
-  tps: 362577.80023
-  hps: 19.33643
+  dps: 401966.36406
+  tps: 365443.89939
+  hps: 18.92445
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-RuneofRazorice-3370"
  value: {
-  dps: 412795.22184
-  tps: 377141.56607
-  hps: 19.33643
+  dps: 418305.36868
+  tps: 381782.90402
+  hps: 18.92445
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-RuneofRe-Origination-96918"
  value: {
-  dps: 382314.5152
-  tps: 349222.21567
-  hps: 5775.33705
+  dps: 385728.61863
+  tps: 351661.99824
+  hps: 6941.30848
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-RuneofSpellbreaking-3595"
  value: {
-  dps: 391749.28794
-  tps: 356066.95284
-  hps: 18.99489
+  dps: 395026.06591
+  tps: 358466.78417
+  hps: 19.08704
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-RuneofSpellshattering-3367"
  value: {
-  dps: 392638.87219
-  tps: 356965.77332
-  hps: 18.99489
+  dps: 395133.2414
+  tps: 358560.34668
+  hps: 19.08704
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-RuneofSwordbreaking-3594"
  value: {
-  dps: 391448.36233
-  tps: 355794.70656
-  hps: 19.33643
+  dps: 395655.5331
+  tps: 359133.06844
+  hps: 18.92445
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-RuneofSwordshattering-3365"
  value: {
-  dps: 391448.36233
-  tps: 355794.70656
-  hps: 19.33643
+  dps: 395655.5331
+  tps: 359133.06844
+  hps: 18.92445
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-RuneoftheNerubianCarapace-3883"
  value: {
-  dps: 392000.31675
-  tps: 356325.66551
-  hps: 18.99489
+  dps: 395274.36497
+  tps: 358733.13539
+  hps: 19.08704
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-RuneoftheStoneskinGargoyle-3847"
  value: {
-  dps: 391664.572
-  tps: 355990.32869
-  hps: 18.99489
+  dps: 395268.47743
+  tps: 358714.24576
+  hps: 19.08704
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SI:7Operative'sManual-92784"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-ScrollofReveredAncestors-89080"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SearingWords-81267"
  value: {
-  dps: 377599.71837
-  tps: 345936.64413
-  hps: 5736.50768
+  dps: 380383.72239
+  tps: 347933.46837
+  hps: 6895.89595
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Shock-ChargerMedallion-93259"
  value: {
-  dps: 378169.07255
-  tps: 346319.72677
-  hps: 5790.74744
+  dps: 380872.98028
+  tps: 348275.62937
+  hps: 6956.59374
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SigilofCompassion-83736"
  value: {
-  dps: 376000.23961
-  tps: 344672.20306
-  hps: 5656.02799
+  dps: 379222.41719
+  tps: 347135.55543
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SigilofDevotion-83740"
  value: {
-  dps: 378749.89123
-  tps: 347218.57607
-  hps: 5721.46475
+  dps: 381899.36179
+  tps: 349585.28682
+  hps: 6888.37448
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SigilofFidelity-83737"
  value: {
-  dps: 377290.25138
-  tps: 345321.36309
-  hps: 5814.77258
+  dps: 382268.49557
+  tps: 349564.22258
+  hps: 6993.7656
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SigilofGrace-83738"
  value: {
-  dps: 376415.71297
-  tps: 344576.20909
-  hps: 5722.42513
+  dps: 381245.05146
+  tps: 348551.31248
+  hps: 6931.37762
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SigilofKypariZar-84076"
  value: {
-  dps: 378885.19018
-  tps: 347333.44385
-  hps: 5725.22548
+  dps: 381950.56159
+  tps: 349607.77531
+  hps: 6892.13521
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SigilofPatience-83739"
  value: {
-  dps: 376535.61786
-  tps: 345212.01638
-  hps: 5656.02799
+  dps: 379728.30315
+  tps: 347641.44138
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SigilofRampage-105580"
  value: {
-  dps: 374671.95934
-  tps: 343233.72762
-  hps: 5656.02799
+  dps: 377838.88052
+  tps: 345635.29678
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SigiloftheCatacombs-83732"
  value: {
-  dps: 378083.43642
-  tps: 346052.17933
-  hps: 5791.72414
+  dps: 382911.60275
+  tps: 349942.65968
+  hps: 7014.85828
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SinisterPrimalDiamond"
  value: {
-  dps: 400861.92284
-  tps: 361138.54029
-  hps: 5902.30141
+  dps: 405699.95982
+  tps: 364953.71876
+  hps: 7070.48112
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Skeer'sBloodsoakedTalisman-105632"
  value: {
-  dps: 399067.73509
-  tps: 363970.85168
-  hps: 5890.53134
+  dps: 403622.42648
+  tps: 367774.59683
+  hps: 7082.83942
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SkullrenderMedallion-93256"
  value: {
-  dps: 385861.36002
-  tps: 352843.92773
-  hps: 5734.25124
+  dps: 389346.37258
+  tps: 355510.44545
+  hps: 6961.74382
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SoothingTalismanoftheShado-PanAssault-94509"
  value: {
-  dps: 373436.66427
-  tps: 342169.50676
-  hps: 5717.5804
+  dps: 376804.90635
+  tps: 344656.58221
+  hps: 6852.91006
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SoulBarrier-96927"
  value: {
-  dps: 374619.42251
-  tps: 343301.939
-  hps: 6019.287
+  dps: 376770.01051
+  tps: 344607.05216
+  hps: 7210.57829
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SparkofZandalar-96770"
  value: {
-  dps: 388278.72453
-  tps: 355846.5228
-  hps: 5790.94291
+  dps: 391331.12491
+  tps: 357787.00306
+  hps: 6911.1206
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SpiritsoftheSun-87163"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SpringrainIdolofDestruction-101023"
  value: {
-  dps: 378865.67936
-  tps: 347015.95333
-  hps: 5751.12277
+  dps: 382033.82452
+  tps: 349310.7956
+  hps: 6912.9483
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SpringrainIdolofRage-101009"
  value: {
-  dps: 377551.64962
-  tps: 346181.20264
-  hps: 5656.02799
+  dps: 380741.76698
+  tps: 348609.60711
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SpringrainStoneofDestruction-101026"
  value: {
-  dps: 378308.46166
-  tps: 346984.86018
-  hps: 5656.02799
+  dps: 381504.37099
+  tps: 349417.50922
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SpringrainStoneofRage-101012"
  value: {
-  dps: 378418.14956
-  tps: 347069.46045
-  hps: 5656.02799
+  dps: 381672.87027
+  tps: 349554.87148
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SpringrainStoneofWisdom-101041"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Static-Caster'sMedallion-93254"
  value: {
-  dps: 378169.07255
-  tps: 346319.72677
-  hps: 5790.74744
+  dps: 380872.98028
+  tps: 348275.62937
+  hps: 6956.59374
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SteadfastFootman'sMedallion-92782"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SteadfastTalismanoftheShado-PanAssault-94507"
  value: {
-  dps: 378729.99252
-  tps: 347406.39104
-  hps: 5656.02799
+  dps: 381959.34291
+  tps: 349872.48115
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-StreamtalkerIdolofDestruction-101222"
  value: {
-  dps: 378898.58667
-  tps: 347142.28362
-  hps: 5755.92014
+  dps: 383756.74227
+  tps: 351036.31737
+  hps: 6907.87557
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-StreamtalkerIdolofRage-101217"
  value: {
-  dps: 377592.85481
-  tps: 346228.90545
-  hps: 5656.02799
+  dps: 380741.25853
+  tps: 348612.92919
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-StreamtalkerStoneofDestruction-101225"
  value: {
-  dps: 378224.18656
-  tps: 346900.58508
-  hps: 5656.02799
+  dps: 381457.77586
+  tps: 349370.9141
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-StreamtalkerStoneofRage-101220"
  value: {
-  dps: 378371.3489
-  tps: 347022.65979
-  hps: 5656.02799
+  dps: 381588.65217
+  tps: 349470.65338
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-StreamtalkerStoneofWisdom-101250"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-StuffofNightmares-87160"
  value: {
-  dps: 378204.30835
-  tps: 346880.70687
-  hps: 5656.02799
+  dps: 381421.61751
+  tps: 349334.75574
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SunsoulDefenderIdol-101160"
  value: {
-  dps: 373571.61909
-  tps: 342235.34669
-  hps: 5836.1363
+  dps: 376331.2062
+  tps: 344200.94915
+  hps: 7045.2337
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SunsoulDefenderStone-101163"
  value: {
-  dps: 377863.44839
-  tps: 346527.17599
-  hps: 5836.1363
+  dps: 380677.18687
+  tps: 348546.92982
+  hps: 7045.2337
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SunsoulIdolofBattle-101152"
  value: {
-  dps: 386337.53823
-  tps: 353168.25596
-  hps: 5744.2865
+  dps: 389716.09467
+  tps: 355656.91728
+  hps: 6907.4355
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SunsoulStoneofBattle-101151"
  value: {
-  dps: 384907.31455
-  tps: 352709.2834
-  hps: 5656.02799
+  dps: 388284.73361
+  tps: 355300.96349
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SunsoulStoneofWisdom-101138"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SwordguardEmbroidery(Rank3)-4894"
  value: {
-  dps: 422070.41659
-  tps: 382040.40223
-  hps: 5840.22132
+  dps: 428164.59599
+  tps: 386917.59851
+  hps: 7179.66283
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SymboloftheCatacombs-83735"
  value: {
-  dps: 378977.66052
-  tps: 347274.91015
-  hps: 5717.93065
+  dps: 382115.94934
+  tps: 349629.65638
+  hps: 6872.99052
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SynapseSprings(MarkII)-4898"
  value: {
-  dps: 421762.31496
-  tps: 381765.52545
-  hps: 5856.61871
+  dps: 427795.49372
+  tps: 386589.40444
+  hps: 7191.96087
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-TalismanofBloodlust-96864"
  value: {
-  dps: 377076.74283
-  tps: 344831.4573
-  hps: 5780.78974
+  dps: 380862.14891
+  tps: 347982.54204
+  hps: 6944.50177
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-TerrorintheMists-87167"
  value: {
-  dps: 381000.88069
-  tps: 348091.63854
-  hps: 5824.36394
+  dps: 385120.9581
+  tps: 351335.95586
+  hps: 7034.90706
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Thok'sAcid-GroovedTooth-105607"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Thok'sTailTip-105609"
  value: {
-  dps: 417700.30844
-  tps: 378918.97109
-  hps: 5849.78087
+  dps: 421742.5472
+  tps: 381567.49909
+  hps: 7140.73751
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Thousand-YearPickledEgg-257881"
  value: {
-  dps: 375066.47708
-  tps: 343068.26426
-  hps: 5726.81025
+  dps: 379999.0285
+  tps: 347354.14648
+  hps: 6898.68564
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-TickingEbonDetonator-105612"
  value: {
-  dps: 382149.85777
-  tps: 350705.90249
-  hps: 5667.31019
+  dps: 385365.12589
+  tps: 353159.66053
+  hps: 6828.61387
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Time-LostArtifact-103678"
  value: {
-  dps: 382351.10928
-  tps: 350155.80827
-  hps: 5774.77107
+  dps: 383709.47067
+  tps: 350582.88234
+  hps: 6901.0361
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-TrailseekerIdolofRage-101054"
  value: {
-  dps: 377605.19171
-  tps: 346237.2259
-  hps: 5656.02799
+  dps: 380835.25139
+  tps: 348702.78692
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-TrailseekerStoneofRage-101057"
  value: {
-  dps: 378335.20195
-  tps: 346986.51284
-  hps: 5656.02799
+  dps: 381590.41729
+  tps: 349472.4185
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-TyrannicalGladiator'sBadgeofConquest-100043"
  value: {
-  dps: 374337.88928
-  tps: 342968.33878
-  hps: 5656.02799
+  dps: 377480.41977
+  tps: 345346.37444
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-TyrannicalGladiator'sBadgeofDominance-100016"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-TyrannicalGladiator'sBadgeofVictory-100019"
  value: {
-  dps: 382066.17662
-  tps: 349294.86628
-  hps: 5656.02799
+  dps: 385455.61127
+  tps: 351865.18669
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-TyrannicalGladiator'sEmblemofCruelty-100066"
  value: {
-  dps: 377997.1411
-  tps: 346258.44682
-  hps: 5795.71618
+  dps: 380665.14301
+  tps: 348159.91018
+  hps: 6975.43651
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-TyrannicalGladiator'sEmblemofMeditation-99990"
  value: {
-  dps: 373753.95992
-  tps: 342449.10992
-  hps: 5686.84721
+  dps: 376731.55284
+  tps: 344690.41008
+  hps: 6881.05336
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-TyrannicalGladiator'sEmblemofTenacity-100092"
  value: {
-  dps: 375344.20021
-  tps: 343973.37305
-  hps: 5885.44458
+  dps: 376448.51833
+  tps: 344315.59447
+  hps: 7071.05561
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-TyrannicalGladiator'sInsigniaofConquest-100026"
  value: {
-  dps: 374535.42807
-  tps: 343154.46521
-  hps: 5656.02799
+  dps: 377560.46248
+  tps: 345416.46999
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-TyrannicalGladiator'sInsigniaofDominance-100152"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-TyrannicalGladiator'sInsigniaofVictory-100085"
  value: {
-  dps: 385244.14181
-  tps: 351956.30052
-  hps: 5656.02799
+  dps: 388713.87072
+  tps: 354643.12405
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-TyrannicalPrimalDiamond"
  value: {
-  dps: 399885.52373
-  tps: 360309.96058
-  hps: 5881.80466
+  dps: 404631.04518
+  tps: 364041.23633
+  hps: 7041.16898
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-UnerringVisionofLeiShen-96930"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-VaporshieldMedallion-93262"
  value: {
-  dps: 377858.63165
-  tps: 346535.03017
-  hps: 5656.02799
+  dps: 381155.63862
+  tps: 349068.77685
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-VialofDragon'sBlood-87063"
  value: {
-  dps: 377893.44802
-  tps: 346565.41148
-  hps: 5656.02799
+  dps: 381157.58467
+  tps: 349070.72291
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-VialofIchorousBlood-100963"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-VialofLivingCorruption-105568"
  value: {
-  dps: 374784.86177
-  tps: 343440.20192
-  hps: 6075.17691
+  dps: 376404.85549
+  tps: 344233.51731
+  hps: 7342.04652
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-ViciousTalismanoftheShado-PanAssault-94511"
  value: {
-  dps: 374591.70714
-  tps: 343174.78811
-  hps: 5656.02799
+  dps: 377785.72131
+  tps: 345591.64497
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-VisionofthePredator-81192"
  value: {
-  dps: 378192.97548
-  tps: 346062.41401
-  hps: 5732.74695
+  dps: 381290.33401
+  tps: 348331.07959
+  hps: 6930.71006
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-VolatileTalismanoftheShado-PanAssault-94510"
  value: {
-  dps: 374797.26095
-  tps: 343126.42907
-  hps: 5749.5683
+  dps: 380683.41656
+  tps: 347835.09375
+  hps: 6935.54462
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-WindsweptPages-81125"
  value: {
-  dps: 376102.21976
-  tps: 344003.97719
-  hps: 5749.68397
+  dps: 381275.06209
+  tps: 348251.15156
+  hps: 6903.7033
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-WoundripperMedallion-93253"
  value: {
-  dps: 378450.87963
-  tps: 346424.68891
-  hps: 5734.25124
+  dps: 381879.84978
+  tps: 349053.34158
+  hps: 6961.74382
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Wushoolay'sFinalChoice-96785"
  value: {
-  dps: 374112.15612
-  tps: 342788.55464
-  hps: 5656.02799
+  dps: 377235.73111
+  tps: 345148.86935
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Xing-Ho,BreathofYu'lon-102246"
  value: {
-  dps: 385766.33542
-  tps: 348689.06196
-  hps: 5778.46115
+  dps: 389222.91011
+  tps: 350672.15007
+  hps: 6902.50698
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Yu'lon'sBite-103987"
  value: {
-  dps: 382682.82094
-  tps: 349457.2056
-  hps: 5850.83396
+  dps: 386205.23033
+  tps: 352228.46216
+  hps: 7060.27502
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-ZenAlchemistStone-75274"
  value: {
-  dps: 385915.66406
-  tps: 352952.51294
-  hps: 5656.02799
+  dps: 389386.9927
+  tps: 355600.26562
+  hps: 6821.0924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Average-Default"
  value: {
-  dps: 424517.00638
-  tps: 384044.15439
-  hps: 5656.8646
+  dps: 428826.34909
+  tps: 387193.55875
+  hps: 6858.33259
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-DefaultTalents-Basic-obliterate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.5260551489e+06
-  tps: 1.48691663465e+06
-  hps: 5121.19666
+  dps: 1.55888998392e+06
+  tps: 1.51868836191e+06
+  hps: 13033.91445
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-DefaultTalents-Basic-obliterate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 420024.80961
-  tps: 380706.99231
-  hps: 5869.19658
+  dps: 425873.78903
+  tps: 385063.82114
+  hps: 7105.05317
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-DefaultTalents-Basic-obliterate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 604809.25018
-  tps: 452388.09824
-  hps: 6730.57646
+  dps: 620626.21935
+  tps: 461535.89675
+  hps: 8248.83983
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-DefaultTalents-Basic-obliterate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.08712114097e+06
-  tps: 1.06338040611e+06
-  hps: 4357.57974
+  dps: 1.10365481238e+06
+  tps: 1.07934480521e+06
+  hps: 11356.5557
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-DefaultTalents-Basic-obliterate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 328599.80932
-  tps: 304056.35104
-  hps: 5067.52555
+  dps: 331309.95263
+  tps: 306614.90762
+  hps: 6109.77253
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-DefaultTalents-Basic-obliterate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 402930.39754
-  tps: 316222.13388
-  hps: 5391.78116
+  dps: 410231.95311
+  tps: 322583.70757
+  hps: 6660.47885
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RoilingBlood-Basic-obliterate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.4975675428e+06
-  tps: 1.45834337016e+06
-  hps: 5249.73882
+  dps: 1.52946978176e+06
+  tps: 1.48920861793e+06
+  hps: 12860.12244
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RoilingBlood-Basic-obliterate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 425918.88252
-  tps: 386574.51499
-  hps: 5971.69168
+  dps: 432617.79704
+  tps: 391820.57311
+  hps: 7282.50942
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RoilingBlood-Basic-obliterate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 612460.60834
-  tps: 459938.99598
-  hps: 6879.3127
+  dps: 630507.66945
+  tps: 471698.98593
+  hps: 8447.03496
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RoilingBlood-Basic-obliterate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.06291599384e+06
-  tps: 1.03920273833e+06
-  hps: 4532.44381
+  dps: 1.08236304471e+06
+  tps: 1.05812998009e+06
+  hps: 11233.6254
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RoilingBlood-Basic-obliterate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 339317.44054
-  tps: 314416.38246
-  hps: 5136.6058
+  dps: 344295.07642
+  tps: 319244.78161
+  hps: 6239.98745
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RoilingBlood-Basic-obliterate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 412733.871
-  tps: 325240.65892
-  hps: 5494.77389
+  dps: 419829.33755
+  tps: 331744.62205
+  hps: 6761.90245
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RunicCorruption-Basic-obliterate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.46997937863e+06
-  tps: 1.4308680192e+06
-  hps: 5096.29791
+  dps: 1.50799528929e+06
+  tps: 1.46758604497e+06
+  hps: 12445.82511
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RunicCorruption-Basic-obliterate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 415736.73911
-  tps: 376435.52484
-  hps: 5847.12781
+  dps: 421876.39176
+  tps: 381260.87419
+  hps: 7146.38527
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RunicCorruption-Basic-obliterate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 599257.1791
-  tps: 447192.80945
-  hps: 6715.94406
+  dps: 618948.38899
+  tps: 460475.7455
+  hps: 8390.62397
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RunicCorruption-Basic-obliterate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.05400944377e+06
-  tps: 1.0301694914e+06
-  hps: 4379.15308
+  dps: 1.08632970977e+06
+  tps: 1.06168402701e+06
+  hps: 10891.14854
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RunicCorruption-Basic-obliterate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 326937.63554
-  tps: 302346.73592
-  hps: 5082.4086
+  dps: 328355.62067
+  tps: 303545.5919
+  hps: 6046.12727
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RunicCorruption-Basic-obliterate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 399034.21859
-  tps: 312498.84453
-  hps: 5390.21204
+  dps: 409660.30464
+  tps: 322035.41826
+  hps: 6717.46714
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RunicEmpowerment-Basic-obliterate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.5333661342e+06
-  tps: 1.49404035004e+06
-  hps: 5091.48537
+  dps: 1.57221054579e+06
+  tps: 1.53127408628e+06
+  hps: 13117.19536
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RunicEmpowerment-Basic-obliterate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 416646.97785
-  tps: 377184.58937
-  hps: 5861.73564
+  dps: 421386.99189
+  tps: 380491.32337
+  hps: 7061.71394
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RunicEmpowerment-Basic-obliterate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 603877.59912
-  tps: 451184.63764
-  hps: 6879.91802
+  dps: 617315.50662
+  tps: 457866.92905
+  hps: 8384.15431
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RunicEmpowerment-Basic-obliterate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.08915459038e+06
-  tps: 1.06542151961e+06
-  hps: 4327.18598
+  dps: 1.11242550923e+06
+  tps: 1.08796378801e+06
+  hps: 11510.19358
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RunicEmpowerment-Basic-obliterate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 325878.42478
-  tps: 301497.57749
-  hps: 5049.78475
+  dps: 327733.35493
+  tps: 303058.13229
+  hps: 6051.49562
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RunicEmpowerment-Basic-obliterate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 400401.7766
-  tps: 314252.437
-  hps: 5295.23155
+  dps: 410235.20041
+  tps: 322831.16535
+  hps: 6695.3328
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-UnholyBlight-Basic-obliterate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.50731690462e+06
-  tps: 1.4681346958e+06
-  hps: 5233.68004
+  dps: 1.53812166628e+06
+  tps: 1.49791274586e+06
+  hps: 12887.52395
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-UnholyBlight-Basic-obliterate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 428173.43372
-  tps: 388691.29592
-  hps: 6001.86265
+  dps: 433570.88707
+  tps: 392830.39337
+  hps: 7244.50295
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-UnholyBlight-Basic-obliterate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 615037.55494
-  tps: 462540.97457
-  hps: 6882.69886
+  dps: 631098.01269
+  tps: 472316.00106
+  hps: 8447.03496
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-UnholyBlight-Basic-obliterate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.07081315791e+06
-  tps: 1.04712693524e+06
-  hps: 4517.56076
+  dps: 1.09090759807e+06
+  tps: 1.06661779265e+06
+  hps: 11205.14792
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-UnholyBlight-Basic-obliterate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 339039.68981
-  tps: 314206.79531
-  hps: 5130.57648
+  dps: 342836.58346
+  tps: 317756.26105
+  hps: 6199.76515
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-UnholyBlight-Basic-obliterate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 412209.21599
-  tps: 324744.97067
-  hps: 5477.34691
+  dps: 421015.71326
+  tps: 332866.69211
+  hps: 6692.19455
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 386803.38586
-  tps: 349937.35183
-  hps: 5527.03718
+  dps: 390362.5633
+  tps: 352616.06805
+  hps: 6540.24108
  }
 }

--- a/sim/death_knight/items.go
+++ b/sim/death_knight/items.go
@@ -264,11 +264,14 @@ var ItemSetBattleplateOfCyclopeanDread = core.NewItemSet(core.ItemSet{
 					},
 				})
 			} else if dk.Spec == proto.Spec_SpecFrostDeathKnight {
+				// Frozen Power is missing both the "Suppress Weapon Effects" and "Suppress
+				// Caster Procs" flags in-game: WCL logs show it feeding MH weapon enchant
+				// procs (Fallen Crusader) and trinket triggers (Fusion-Fire Core cleave).
 				frozenPowerSpell := dk.RegisterSpell(core.SpellConfig{
 					ActionID:       core.ActionID{SpellID: 147620},
 					SpellSchool:    core.SpellSchoolFrost,
-					ProcMask:       core.ProcMaskEmpty,
-					Flags:          core.SpellFlagPassiveSpell | core.SpellFlagNoOnCastComplete | core.SpellFlagNoOnDamageDealt,
+					ProcMask:       core.ProcMaskMeleeMHSpecial | core.ProcMaskMeleeProc,
+					Flags:          core.SpellFlagPassiveSpell | core.SpellFlagNoOnCastComplete,
 					ClassSpellMask: DeathKnightSpellFrozenPower,
 
 					DamageMultiplier: 1,
@@ -287,8 +290,11 @@ var ItemSetBattleplateOfCyclopeanDread = core.NewItemSet(core.ItemSet{
 					}
 
 					dk.PillarOfFrostAura.AttachProcTrigger(core.ProcTrigger{
-						Callback:           core.CallbackOnSpellHitDealt,
-						ProcMask:           core.ProcMaskSpecial,
+						Callback: core.CallbackOnSpellHitDealt,
+						ProcMask: core.ProcMaskSpecial,
+						// Frozen Power carries ProcMaskMeleeProc so it can feed other proc
+						// systems, but it does not re-trigger itself (WCL-verified).
+						ProcMaskExclude:    core.ProcMaskProc,
 						Outcome:            core.OutcomeLanded,
 						RequireDamageDealt: true,
 

--- a/sim/death_knight/runeforging.go
+++ b/sim/death_knight/runeforging.go
@@ -253,7 +253,7 @@ func init() {
 
 			// Wowhead lists an 8ms proc cooldown on Razor Frost (50401), but it is not
 			// enforced in-game: logs show same-millisecond double procs from an OH auto +
-			// OH special (https://classic.warcraftlogs.com/reports/mjRP7htDnYNdLF31?fight=26&source=28)
+			// OH special (https://classic.warcraftlogs.com/reports/mjRP7htDnYNdLF31?fight=26&source=28&type=damage-done&view=events&start=9741342&end=9741442)
 			// and two T16 Frozen Power procs 1ms apart
 			// (https://classic.warcraftlogs.com/reports/6Mn3mZKPyjtrWVvT?fight=1&source=4).
 			aura := character.MakeProcTriggerAura(core.ProcTrigger{

--- a/sim/death_knight/runeforging.go
+++ b/sim/death_knight/runeforging.go
@@ -251,11 +251,15 @@ func init() {
 				continue
 			}
 
+			// Wowhead lists an 8ms proc cooldown on Razor Frost (50401), but it is not
+			// enforced in-game: logs show same-millisecond double procs from an OH auto +
+			// OH special (https://classic.warcraftlogs.com/reports/mjRP7htDnYNdLF31?fight=26&source=28)
+			// and two T16 Frozen Power procs 1ms apart
+			// (https://classic.warcraftlogs.com/reports/6Mn3mZKPyjtrWVvT?fight=1&source=4).
 			aura := character.MakeProcTriggerAura(core.ProcTrigger{
 				Name:     fmt.Sprintf("Razor Frost %s", itemSlot),
 				Callback: core.CallbackOnSpellHitDealt,
 				Outcome:  core.OutcomeLanded,
-				ICD:      time.Millisecond * 8,
 				ProcMask: procMask,
 				DPM:      dpm,
 				Handler: func(sim *core.Simulation, _ *core.Spell, result *core.SpellResult) {

--- a/sim/death_knight/unholy/TestUnholy.results
+++ b/sim/death_knight/unholy/TestUnholy.results
@@ -1713,8 +1713,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-RuneofRazorice-3370"
  value: {
-  dps: 398839.84757
-  tps: 287163.21603
+  dps: 398881.18184
+  tps: 287204.5503
   hps: 20.83558
  }
 }


### PR DESCRIPTION
The T16 Frost 4pc proc Frozen Power (147620) is missing both the "Suppress Weapon Effects" and "Suppress Caster Procs" flags in-game: WCL logs show it triggering Rune of the Fallen Crusader (verified via per-proc timestamp attribution and Pillar of Frost window clustering) and trinket effects (verified via Fusion-Fire Core cleave damage-copy matching). The sim registered it with `ProcMaskEmpty` + `SpellFlagNoOnDamageDealt`, so it could trigger nothing.

Fix: Frozen Power now carries `ProcMaskMeleeMHSpecial | ProcMaskMeleeProc` (rolls the Fallen Crusader enchant DPM at MH speed and feeds `ProcMaskProc`-accepting trinket listeners), with `ProcMaskExclude: ProcMaskProc` on the Pillar of Frost trigger so it cannot re-trigger itself.

Unholy Strength uptime from crawled SoO logs (Frost DKs with FC on MH, fights ≥90s; 4pc detected via Frozen Power presence, cross-validated against COMBATANT_INFO gear on Classic with zero mismatches):

| Group | n | US uptime | procs/min |
|---|---|---|---|
| MoP Classic heroic, 4pc | 10 | **72.5%** | **7.05** |
| MoP Classic heroic, 0–3pc | 732 | 59.7% | 4.19 |
| Retail heroic 2014, 4pc | 786 | **83.6%** | **9.03** |
| Retail heroic 2014, no 4pc | 13 | 57.5% | 4.31 |
| Retail normal 2013/14, 4pc | 702 | **81.0%** | **8.41** |
| Retail normal 2013/14, no 4pc | 191 | 71.9% | 5.91 |

Sim impact: masterfrost 80.0% → 87.1% uptime (6.51 → 9.15 procs/min), 2h-obliterate 93.5% → 95.5% (11.05 → 13.33), ≈ +1% DPS on both presets. The added +2.3–2.6 procs/min matches the log-derived estimate, and the fixed masterfrost numbers land on the retail 4pc dual-wield median (84.8% / 8.96).

---

**Also removes the 8ms ICD from the Razorice (Razor Frost 50401) trigger.** Wowhead lists an 8ms proc cooldown, but it is not enforced in-game: across 15 Razorice-OH players in crawled Classic SoO logs (8,059 procs), 64 inter-proc gaps are under 8ms — 28 at exactly 0ms (e.g. OH auto + Frost Strike OH in the same millisecond: [Coldcrush, Garrosh](https://classic.warcraftlogs.com/reports/mjRP7htDnYNdLF31?fight=26&source=28&type=damage-done&view=events&start=9741342&end=9741442)). A [training dummy log](https://classic.warcraftlogs.com/reports/6Mn3mZKPyjtrWVvT?fight=1&source=4) from a Razorice-MH + 4pc DK additionally shows both Frozen Power procs of a dual Obliterate each triggering their own Razor Frost 1ms apart (3 Razorice instances in one volley), confirming both the missing ICD and that Frozen Power acts as a main-hand weapon hit for enchant effects — which the composite proc mask above models correctly.
