### PR TITLE
Give Flurry of Xuen a proc mask so it can feed proc effects

### DIFF
--- a/sim/common/mop/cloaks_phase_4_54.go
+++ b/sim/common/mop/cloaks_phase_4_54.go
@@ -96,8 +96,11 @@ func init() {
 			flurryConfig := core.SpellConfig{
 				ActionID:    core.ActionID{SpellID: 147891},
 				SpellSchool: core.SpellSchoolPhysical,
-				ProcMask:    core.ProcMaskEmpty,
-				Flags:       core.SpellFlagNoOnCastComplete | core.SpellFlagPassiveSpell,
+				// Verified on classic logs: Flurry of Xuen hits feed proc effects
+				// (e.g. Haromm's Talisman Multistrike, RPPM stat procs) but not
+				// Stormlash, which only matches direct/special masks.
+				ProcMask: core.Ternary(character.Class == proto.Class_ClassHunter, core.ProcMaskRangedProc, core.ProcMaskMeleeProc),
+				Flags:    core.SpellFlagNoOnCastComplete | core.SpellFlagPassiveSpell,
 
 				DamageMultiplier: 1,
 				CritMultiplier:   character.DefaultCritMultiplier(),

--- a/sim/death_knight/blood/TestBlood.results
+++ b/sim/death_knight/blood/TestBlood.results
@@ -33,1774 +33,1774 @@ character_stats_results: {
 dps_results: {
  key: "TestBlood-AllItems-AgilePrimalDiamond"
  value: {
-  dps: 390455.05526
-  tps: 1.92900823158e+06
-  dtps: 169920.22055
-  hps: 188418.3512
+  dps: 391687.07073
+  tps: 1.9314308319e+06
+  dtps: 169474.45491
+  hps: 187813.51388
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-AlacrityofXuen-103989"
  value: {
-  dps: 404495.05328
-  tps: 1.97957377287e+06
-  dtps: 147269.19947
-  hps: 172797.60054
+  dps: 402206.19654
+  tps: 1.98935356709e+06
+  dtps: 147601.45738
+  hps: 171700.40358
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ArcaneBadgeoftheShieldwall-93347"
  value: {
-  dps: 387020.60218
-  tps: 1.90570902132e+06
-  dtps: 150730.59091
-  hps: 172453.33408
+  dps: 385828.36971
+  tps: 1.9140127503e+06
+  dtps: 150856.23883
+  hps: 170069.16767
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ArrowflightMedallion-93258"
  value: {
-  dps: 390900.44801
-  tps: 1.93183828541e+06
-  dtps: 151305.91937
-  hps: 172372.60624
+  dps: 390886.70601
+  tps: 1.93845162283e+06
+  dtps: 154456.74241
+  hps: 175668.51982
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-AssuranceofConsequence-105472"
  value: {
-  dps: 384160.72195
-  tps: 1.90440634829e+06
-  dtps: 151483.65125
-  hps: 174701.91835
+  dps: 384163.592
+  tps: 1.91103761085e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-AusterePrimalDiamond"
  value: {
-  dps: 387946.76035
-  tps: 1.91866030545e+06
-  dtps: 167343.2317
-  hps: 186808.9656
+  dps: 386986.00001
+  tps: 1.90745491943e+06
+  dtps: 167653.40513
+  hps: 187270.22067
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BadJuju-96781"
  value: {
-  dps: 382676.49237
-  tps: 1.89705572751e+06
-  dtps: 153237.81783
-  hps: 182231.38979
+  dps: 384072.02637
+  tps: 1.90001141696e+06
+  dtps: 154346.7537
+  hps: 181499.84087
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BadgeofKypariZar-84079"
  value: {
-  dps: 389131.66706
-  tps: 1.93623158278e+06
-  dtps: 151559.70092
-  hps: 177667.68338
+  dps: 388499.75829
+  tps: 1.92529154256e+06
+  dtps: 155140.90094
+  hps: 180862.76091
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BattlegearoftheLostCatacomb"
  value: {
-  dps: 357929.94983
-  tps: 1.873988001e+06
-  dtps: 183256.57307
-  hps: 177996.29174
+  dps: 355274.28906
+  tps: 1.85988099279e+06
+  dtps: 181536.90015
+  hps: 173352.10253
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BattleplateofCyclopeanDread"
  value: {
-  dps: 346778.24385
-  tps: 1.81902080261e+06
-  dtps: 178718.5835
-  hps: 192087.9784
+  dps: 348170.89731
+  tps: 1.82607542461e+06
+  dtps: 179926.03429
+  hps: 193931.44887
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BattleplateoftheAll-ConsumingMaw"
  value: {
-  dps: 381719.1475
-  tps: 1.90227278892e+06
-  dtps: 177705.48902
-  hps: 179149.80025
+  dps: 381631.37495
+  tps: 1.90389033426e+06
+  dtps: 177956.91925
+  hps: 176993.75374
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlackBloodofY'Shaarj-105648"
  value: {
-  dps: 393636.98157
-  tps: 1.95990351158e+06
-  dtps: 151144.0661
-  hps: 176083.82127
+  dps: 395457.76381
+  tps: 1.95512417637e+06
+  dtps: 149848.74031
+  hps: 173096.15365
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BlossomofPureSnow-89081"
  value: {
-  dps: 389779.61857
-  tps: 1.92869686026e+06
-  dtps: 151543.94728
-  hps: 172986.32867
+  dps: 389408.2722
+  tps: 1.93143711944e+06
+  dtps: 154768.73198
+  hps: 176146.71338
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BottleofInfiniteStars-87057"
  value: {
-  dps: 384538.02297
-  tps: 1.91346665062e+06
-  dtps: 152458.63988
-  hps: 181124.11637
+  dps: 383696.87119
+  tps: 1.90965050059e+06
+  dtps: 152325.08788
+  hps: 178684.83615
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BraidofTenSongs-84072"
  value: {
-  dps: 388263.45087
-  tps: 1.92566545799e+06
-  dtps: 151856.65192
-  hps: 172761.63573
+  dps: 388975.90154
+  tps: 1.92351425989e+06
+  dtps: 148843.73079
+  hps: 172542.57944
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Brawler'sStatue-257885"
  value: {
-  dps: 390251.69291
-  tps: 1.93891809464e+06
-  dtps: 149955.11052
-  hps: 173362.68053
+  dps: 390626.8559
+  tps: 1.93859272295e+06
+  dtps: 150521.53269
+  hps: 172520.16455
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BreathoftheHydra-96827"
  value: {
-  dps: 392643.51048
-  tps: 1.93463855071e+06
-  dtps: 151222.09069
-  hps: 175309.82002
+  dps: 392940.80299
+  tps: 1.94368331028e+06
+  dtps: 151285.71452
+  hps: 174648.34338
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BroochofMunificentDeeds-87500"
  value: {
-  dps: 384992.99934
-  tps: 1.91481090639e+06
-  dtps: 151353.21563
-  hps: 175218.28126
+  dps: 383328.79359
+  tps: 1.90561893957e+06
+  dtps: 154825.28761
+  hps: 178903.97104
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BrutalTalismanoftheShado-PanAssault-94508"
  value: {
-  dps: 402326.71241
-  tps: 1.97363718653e+06
-  dtps: 148899.29263
-  hps: 174435.33131
+  dps: 399675.99853
+  tps: 1.96726836742e+06
+  dtps: 147984.60027
+  hps: 173364.3393
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BurningPrimalDiamond"
  value: {
-  dps: 390394.33821
-  tps: 1.9286201563e+06
-  dtps: 169920.22055
-  hps: 188418.3512
+  dps: 391628.93685
+  tps: 1.93106083882e+06
+  dtps: 169474.45491
+  hps: 187813.51388
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CapacitivePrimalDiamond"
  value: {
-  dps: 409166.29963
-  tps: 2.07557884718e+06
-  dtps: 170131.61878
-  hps: 189318.31542
+  dps: 409217.39804
+  tps: 2.07119815202e+06
+  dtps: 170888.77034
+  hps: 188047.7631
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CarbonicCarbuncle-81138"
  value: {
-  dps: 392593.31813
-  tps: 1.9419492083e+06
-  dtps: 149812.944
-  hps: 173761.0041
+  dps: 392223.85133
+  tps: 1.93145622076e+06
+  dtps: 152039.23785
+  hps: 173778.45842
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Cha-Ye'sEssenceofBrilliance-96888"
  value: {
-  dps: 393667.92478
-  tps: 1.9544870989e+06
-  dtps: 151487.09957
-  hps: 174318.92188
+  dps: 393031.66173
+  tps: 1.95534730406e+06
+  dtps: 153994.24809
+  hps: 175364.79499
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CharmofTenSongs-84071"
  value: {
-  dps: 395178.78548
-  tps: 1.95490097574e+06
-  dtps: 152050.15078
-  hps: 171669.14047
+  dps: 395875.43497
+  tps: 1.94733957201e+06
+  dtps: 151605.36734
+  hps: 170835.00969
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CommunalIdolofDestruction-101168"
  value: {
-  dps: 388010.15782
-  tps: 1.91633598674e+06
-  dtps: 152938.23203
-  hps: 181855.20486
+  dps: 389465.0081
+  tps: 1.92071339731e+06
+  dtps: 154762.71778
+  hps: 180664.45788
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CommunalStoneofDestruction-101171"
  value: {
-  dps: 386039.73901
-  tps: 1.91623554067e+06
-  dtps: 150564.92595
-  hps: 176621.10612
+  dps: 384172.75374
+  tps: 1.90050020442e+06
+  dtps: 151695.86584
+  hps: 178029.28099
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CommunalStoneofWisdom-101183"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ContemplationofChi-Ji-103988"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Coren'sColdChromiumCoaster-257880"
  value: {
-  dps: 392620.48934
-  tps: 1.94443195324e+06
-  dtps: 151336.52833
-  hps: 174544.67054
+  dps: 391479.01898
+  tps: 1.94194757895e+06
+  dtps: 153956.51788
+  hps: 175399.5863
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CoreofDecency-87497"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CourageousPrimalDiamond"
  value: {
-  dps: 387331.03211
-  tps: 1.9087399289e+06
-  dtps: 169920.22055
-  hps: 188334.58647
+  dps: 388546.41519
+  tps: 1.91104008074e+06
+  dtps: 169474.45491
+  hps: 187729.90625
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CraftedDreadfulGladiator'sBadgeofConquest-93419"
  value: {
-  dps: 384288.64403
-  tps: 1.90884795406e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383867.32048
+  tps: 1.91104382464e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CraftedDreadfulGladiator'sBadgeofDominance-93600"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CraftedDreadfulGladiator'sBadgeofVictory-93606"
  value: {
-  dps: 386601.70304
-  tps: 1.91679604546e+06
-  dtps: 150062.13484
-  hps: 174527.79902
+  dps: 386058.25298
+  tps: 1.91276772768e+06
+  dtps: 152861.22226
+  hps: 174891.80091
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CraftedDreadfulGladiator'sEmblemofCruelty-93485"
  value: {
-  dps: 388594.89979
-  tps: 1.93020076154e+06
-  dtps: 151637.69438
-  hps: 174919.54542
+  dps: 388246.62525
+  tps: 1.93260986033e+06
+  dtps: 153994.24809
+  hps: 175478.07984
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CraftedDreadfulGladiator'sEmblemofMeditation-93487"
  value: {
-  dps: 384023.78495
-  tps: 1.90733358115e+06
-  dtps: 151637.69438
-  hps: 174874.21669
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175432.75111
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CraftedDreadfulGladiator'sEmblemofTenacity-93486"
  value: {
-  dps: 384992.99934
-  tps: 1.91481090639e+06
-  dtps: 151353.21563
-  hps: 175307.97812
+  dps: 383328.79359
+  tps: 1.90561893957e+06
+  dtps: 154825.28761
+  hps: 178974.76032
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CraftedDreadfulGladiator'sInsigniaofConquest-93424"
  value: {
-  dps: 384287.8531
-  tps: 1.9088181652e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 384104.31903
+  tps: 1.91155057541e+06
+  dtps: 154129.20945
+  hps: 175318.42285
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CraftedDreadfulGladiator'sInsigniaofDominance-93601"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CraftedDreadfulGladiator'sInsigniaofVictory-93611"
  value: {
-  dps: 387411.57788
-  tps: 1.91737064409e+06
-  dtps: 149328.41046
-  hps: 173103.07956
+  dps: 387226.19755
+  tps: 1.91818363721e+06
+  dtps: 152424.16746
+  hps: 174707.99358
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CraftedMalevolentGladiator'sBadgeofConquest-98755"
  value: {
-  dps: 384361.94052
-  tps: 1.90928360389e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383940.61697
+  tps: 1.91147947447e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CraftedMalevolentGladiator'sBadgeofDominance-98910"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CraftedMalevolentGladiator'sBadgeofVictory-98912"
  value: {
-  dps: 387808.96104
-  tps: 1.92074207848e+06
-  dtps: 150105.45107
-  hps: 174396.59854
+  dps: 386666.17275
+  tps: 1.91629601734e+06
+  dtps: 152669.56243
+  hps: 174920.0232
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CraftedMalevolentGladiator'sEmblemofCruelty-98811"
  value: {
-  dps: 389066.73127
-  tps: 1.93257061963e+06
-  dtps: 151637.69438
-  hps: 174932.11609
+  dps: 388776.9653
+  tps: 1.93544188622e+06
+  dtps: 153994.24809
+  hps: 175490.65051
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CraftedMalevolentGladiator'sEmblemofMeditation-98813"
  value: {
-  dps: 384023.78495
-  tps: 1.90733358115e+06
-  dtps: 151637.69438
-  hps: 174874.21669
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175432.75111
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CraftedMalevolentGladiator'sEmblemofTenacity-98812"
  value: {
-  dps: 385604.77157
-  tps: 1.91755195166e+06
-  dtps: 151473.38785
-  hps: 175249.77354
+  dps: 384493.63874
+  tps: 1.9130126557e+06
+  dtps: 154985.55543
+  hps: 178784.50868
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CraftedMalevolentGladiator'sInsigniaofConquest-98760"
  value: {
-  dps: 384344.68505
-  tps: 1.90928360389e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 384098.90358
+  tps: 1.91155057541e+06
+  dtps: 154129.20945
+  hps: 175318.42285
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CraftedMalevolentGladiator'sInsigniaofDominance-98911"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CraftedMalevolentGladiator'sInsigniaofVictory-98917"
  value: {
-  dps: 387453.53796
-  tps: 1.91825314988e+06
-  dtps: 149106.15627
-  hps: 174088.57462
+  dps: 386945.08391
+  tps: 1.91834962721e+06
+  dtps: 150707.09353
+  hps: 174279.51103
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CurseofHubris-105645"
  value: {
-  dps: 404224.33159
-  tps: 2.00001519371e+06
-  dtps: 151254.30654
-  hps: 174766.8211
+  dps: 406086.37086
+  tps: 2.00070589606e+06
+  dtps: 154265.96281
+  hps: 177595.326
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CutstitcherMedallion-93255"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Daelo'sFinalWords-87496"
  value: {
-  dps: 390769.55564
-  tps: 1.93032105315e+06
-  dtps: 150528.45408
-  hps: 172775.75862
+  dps: 390124.64659
+  tps: 1.92997974865e+06
+  dtps: 151142.86088
+  hps: 173815.55165
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkglowEmbroidery(Rank3)-4893"
  value: {
-  dps: 386887.59875
-  tps: 1.92623610243e+06
-  dtps: 150592.39523
-  hps: 175248.95331
+  dps: 385442.74338
+  tps: 1.90980012577e+06
+  dtps: 153265.20761
+  hps: 178720.89659
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmistVortex-87172"
  value: {
-  dps: 401020.02564
-  tps: 1.96362910743e+06
-  dtps: 150518.48211
-  hps: 172614.02134
+  dps: 395374.18181
+  tps: 1.94793587501e+06
+  dtps: 148269.32515
+  hps: 172620.61995
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DeadeyeBadgeoftheShieldwall-93346"
  value: {
-  dps: 384814.51986
-  tps: 1.90984966968e+06
-  dtps: 151702.51326
-  hps: 175252.58842
+  dps: 383682.69364
+  tps: 1.91133394765e+06
+  dtps: 154404.30122
+  hps: 176342.30126
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DelicateVialoftheSanguinaire-96895"
  value: {
-  dps: 390894.00924
-  tps: 1.94426937216e+06
-  dtps: 147541.40577
-  hps: 172136.86285
+  dps: 393243.4976
+  tps: 1.94417198624e+06
+  dtps: 149332.42652
+  hps: 174975.31417
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DestructivePrimalDiamond"
  value: {
-  dps: 389344.85545
-  tps: 1.91698012004e+06
-  dtps: 169920.22055
-  hps: 188363.05333
+  dps: 390650.68398
+  tps: 1.92050725861e+06
+  dtps: 169474.45491
+  hps: 187756.37768
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DisciplineofXuen-103986"
  value: {
-  dps: 388369.47359
-  tps: 1.92385884384e+06
-  dtps: 152159.43792
-  hps: 177612.16391
+  dps: 388053.86828
+  tps: 1.90662764395e+06
+  dtps: 152115.71987
+  hps: 182079.93464
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Dominator'sArcaneBadge-93342"
  value: {
-  dps: 387020.60218
-  tps: 1.90570902132e+06
-  dtps: 150730.59091
-  hps: 172453.33408
+  dps: 385828.36971
+  tps: 1.9140127503e+06
+  dtps: 150856.23883
+  hps: 170069.16767
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Dominator'sDeadeyeBadge-93341"
  value: {
-  dps: 384814.51986
-  tps: 1.90984966968e+06
-  dtps: 151702.51326
-  hps: 175252.58842
+  dps: 383682.69364
+  tps: 1.91133394765e+06
+  dtps: 154404.30122
+  hps: 176342.30126
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Dominator'sDurableBadge-93345"
  value: {
-  dps: 389399.19154
-  tps: 1.92765145803e+06
-  dtps: 150706.04829
-  hps: 174175.31796
+  dps: 387768.60902
+  tps: 1.92374948632e+06
+  dtps: 151957.77444
+  hps: 174107.79429
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Dominator'sKnightlyBadge-93344"
  value: {
-  dps: 388259.62024
-  tps: 1.92456529709e+06
-  dtps: 149917.1851
-  hps: 174828.97593
+  dps: 385574.3032
+  tps: 1.91358724388e+06
+  dtps: 152793.99861
+  hps: 174929.30411
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Dominator'sMendingBadge-93343"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DreadfulGladiator'sBadgeofConquest-84344"
  value: {
-  dps: 384288.64403
-  tps: 1.90884795406e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383867.32048
+  tps: 1.91104382464e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DreadfulGladiator'sBadgeofDominance-84488"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DreadfulGladiator'sBadgeofVictory-84490"
  value: {
-  dps: 386601.70304
-  tps: 1.91679604546e+06
-  dtps: 150062.13484
-  hps: 174527.79902
+  dps: 386058.25298
+  tps: 1.91276772768e+06
+  dtps: 152861.22226
+  hps: 174891.80091
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DreadfulGladiator'sEmblemofCruelty-84399"
  value: {
-  dps: 388594.89979
-  tps: 1.93020076154e+06
-  dtps: 151637.69438
-  hps: 174919.54542
+  dps: 388246.62525
+  tps: 1.93260986033e+06
+  dtps: 153994.24809
+  hps: 175478.07984
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DreadfulGladiator'sEmblemofMeditation-84401"
  value: {
-  dps: 384023.78495
-  tps: 1.90733358115e+06
-  dtps: 151637.69438
-  hps: 174874.21669
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175432.75111
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DreadfulGladiator'sEmblemofTenacity-84400"
  value: {
-  dps: 384992.99934
-  tps: 1.91481090639e+06
-  dtps: 151353.21563
-  hps: 175307.97812
+  dps: 383328.79359
+  tps: 1.90561893957e+06
+  dtps: 154825.28761
+  hps: 178974.76032
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DreadfulGladiator'sInsigniaofConquest-84349"
  value: {
-  dps: 384351.85297
-  tps: 1.90914366113e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 384097.86904
+  tps: 1.91141063265e+06
+  dtps: 154129.20945
+  hps: 175318.42285
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DreadfulGladiator'sInsigniaofDominance-84489"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DreadfulGladiator'sInsigniaofVictory-84495"
  value: {
-  dps: 389042.14327
-  tps: 1.92386340819e+06
-  dtps: 149502.04218
-  hps: 173617.78831
+  dps: 386265.56973
+  tps: 1.91579119532e+06
+  dtps: 151939.56925
+  hps: 174247.59316
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DurableBadgeoftheShieldwall-93350"
  value: {
-  dps: 389399.19154
-  tps: 1.92765145803e+06
-  dtps: 150706.04829
-  hps: 174175.31796
+  dps: 387768.60902
+  tps: 1.92374948632e+06
+  dtps: 151957.77444
+  hps: 174107.79429
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DysmorphicSamophlangeofDiscontinuity-105615"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EffulgentPrimalDiamond"
  value: {
-  dps: 387809.42341
-  tps: 1.91243707354e+06
-  dtps: 169737.99182
-  hps: 188305.26188
+  dps: 388857.51324
+  tps: 1.91575916702e+06
+  dtps: 169238.92493
+  hps: 188207.17674
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EmberPrimalDiamond"
  value: {
-  dps: 387331.03211
-  tps: 1.9087399289e+06
-  dtps: 169920.22055
-  hps: 188334.58647
+  dps: 388546.41519
+  tps: 1.91104008074e+06
+  dtps: 169474.45491
+  hps: 187729.90625
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EmblemofKypariZar-84077"
  value: {
-  dps: 396803.12834
-  tps: 1.94405779396e+06
-  dtps: 152051.37848
-  hps: 172500.81267
+  dps: 395792.02007
+  tps: 1.95704763307e+06
+  dtps: 151553.24612
+  hps: 173828.28339
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EmblemoftheCatacombs-83733"
  value: {
-  dps: 392025.23349
-  tps: 1.92681452668e+06
-  dtps: 150893.31151
-  hps: 177880.88891
+  dps: 390127.06903
+  tps: 1.91615815964e+06
+  dtps: 152555.46103
+  hps: 177647.48853
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EmptyFruitBarrel-81133"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnchantWeapon-BloodyDancingSteel-5125"
  value: {
-  dps: 380758.94119
-  tps: 1.90148926929e+06
-  dtps: 153402.50501
-  hps: 169399.37507
+  dps: 382805.74506
+  tps: 1.90109212725e+06
+  dtps: 155907.85289
+  hps: 174092.99516
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnchantWeapon-Colossus-4445"
  value: {
-  dps: 380351.71011
-  tps: 1.90565778568e+06
-  dtps: 155396.74508
-  hps: 170785.1002
+  dps: 378062.97999
+  tps: 1.88601648392e+06
+  dtps: 158381.67998
+  hps: 173162.83415
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnchantWeapon-DancingSteel-4444"
  value: {
-  dps: 381972.579
-  tps: 1.9041239905e+06
-  dtps: 153831.97658
-  hps: 170829.49553
+  dps: 382240.92423
+  tps: 1.89962913569e+06
+  dtps: 156715.47202
+  hps: 173963.98308
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnchantWeapon-ElementalForce-4443"
  value: {
-  dps: 379887.41749
-  tps: 1.9034622979e+06
-  dtps: 155997.43194
-  hps: 171551.06885
+  dps: 380874.91458
+  tps: 1.89681425277e+06
+  dtps: 158351.32441
+  hps: 173715.48557
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnchantWeapon-JadeSpirit-4442"
  value: {
-  dps: 378977.44657
-  tps: 1.89991485829e+06
-  dtps: 155997.43194
-  hps: 171551.06885
+  dps: 379801.99383
+  tps: 1.89123834689e+06
+  dtps: 158351.32441
+  hps: 173715.48557
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnchantWeapon-River'sSong-4446"
  value: {
-  dps: 383697.95103
-  tps: 1.90925389026e+06
-  dtps: 153676.71931
-  hps: 172483.41709
+  dps: 384539.53828
+  tps: 1.90654784532e+06
+  dtps: 155908.80582
+  hps: 173238.41196
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnchantWeapon-SpiritofConquest-5124"
  value: {
-  dps: 378977.44657
-  tps: 1.89991485829e+06
-  dtps: 155997.43194
-  hps: 171551.06885
+  dps: 379801.99383
+  tps: 1.89123834689e+06
+  dtps: 158351.32441
+  hps: 173715.48557
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnchantWeapon-Windsong-4441"
  value: {
-  dps: 386305.96904
-  tps: 1.91985077423e+06
-  dtps: 157996.86784
-  hps: 173561.70684
+  dps: 385111.84227
+  tps: 1.90987782941e+06
+  dtps: 158314.62948
+  hps: 174595.72423
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticPrimalDiamond"
  value: {
-  dps: 389344.85545
-  tps: 1.91698012004e+06
-  dtps: 169920.22055
-  hps: 188363.05333
+  dps: 390650.68398
+  tps: 1.92050725861e+06
+  dtps: 169474.45491
+  hps: 187756.37768
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EssenceofTerror-87175"
  value: {
-  dps: 390741.84712
-  tps: 1.9382619097e+06
-  dtps: 151560.1916
-  hps: 175922.51385
+  dps: 389099.88616
+  tps: 1.92395497593e+06
+  dtps: 151596.30879
+  hps: 175390.54184
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EternalPrimalDiamond"
  value: {
-  dps: 388383.34219
-  tps: 1.92211444899e+06
-  dtps: 168853.74846
-  hps: 187544.26707
+  dps: 389738.00837
+  tps: 1.91795300732e+06
+  dtps: 168496.5361
+  hps: 187822.19408
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EvilEyeofGalakras-105491"
  value: {
-  dps: 391235.13668
-  tps: 1.92831317104e+06
-  dtps: 145493.73003
-  hps: 171552.02072
+  dps: 394217.7327
+  tps: 1.95237778618e+06
+  dtps: 147299.38463
+  hps: 171435.98662
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FabledFeatherofJi-Kun-96842"
  value: {
-  dps: 396892.57756
-  tps: 1.94282393532e+06
-  dtps: 148142.7661
-  hps: 171175.13776
+  dps: 398000.51618
+  tps: 1.9438777382e+06
+  dtps: 147637.66116
+  hps: 170519.2454
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FearwurmBadge-84074"
  value: {
-  dps: 393045.69231
-  tps: 1.9556929168e+06
-  dtps: 151672.15401
-  hps: 170556.98661
+  dps: 397233.55667
+  tps: 1.95602743647e+06
+  dtps: 151251.87558
+  hps: 172650.09431
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FearwurmRelic-84070"
  value: {
-  dps: 397389.98442
-  tps: 1.96498888662e+06
-  dtps: 152831.49035
-  hps: 172777.44206
+  dps: 397284.82354
+  tps: 1.97194216993e+06
+  dtps: 153260.67718
+  hps: 174340.57414
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FelsoulIdolofDestruction-101263"
  value: {
-  dps: 390719.17975
-  tps: 1.93018744953e+06
-  dtps: 152609.18596
-  hps: 180833.11202
+  dps: 389505.83508
+  tps: 1.93179446304e+06
+  dtps: 152351.95116
+  hps: 181309.27293
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FelsoulStoneofDestruction-101266"
  value: {
-  dps: 384754.53167
-  tps: 1.89831904689e+06
-  dtps: 151133.87308
-  hps: 179001.51248
+  dps: 386338.25696
+  tps: 1.9053860815e+06
+  dtps: 151709.08163
+  hps: 178969.08491
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Fen-Yu,FuryofXuen-102248"
  value: {
-  dps: 382134.48446
-  tps: 1.88934745e+06
-  dtps: 156681.95069
-  hps: 178355.93259
+  dps: 378647.27798
+  tps: 1.87326818997e+06
+  dtps: 157456.46232
+  hps: 176162.64448
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FlashfrozenResinGlobule-100951"
  value: {
-  dps: 388854.12177
-  tps: 1.92280807242e+06
-  dtps: 152471.79279
-  hps: 174270.87052
+  dps: 387141.3364
+  tps: 1.91387889368e+06
+  dtps: 153683.81975
+  hps: 174324.83642
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FlashingSteelTalisman-81265"
  value: {
-  dps: 389738.2195
-  tps: 1.92891544966e+06
-  dtps: 153407.69964
-  hps: 174636.52427
+  dps: 389388.9242
+  tps: 1.92006247219e+06
+  dtps: 153524.97067
+  hps: 174743.49833
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FleetPrimalDiamond"
  value: {
-  dps: 387505.08612
-  tps: 1.91321179855e+06
-  dtps: 170523.27315
-  hps: 192132.45214
+  dps: 386721.05598
+  tps: 1.90436168987e+06
+  dtps: 169152.95347
+  hps: 189964.51185
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornPrimalDiamond"
  value: {
-  dps: 387331.03211
-  tps: 1.9087399289e+06
-  dtps: 169920.22055
-  hps: 188334.58647
+  dps: 388546.41519
+  tps: 1.91104008074e+06
+  dtps: 169474.45491
+  hps: 187729.90625
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FortitudeoftheZandalari-96793"
  value: {
-  dps: 382779.00641
-  tps: 1.89699178576e+06
-  dtps: 153239.27822
-  hps: 181462.17014
+  dps: 383024.18919
+  tps: 1.89262182926e+06
+  dtps: 154076.40309
+  hps: 181084.9223
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FrenziedCrystalofRage-105572"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Fusion-FireCore-105459"
  value: {
-  dps: 397984.81447
-  tps: 1.95110971312e+06
-  dtps: 145052.66159
-  hps: 169920.93693
+  dps: 396772.57449
+  tps: 1.94735563495e+06
+  dtps: 145672.11069
+  hps: 169067.08801
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GazeoftheTwins-96915"
  value: {
-  dps: 399106.13388
-  tps: 1.96819787369e+06
-  dtps: 146860.04462
-  hps: 169141.39029
+  dps: 400557.0394
+  tps: 1.96186255298e+06
+  dtps: 149177.70916
+  hps: 173725.4285
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Gerp'sPerfectArrow-87495"
  value: {
-  dps: 388308.71392
-  tps: 1.92832604216e+06
-  dtps: 151487.09957
-  hps: 174243.12495
+  dps: 388008.06674
+  tps: 1.93101927732e+06
+  dtps: 153994.24809
+  hps: 175290.85982
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GrievousGladiator'sBadgeofConquest-103145"
  value: {
-  dps: 384385.6645
-  tps: 1.90928360389e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 384059.77668
+  tps: 1.91103914845e+06
+  dtps: 154129.20945
+  hps: 175318.42285
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GrievousGladiator'sBadgeofDominance-103308"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GrievousGladiator'sBadgeofVictory-103314"
  value: {
-  dps: 389031.0333
-  tps: 1.91728820731e+06
-  dtps: 149067.78133
-  hps: 173755.53913
+  dps: 387868.79706
+  tps: 1.91407142847e+06
+  dtps: 149703.17919
+  hps: 173631.17731
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GrievousGladiator'sEmblemofCruelty-103210"
  value: {
-  dps: 391859.96096
-  tps: 1.94635964105e+06
-  dtps: 151637.69438
-  hps: 174956.80907
+  dps: 391260.70876
+  tps: 1.94747937165e+06
+  dtps: 153994.24809
+  hps: 175515.34349
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GrievousGladiator'sEmblemofMeditation-103212"
  value: {
-  dps: 384023.78495
-  tps: 1.90733358115e+06
-  dtps: 151637.69438
-  hps: 174874.21669
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175432.75111
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GrievousGladiator'sEmblemofTenacity-103211"
  value: {
-  dps: 386364.9882
-  tps: 1.92404862712e+06
-  dtps: 151432.26785
-  hps: 175931.49738
+  dps: 385883.00931
+  tps: 1.91582610248e+06
+  dtps: 154117.32112
+  hps: 179019.70089
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GrievousGladiator'sInsigniaofConquest-103150"
  value: {
-  dps: 384549.85639
-  tps: 1.90983049077e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 384225.16662
+  tps: 1.91206419745e+06
+  dtps: 154129.20945
+  hps: 175318.42285
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GrievousGladiator'sInsigniaofDominance-103309"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GrievousGladiator'sInsigniaofVictory-103319"
  value: {
-  dps: 392462.19933
-  tps: 1.92657681543e+06
-  dtps: 148367.3866
-  hps: 172058.11914
+  dps: 390429.26005
+  tps: 1.92023859943e+06
+  dtps: 148920.029
+  hps: 172494.19937
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Haromm'sTalisman-105527"
  value: {
-  dps: 400313.50754
-  tps: 2.016122532e+06
-  dtps: 151058.85607
-  hps: 173458.00606
+  dps: 401063.68775
+  tps: 2.02984179743e+06
+  dtps: 153819.75992
+  hps: 175023.48498
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Hawkmaster'sTalon-89082"
  value: {
-  dps: 393254.41766
-  tps: 1.94805170639e+06
-  dtps: 151477.30938
-  hps: 174621.0979
+  dps: 392584.89943
+  tps: 1.94525855871e+06
+  dtps: 152204.85983
+  hps: 174852.37157
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Heart-LesionDefenderIdol-100999"
  value: {
-  dps: 390462.22275
-  tps: 1.92722919067e+06
-  dtps: 149466.09703
-  hps: 174676.16263
+  dps: 390545.75802
+  tps: 1.92956724287e+06
+  dtps: 150343.8505
+  hps: 175234.51113
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Heart-LesionDefenderStone-101002"
  value: {
-  dps: 386559.50852
-  tps: 1.91770544048e+06
-  dtps: 152384.16791
-  hps: 179824.69818
+  dps: 384646.80673
+  tps: 1.90032185134e+06
+  dtps: 151231.37547
+  hps: 179348.53487
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Heart-LesionIdolofBattle-100991"
  value: {
-  dps: 392301.13842
-  tps: 1.94586861917e+06
-  dtps: 149471.96031
-  hps: 174120.37204
+  dps: 391125.34719
+  tps: 1.93766801224e+06
+  dtps: 151231.33833
+  hps: 174407.05319
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Heart-LesionStoneofBattle-100990"
  value: {
-  dps: 388435.97541
-  tps: 1.9186271749e+06
-  dtps: 147903.65948
-  hps: 174374.01029
+  dps: 386667.63229
+  tps: 1.9056401329e+06
+  dtps: 149357.00447
+  hps: 176693.76762
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HeartofFire-81181"
  value: {
-  dps: 384575.03545
-  tps: 1.91587303908e+06
-  dtps: 151741.14206
-  hps: 178336.16225
+  dps: 383529.50698
+  tps: 1.91080028262e+06
+  dtps: 153378.16223
+  hps: 178254.47889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HeartwarmerMedallion-93260"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HelmbreakerMedallion-93261"
  value: {
-  dps: 393270.022
-  tps: 1.94754510264e+06
-  dtps: 150034.71966
-  hps: 173617.92508
+  dps: 394974.82785
+  tps: 1.95355117583e+06
+  dtps: 150443.69456
+  hps: 173323.65737
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Horridon'sLastGasp-96757"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassivePrimalDiamond"
  value: {
-  dps: 389344.85545
-  tps: 1.91698012004e+06
-  dtps: 169920.22055
-  hps: 188363.05333
+  dps: 390650.68398
+  tps: 1.92050725861e+06
+  dtps: 169474.45491
+  hps: 187756.37768
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IndomitablePrimalDiamond"
  value: {
-  dps: 386887.59875
-  tps: 1.92623610243e+06
-  dtps: 150592.39523
-  hps: 175522.05903
+  dps: 384541.44023
+  tps: 1.90891021321e+06
+  dtps: 153265.20761
+  hps: 178169.1398
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InscribedBagofHydra-Spawn-96828"
  value: {
-  dps: 388375.48191
-  tps: 1.92750620891e+06
-  dtps: 150385.07271
-  hps: 174337.24124
+  dps: 388583.15012
+  tps: 1.93550468478e+06
+  dtps: 152424.47347
+  hps: 174233.59293
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InsigniaofKypariZar-84078"
  value: {
-  dps: 389053.91922
-  tps: 1.93549678627e+06
-  dtps: 148836.65146
-  hps: 172118.0407
+  dps: 388504.98266
+  tps: 1.93854213837e+06
+  dtps: 150515.67578
+  hps: 172560.31441
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IronBellyWok-89083"
  value: {
-  dps: 398416.15266
-  tps: 1.97661425645e+06
-  dtps: 149381.76861
-  hps: 173217.18347
+  dps: 398093.21404
+  tps: 1.9670128567e+06
+  dtps: 149864.34055
+  hps: 174564.95348
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IronProtectorTalisman-85181"
  value: {
-  dps: 387956.34735
-  tps: 1.92352289523e+06
-  dtps: 150441.79465
-  hps: 174843.1001
+  dps: 387438.08175
+  tps: 1.93138771786e+06
+  dtps: 151858.18864
+  hps: 176169.55855
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-JadeBanditFigurine-86772"
  value: {
-  dps: 394894.9535
-  tps: 1.95557211964e+06
-  dtps: 153552.70376
-  hps: 175605.7684
+  dps: 396826.99809
+  tps: 1.96261978242e+06
+  dtps: 151898.27472
+  hps: 173181.50092
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-JadeCharioteerFigurine-86771"
  value: {
-  dps: 398332.84102
-  tps: 1.96452493167e+06
-  dtps: 151719.50521
-  hps: 175212.40074
+  dps: 398832.81451
+  tps: 1.96454630136e+06
+  dtps: 150123.73312
+  hps: 172631.83695
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-JadeCourtesanFigurine-86774"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-JadeMagistrateFigurine-86773"
  value: {
-  dps: 389290.43526
-  tps: 1.92659524648e+06
-  dtps: 151543.94728
-  hps: 172968.92305
+  dps: 388913.62897
+  tps: 1.92718287802e+06
+  dtps: 154767.30568
+  hps: 175954.52763
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-JadeWarlordFigurine-86775"
  value: {
-  dps: 386127.07777
-  tps: 1.92063006358e+06
-  dtps: 151381.87479
-  hps: 176226.94172
+  dps: 385086.36579
+  tps: 1.91174100203e+06
+  dtps: 154570.91377
+  hps: 179929.6791
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Ji-Kun'sRisingWinds-96843"
  value: {
-  dps: 392233.74306
-  tps: 1.94631686829e+06
-  dtps: 151569.9227
-  hps: 174384.08959
+  dps: 392624.01552
+  tps: 1.94336627723e+06
+  dtps: 149256.8205
+  hps: 171924.10732
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Juggernaut'sFocusingCrystal-105514"
  value: {
-  dps: 393191.87632
-  tps: 1.95412212229e+06
-  dtps: 146494.00007
-  hps: 179999.2408
+  dps: 393147.7723
+  tps: 1.95477813015e+06
+  dtps: 147127.94582
+  hps: 181673.72245
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Kardris'ToxicTotem-105540"
  value: {
-  dps: 399058.48254
-  tps: 2.01248537112e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 400095.75481
+  tps: 2.02488861874e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-KnightlyBadgeoftheShieldwall-93349"
  value: {
-  dps: 388259.62024
-  tps: 1.92456529709e+06
-  dtps: 149917.1851
-  hps: 174828.97593
+  dps: 385574.3032
+  tps: 1.91358724388e+06
+  dtps: 152793.99861
+  hps: 174929.30411
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-KnotofTenSongs-84073"
  value: {
-  dps: 391278.26805
-  tps: 1.93722345507e+06
-  dtps: 148467.78245
-  hps: 171667.33076
+  dps: 389901.44382
+  tps: 1.93256607359e+06
+  dtps: 150629.99796
+  hps: 172753.58315
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Kor'kronBookofHurting-92785"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Lao-Chin'sLiquidCourage-89079"
  value: {
-  dps: 385358.29388
-  tps: 1.9177688082e+06
-  dtps: 152135.96342
-  hps: 177689.98004
+  dps: 384463.91274
+  tps: 1.91006274438e+06
+  dtps: 154347.11063
+  hps: 180028.24432
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LeiShen'sFinalOrders-87072"
  value: {
-  dps: 395179.81939
-  tps: 1.94973024697e+06
-  dtps: 149167.08508
-  hps: 173413.28315
+  dps: 394735.80175
+  tps: 1.94831664467e+06
+  dtps: 147550.88527
+  hps: 171223.90561
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LessonsoftheDarkmaster-81268"
  value: {
-  dps: 394082.40516
-  tps: 1.94492114472e+06
-  dtps: 151382.66934
-  hps: 174444.24224
+  dps: 392870.46016
+  tps: 1.93269628139e+06
+  dtps: 152088.09902
+  hps: 174527.33519
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LightdrinkerIdolofRage-101200"
  value: {
-  dps: 385332.24135
-  tps: 1.9199251977e+06
-  dtps: 151912.16267
-  hps: 180516.82017
+  dps: 383247.86522
+  tps: 1.90855662644e+06
+  dtps: 153440.14388
+  hps: 179310.87894
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LightdrinkerStoneofRage-101203"
  value: {
-  dps: 387149.68212
-  tps: 1.92499916516e+06
-  dtps: 151682.65512
-  hps: 179852.15426
+  dps: 385926.6916
+  tps: 1.90600433524e+06
+  dtps: 151658.02469
+  hps: 179663.86544
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LightoftheCosmos-87065"
  value: {
-  dps: 392631.31248
-  tps: 1.93813465742e+06
-  dtps: 152108.32584
-  hps: 176017.05338
+  dps: 390528.3007
+  tps: 1.93393961035e+06
+  dtps: 152544.64946
+  hps: 175220.57075
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LightweaveEmbroidery(Rank3)-4892"
  value: {
-  dps: 386887.59875
-  tps: 1.92623610243e+06
-  dtps: 150592.39523
-  hps: 175248.95331
+  dps: 385442.74338
+  tps: 1.90980012577e+06
+  dtps: 153265.20761
+  hps: 178720.89659
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LordBlastington'sScopeofDoom-4699"
  value: {
-  dps: 378977.44657
-  tps: 1.89991485829e+06
-  dtps: 155997.43194
-  hps: 171551.06885
+  dps: 379801.99383
+  tps: 1.89123834689e+06
+  dtps: 158351.32441
+  hps: 173715.48557
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MalevolentGladiator'sBadgeofConquest-91452"
  value: {
-  dps: 384361.94052
-  tps: 1.90928360389e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383940.61697
+  tps: 1.91147947447e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MalevolentGladiator'sBadgeofDominance-91753"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MalevolentGladiator'sBadgeofVictory-91763"
  value: {
-  dps: 387808.96104
-  tps: 1.92074207848e+06
-  dtps: 150105.45107
-  hps: 174396.59854
+  dps: 386666.17275
+  tps: 1.91629601734e+06
+  dtps: 152669.56243
+  hps: 174920.0232
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MalevolentGladiator'sEmblemofCruelty-91562"
  value: {
-  dps: 389066.73127
-  tps: 1.93257061963e+06
-  dtps: 151637.69438
-  hps: 174932.11609
+  dps: 388776.9653
+  tps: 1.93544188622e+06
+  dtps: 153994.24809
+  hps: 175490.65051
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MalevolentGladiator'sEmblemofMeditation-91564"
  value: {
-  dps: 384023.78495
-  tps: 1.90733358115e+06
-  dtps: 151637.69438
-  hps: 174874.21669
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175432.75111
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MalevolentGladiator'sEmblemofTenacity-91563"
  value: {
-  dps: 385604.77157
-  tps: 1.91755195166e+06
-  dtps: 151473.38785
-  hps: 175249.77354
+  dps: 384493.63874
+  tps: 1.9130126557e+06
+  dtps: 154985.55543
+  hps: 178784.50868
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MalevolentGladiator'sInsigniaofConquest-91457"
  value: {
-  dps: 384331.87558
-  tps: 1.90914366113e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 384000.08689
+  tps: 1.91077827837e+06
+  dtps: 154129.20945
+  hps: 175318.42285
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MalevolentGladiator'sInsigniaofDominance-91754"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MalevolentGladiator'sInsigniaofVictory-91768"
  value: {
-  dps: 387574.96566
-  tps: 1.91934818469e+06
-  dtps: 148946.07633
-  hps: 173935.51565
+  dps: 386830.54562
+  tps: 1.91723185616e+06
+  dtps: 150786.41777
+  hps: 173837.37267
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MarkoftheCatacombs-83731"
  value: {
-  dps: 389650.30422
-  tps: 1.94011006345e+06
-  dtps: 152031.77921
-  hps: 178387.1894
+  dps: 388911.22
+  tps: 1.93296212131e+06
+  dtps: 155782.27844
+  hps: 181716.16608
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MarkoftheHardenedGrunt-92783"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MedallionofMystifyingVapors-93257"
  value: {
-  dps: 388276.76122
-  tps: 1.93230908912e+06
-  dtps: 149844.25986
-  hps: 173788.24298
+  dps: 388918.33242
+  tps: 1.9291740846e+06
+  dtps: 151408.10717
+  hps: 174480.96105
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MedallionoftheCatacombs-83734"
  value: {
-  dps: 388423.59465
-  tps: 1.93631112065e+06
-  dtps: 149889.44903
-  hps: 177194.44105
+  dps: 387871.20611
+  tps: 1.92219476978e+06
+  dtps: 153636.82853
+  hps: 178591.67521
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MendingBadgeoftheShieldwall-93348"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MirrorScope-4700"
  value: {
-  dps: 378977.44657
-  tps: 1.89991485829e+06
-  dtps: 155997.43194
-  hps: 171551.06885
+  dps: 379801.99383
+  tps: 1.89123834689e+06
+  dtps: 158351.32441
+  hps: 173715.48557
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MistdancerDefenderIdol-101089"
  value: {
-  dps: 391072.93015
-  tps: 1.9257800479e+06
-  dtps: 148849.28803
-  hps: 174560.45664
+  dps: 391019.47458
+  tps: 1.92836421138e+06
+  dtps: 150476.09445
+  hps: 174776.76008
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MistdancerDefenderStone-101087"
  value: {
-  dps: 386233.15549
-  tps: 1.91819206511e+06
-  dtps: 152117.58293
-  hps: 181216.31161
+  dps: 384362.92699
+  tps: 1.90588742351e+06
+  dtps: 152623.50579
+  hps: 182490.53569
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MistdancerIdolofRage-101113"
  value: {
-  dps: 385239.8682
-  tps: 1.91942490998e+06
-  dtps: 151912.16267
-  hps: 180516.82017
+  dps: 383380.73207
+  tps: 1.9111155664e+06
+  dtps: 153305.18252
+  hps: 179055.11164
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MistdancerStoneofRage-101117"
  value: {
-  dps: 384524.92965
-  tps: 1.90422909813e+06
-  dtps: 151556.28698
-  hps: 178822.10252
+  dps: 386697.16989
+  tps: 1.90752201479e+06
+  dtps: 152232.5345
+  hps: 180796.28328
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MistdancerStoneofWisdom-101107"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MithrilWristwatch-257884"
  value: {
-  dps: 389921.21448
-  tps: 1.93728249588e+06
-  dtps: 151487.09957
-  hps: 174268.28811
+  dps: 389541.07886
+  tps: 1.93940852758e+06
+  dtps: 153994.24809
+  hps: 175316.02298
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MountainsageIdolofDestruction-101069"
  value: {
-  dps: 384402.77896
-  tps: 1.89923784585e+06
-  dtps: 151986.55909
-  hps: 179431.014
+  dps: 387064.91205
+  tps: 1.91128389143e+06
+  dtps: 153774.63327
+  hps: 177773.01251
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MountainsageStoneofDestruction-101072"
  value: {
-  dps: 384208.70186
-  tps: 1.90425880291e+06
-  dtps: 152190.22453
-  hps: 178131.88875
+  dps: 383810.9848
+  tps: 1.89833727747e+06
+  dtps: 151663.50416
+  hps: 179991.59883
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-NitroBoosts-4223"
  value: {
-  dps: 386887.59875
-  tps: 1.92623610243e+06
-  dtps: 150592.39523
-  hps: 175522.05903
+  dps: 384541.44023
+  tps: 1.90891021321e+06
+  dtps: 153265.20761
+  hps: 178169.1398
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-OathswornDefenderIdol-101303"
  value: {
-  dps: 391181.25537
-  tps: 1.94024134563e+06
-  dtps: 149898.11002
-  hps: 175307.16414
+  dps: 390627.43495
+  tps: 1.93125868576e+06
+  dtps: 151384.30271
+  hps: 176316.0617
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-OathswornDefenderStone-101306"
  value: {
-  dps: 385699.96953
-  tps: 1.91284909172e+06
-  dtps: 151520.08907
-  hps: 179597.78807
+  dps: 385215.38849
+  tps: 1.91508219269e+06
+  dtps: 152600.04407
+  hps: 182115.97659
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-OathswornIdolofBattle-101295"
  value: {
-  dps: 395433.82056
-  tps: 1.95455297076e+06
-  dtps: 149174.15304
-  hps: 173639.94042
+  dps: 392159.27551
+  tps: 1.94048486111e+06
+  dtps: 151815.42598
+  hps: 174530.17633
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-OathswornStoneofBattle-101294"
  value: {
-  dps: 388534.98502
-  tps: 1.92596701325e+06
-  dtps: 149371.00291
-  hps: 177086.37116
+  dps: 385047.29747
+  tps: 1.90142374505e+06
+  dtps: 150417.20188
+  hps: 177849.88411
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PhaseFingers-4697"
  value: {
-  dps: 385961.61848
-  tps: 1.91686782151e+06
-  dtps: 148995.7244
-  hps: 173573.46111
+  dps: 385058.04099
+  tps: 1.91651562731e+06
+  dtps: 152811.1809
+  hps: 176693.96758
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PlateofCyclopeanDread"
  value: {
-  dps: 343338.94825
-  tps: 1.79549447882e+06
-  dtps: 169556.17328
-  hps: 195117.45857
+  dps: 343541.01698
+  tps: 1.79888538511e+06
+  dtps: 167727.54121
+  hps: 194074.04848
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PlateoftheAll-ConsumingMaw"
  value: {
-  dps: 374334.96617
-  tps: 1.97431437657e+06
-  dtps: 167395.02091
-  hps: 173887.49484
+  dps: 374760.3253
+  tps: 1.97690728031e+06
+  dtps: 167229.97312
+  hps: 173068.02538
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PlateoftheLostCatacomb"
  value: {
-  dps: 349958.20115
-  tps: 1.84242589202e+06
-  dtps: 175175.56011
-  hps: 177999.01599
+  dps: 353058.36109
+  tps: 1.86389500417e+06
+  dtps: 174469.25884
+  hps: 177691.12833
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PouchofWhiteAsh-103639"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulPrimalDiamond"
  value: {
-  dps: 387809.42341
-  tps: 1.91243707354e+06
-  dtps: 169737.99182
-  hps: 188305.26188
+  dps: 388857.51324
+  tps: 1.91575916702e+06
+  dtps: 169238.92493
+  hps: 188207.17674
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PriceofProgress-81266"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PridefulGladiator'sBadgeofConquest-103342"
  value: {
-  dps: 384474.12388
-  tps: 1.90967400625e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 384160.35473
+  tps: 1.91151438153e+06
+  dtps: 154129.20945
+  hps: 175318.42285
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PridefulGladiator'sBadgeofDominance-103505"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PridefulGladiator'sBadgeofVictory-103511"
  value: {
-  dps: 392587.64828
-  tps: 1.93211413614e+06
-  dtps: 148084.90906
-  hps: 172892.17542
+  dps: 390204.4054
+  tps: 1.92422530236e+06
+  dtps: 149430.92477
+  hps: 173409.44307
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PridefulGladiator'sEmblemofCruelty-103407"
  value: {
-  dps: 394444.37544
-  tps: 1.95729352019e+06
-  dtps: 151637.69438
-  hps: 174995.61746
+  dps: 393766.03025
+  tps: 1.95839366858e+06
+  dtps: 153994.24809
+  hps: 175552.01501
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PridefulGladiator'sEmblemofMeditation-103409"
  value: {
-  dps: 384023.78495
-  tps: 1.90733358115e+06
-  dtps: 151637.69438
-  hps: 174874.21669
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175432.75111
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PridefulGladiator'sEmblemofTenacity-103408"
  value: {
-  dps: 386433.47351
-  tps: 1.92456442851e+06
-  dtps: 151437.74304
-  hps: 176493.92211
+  dps: 385988.26562
+  tps: 1.91387112537e+06
+  dtps: 154026.61637
+  hps: 179493.4177
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PridefulGladiator'sInsigniaofConquest-103347"
  value: {
-  dps: 384590.1582
-  tps: 1.90998311403e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 384437.27569
+  tps: 1.91324846833e+06
+  dtps: 154129.20945
+  hps: 175318.42285
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PridefulGladiator'sInsigniaofDominance-103506"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PridefulGladiator'sInsigniaofVictory-103516"
  value: {
-  dps: 393195.88612
-  tps: 1.93867764777e+06
-  dtps: 148453.32912
-  hps: 173091.20626
+  dps: 392859.47668
+  tps: 1.93160157958e+06
+  dtps: 148160.84729
+  hps: 174390.48919
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Primordius'TalismanofRage-96873"
  value: {
-  dps: 398221.42866
-  tps: 1.96760964472e+06
-  dtps: 149778.4304
-  hps: 172309.42298
+  dps: 398963.7114
+  tps: 1.96632193174e+06
+  dtps: 150268.6496
+  hps: 174310.34449
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PrismaticPrisonofPride-105474"
  value: {
-  dps: 394080.82435
-  tps: 1.96562167754e+06
-  dtps: 153935.76241
-  hps: 183259.31244
+  dps: 394083.7753
+  tps: 1.95934109816e+06
+  dtps: 151986.88961
+  hps: 180327.53181
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PurifiedBindingsofImmerseus-105422"
  value: {
-  dps: 394080.82435
-  tps: 1.96562167754e+06
-  dtps: 153935.76241
-  hps: 183259.31244
+  dps: 394083.7753
+  tps: 1.95934109816e+06
+  dtps: 151986.88961
+  hps: 180327.53181
  }
 }
 dps_results: {
@@ -1824,820 +1824,820 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-Qin-xi'sPolarizingSeal-87075"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RelicofChi-Ji-79330"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RelicofKypariZar-84075"
  value: {
-  dps: 392820.3909
-  tps: 1.93970343943e+06
-  dtps: 151503.34688
-  hps: 171476.72282
+  dps: 394556.35469
+  tps: 1.94470599046e+06
+  dtps: 150786.68518
+  hps: 173709.65563
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RelicofNiuzao-79329"
  value: {
-  dps: 385868.03655
-  tps: 1.91982007111e+06
-  dtps: 151110.12204
-  hps: 174701.10779
+  dps: 385665.8098
+  tps: 1.91520853977e+06
+  dtps: 154576.11351
+  hps: 178956.12813
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RelicofXuen-79327"
  value: {
-  dps: 389346.46242
-  tps: 1.92109329055e+06
-  dtps: 148203.20474
-  hps: 172318.49599
+  dps: 389234.7839
+  tps: 1.91777683724e+06
+  dtps: 150570.32871
+  hps: 172823.66522
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RelicofXuen-79328"
  value: {
-  dps: 384479.89017
-  tps: 1.90993611845e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 384110.8269
+  tps: 1.91240736407e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RelicofYu'lon-79331"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Renataki'sSoulCharm-96741"
  value: {
-  dps: 392628.49161
-  tps: 1.94291227835e+06
-  dtps: 152139.03278
-  hps: 175163.66364
+  dps: 393850.51489
+  tps: 1.94371486449e+06
+  dtps: 150968.0431
+  hps: 174070.414
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ResolveofNiuzao-103990"
  value: {
-  dps: 382074.9619
-  tps: 1.89556802653e+06
-  dtps: 152847.63027
-  hps: 182260.65756
+  dps: 382690.2547
+  tps: 1.89280943768e+06
+  dtps: 153589.12149
+  hps: 180720.79894
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReverberatingPrimalDiamond"
  value: {
-  dps: 391414.58124
-  tps: 1.93268936101e+06
-  dtps: 169678.14942
-  hps: 188174.2507
+  dps: 392419.40074
+  tps: 1.93382851364e+06
+  dtps: 168849.31214
+  hps: 187098.12861
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RevitalizingPrimalDiamond"
  value: {
-  dps: 390394.33821
-  tps: 1.9286201563e+06
-  dtps: 169920.22055
-  hps: 188418.3512
+  dps: 391628.93685
+  tps: 1.93106083882e+06
+  dtps: 169474.45491
+  hps: 187813.51388
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuneofCinderglacier-3369"
  value: {
-  dps: 385634.84156
-  tps: 1.93681158046e+06
-  dtps: 155712.19909
-  hps: 171568.29342
+  dps: 385942.44775
+  tps: 1.93265045965e+06
+  dtps: 158195.62215
+  hps: 174063.95289
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuneofRazorice-3370"
  value: {
-  dps: 386914.55402
-  tps: 1.95547461042e+06
-  dtps: 155997.43194
-  hps: 171551.06885
+  dps: 387742.75534
+  tps: 1.94682367746e+06
+  dtps: 158351.32441
+  hps: 173715.48557
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuneofRe-Origination-96918"
  value: {
-  dps: 412231.92783
-  tps: 2.06235312682e+06
-  dtps: 151307.21953
-  hps: 165881.56597
+  dps: 411204.36804
+  tps: 2.04764224372e+06
+  dtps: 149849.76326
+  hps: 162247.44117
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuneofSpellbreaking-3595"
  value: {
-  dps: 378977.44657
-  tps: 1.89991485829e+06
-  dtps: 155997.43194
-  hps: 171551.06885
+  dps: 379801.99383
+  tps: 1.89123834689e+06
+  dtps: 158351.32441
+  hps: 173715.48557
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuneofSpellshattering-3367"
  value: {
-  dps: 378977.44657
-  tps: 1.89991485829e+06
-  dtps: 155997.43194
-  hps: 171551.06885
+  dps: 379801.99383
+  tps: 1.89123834689e+06
+  dtps: 158351.32441
+  hps: 173715.48557
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuneofSwordbreaking-3594"
  value: {
-  dps: 379176.78967
-  tps: 1.88555666702e+06
-  dtps: 151138.43024
-  hps: 169120.45165
+  dps: 379961.60361
+  tps: 1.88541564214e+06
+  dtps: 153152.48371
+  hps: 172506.74574
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuneofSwordshattering-3365"
  value: {
-  dps: 379940.25569
-  tps: 1.8830295136e+06
-  dtps: 148335.75842
-  hps: 168459.24415
+  dps: 379312.42703
+  tps: 1.88269644446e+06
+  dtps: 149698.97679
+  hps: 169607.17321
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuneoftheNerubianCarapace-3883"
  value: {
-  dps: 378748.54828
-  tps: 1.89368861924e+06
-  dtps: 154867.71384
-  hps: 170689.65993
+  dps: 379565.95051
+  tps: 1.88983405117e+06
+  dtps: 157293.47872
+  hps: 173697.13956
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuneoftheStoneskinGargoyle-3847"
  value: {
-  dps: 379654.41121
-  tps: 1.89531552548e+06
-  dtps: 154416.58159
-  hps: 171358.66563
+  dps: 380388.8577
+  tps: 1.89234007664e+06
+  dtps: 155465.72096
+  hps: 172752.22586
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SI:7Operative'sManual-92784"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScrollofReveredAncestors-89080"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SearingWords-81267"
  value: {
-  dps: 389252.53887
-  tps: 1.93388800715e+06
-  dtps: 151487.09957
-  hps: 174255.69562
+  dps: 388936.36572
+  tps: 1.93660481789e+06
+  dtps: 153994.24809
+  hps: 175303.43049
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Shock-ChargerMedallion-93259"
  value: {
-  dps: 386924.6026
-  tps: 1.9118075028e+06
-  dtps: 152736.67768
-  hps: 174527.80369
+  dps: 388436.82556
+  tps: 1.92124164844e+06
+  dtps: 150078.05359
+  hps: 172188.22419
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigilofCompassion-83736"
  value: {
-  dps: 385096.17926
-  tps: 1.92086791217e+06
-  dtps: 151559.70092
-  hps: 177013.91329
+  dps: 384186.61717
+  tps: 1.90987419902e+06
+  dtps: 154864.53899
+  hps: 179644.1429
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigilofDevotion-83740"
  value: {
-  dps: 388201.1894
-  tps: 1.93003848583e+06
-  dtps: 151137.72553
-  hps: 177437.919
+  dps: 388004.63629
+  tps: 1.92932647781e+06
+  dtps: 153496.733
+  hps: 179050.35452
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigilofFidelity-83737"
  value: {
-  dps: 394840.61124
-  tps: 1.93502882614e+06
-  dtps: 151688.12473
-  hps: 173690.3457
+  dps: 395027.77051
+  tps: 1.93733231857e+06
+  dtps: 151375.86599
+  hps: 171741.16396
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigilofGrace-83738"
  value: {
-  dps: 392807.43452
-  tps: 1.93650034349e+06
-  dtps: 154164.31062
-  hps: 178033.68479
+  dps: 389265.5814
+  tps: 1.92269605021e+06
+  dtps: 151088.83567
+  hps: 173843.78195
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigilofKypariZar-84076"
  value: {
-  dps: 389956.3756
-  tps: 1.93450093229e+06
-  dtps: 150670.5851
-  hps: 177224.98812
+  dps: 390551.70894
+  tps: 1.93963444392e+06
+  dtps: 154165.37502
+  hps: 178995.23938
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigilofPatience-83739"
  value: {
-  dps: 387286.42566
-  tps: 1.91946863652e+06
-  dtps: 149968.21687
-  hps: 177268.87908
+  dps: 386306.31504
+  tps: 1.91970740912e+06
+  dtps: 153424.41044
+  hps: 178513.45264
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigilofRampage-105580"
  value: {
-  dps: 384800.95084
-  tps: 1.90997606131e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 384437.3456
+  tps: 1.91287879643e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SigiloftheCatacombs-83732"
  value: {
-  dps: 393138.4318
-  tps: 1.95320735937e+06
-  dtps: 151935.79594
-  hps: 172297.98244
+  dps: 393662.81087
+  tps: 1.94375721091e+06
+  dtps: 153472.08247
+  hps: 174160.45606
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SinisterPrimalDiamond"
  value: {
-  dps: 388840.51272
-  tps: 1.91451508404e+06
-  dtps: 169920.22055
-  hps: 188334.58647
+  dps: 390065.27629
+  tps: 1.91758680011e+06
+  dtps: 169474.45491
+  hps: 187729.90625
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Skeer'sBloodsoakedTalisman-105632"
  value: {
-  dps: 412382.27953
-  tps: 2.03703634439e+06
-  dtps: 147463.00229
-  hps: 169449.62942
+  dps: 411390.90505
+  tps: 2.0334340427e+06
+  dtps: 147672.95045
+  hps: 173818.73893
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SkullrenderMedallion-93256"
  value: {
-  dps: 393270.022
-  tps: 1.94754510264e+06
-  dtps: 150034.71966
-  hps: 173617.92508
+  dps: 394974.82785
+  tps: 1.95355117583e+06
+  dtps: 150443.69456
+  hps: 173323.65737
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SoothingTalismanoftheShado-PanAssault-94509"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SoulBarrier-96927"
  value: {
-  dps: 386351.19538
-  tps: 1.9237806999e+06
-  dtps: 150620.91074
-  hps: 175548.8646
+  dps: 385442.74338
+  tps: 1.90980012577e+06
+  dtps: 153287.68962
+  hps: 178727.42199
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SparkofZandalar-96770"
  value: {
-  dps: 392351.58647
-  tps: 1.94214078363e+06
-  dtps: 146916.94154
-  hps: 173205.33949
+  dps: 395410.53705
+  tps: 1.95107649917e+06
+  dtps: 148171.03789
+  hps: 174405.32424
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SpiritsoftheSun-87163"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SpringrainIdolofDestruction-101023"
  value: {
-  dps: 388791.58954
-  tps: 1.92085663803e+06
-  dtps: 151984.64218
-  hps: 179507.94052
+  dps: 389396.98484
+  tps: 1.92426545619e+06
+  dtps: 154291.75954
+  hps: 181204.57761
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SpringrainIdolofRage-101009"
  value: {
-  dps: 385148.80863
-  tps: 1.91862325829e+06
-  dtps: 151912.16267
-  hps: 180516.82017
+  dps: 383156.34846
+  tps: 1.90790790935e+06
+  dtps: 153440.14388
+  hps: 179310.87894
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SpringrainStoneofDestruction-101026"
  value: {
-  dps: 385945.30461
-  tps: 1.90394137339e+06
-  dtps: 152300.84353
-  hps: 178304.79838
+  dps: 385219.23324
+  tps: 1.90454437561e+06
+  dtps: 151461.43982
+  hps: 181036.28456
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SpringrainStoneofRage-101012"
  value: {
-  dps: 385715.65268
-  tps: 1.90518789133e+06
-  dtps: 151350.12055
-  hps: 178808.36288
+  dps: 385874.10847
+  tps: 1.90272266772e+06
+  dtps: 151708.32123
+  hps: 179906.32511
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SpringrainStoneofWisdom-101041"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Static-Caster'sMedallion-93254"
  value: {
-  dps: 386924.6026
-  tps: 1.9118075028e+06
-  dtps: 152736.67768
-  hps: 174527.80369
+  dps: 388436.82556
+  tps: 1.92124164844e+06
+  dtps: 150078.05359
+  hps: 172188.22419
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SteadfastFootman'sMedallion-92782"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SteadfastTalismanoftheShado-PanAssault-94507"
  value: {
-  dps: 383518.66469
-  tps: 1.90388288705e+06
-  dtps: 153138.11291
-  hps: 184124.19548
+  dps: 383080.88332
+  tps: 1.90054655233e+06
+  dtps: 153159.80914
+  hps: 180002.67233
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StreamtalkerIdolofDestruction-101222"
  value: {
-  dps: 391250.3522
-  tps: 1.93913940568e+06
-  dtps: 150922.02396
-  hps: 179746.98518
+  dps: 390684.39619
+  tps: 1.93761030526e+06
+  dtps: 153082.82275
+  hps: 180380.64308
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StreamtalkerIdolofRage-101217"
  value: {
-  dps: 385230.03709
-  tps: 1.91880409468e+06
-  dtps: 151912.16267
-  hps: 180516.82017
+  dps: 383144.19678
+  tps: 1.90776796658e+06
+  dtps: 153440.14388
+  hps: 179310.87894
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StreamtalkerStoneofDestruction-101225"
  value: {
-  dps: 383989.2738
-  tps: 1.90743238687e+06
-  dtps: 151258.81792
-  hps: 179910.37521
+  dps: 386080.18456
+  tps: 1.9113226884e+06
+  dtps: 152071.26582
+  hps: 180667.2811
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StreamtalkerStoneofRage-101220"
  value: {
-  dps: 384778.73963
-  tps: 1.91204843422e+06
-  dtps: 150833.78422
-  hps: 176710.40905
+  dps: 385522.03257
+  tps: 1.90951595527e+06
+  dtps: 152299.65251
+  hps: 179571.84649
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StreamtalkerStoneofWisdom-101250"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StuffofNightmares-87160"
  value: {
-  dps: 395228.35456
-  tps: 1.93876601205e+06
-  dtps: 151410.17987
-  hps: 180902.03552
+  dps: 392123.78015
+  tps: 1.92579307652e+06
+  dtps: 150673.56358
+  hps: 179204.92086
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SunsoulDefenderIdol-101160"
  value: {
-  dps: 391762.62839
-  tps: 1.92922764791e+06
-  dtps: 149780.78122
-  hps: 174478.6562
+  dps: 391145.80005
+  tps: 1.9278006293e+06
+  dtps: 150697.57459
+  hps: 175153.32074
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SunsoulDefenderStone-101163"
  value: {
-  dps: 387074.52896
-  tps: 1.92142443845e+06
-  dtps: 152552.92104
-  hps: 178913.34125
+  dps: 384066.64114
+  tps: 1.90433195671e+06
+  dtps: 151765.46887
+  hps: 182081.3267
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SunsoulIdolofBattle-101152"
  value: {
-  dps: 394347.7232
-  tps: 1.95309539689e+06
-  dtps: 148791.96936
-  hps: 173058.86409
+  dps: 391380.44803
+  tps: 1.93947714916e+06
+  dtps: 151278.19049
+  hps: 174169.72238
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SunsoulStoneofBattle-101151"
  value: {
-  dps: 389284.79514
-  tps: 1.92539304018e+06
-  dtps: 149864.35658
-  hps: 176296.43666
+  dps: 387063.15614
+  tps: 1.90706974869e+06
+  dtps: 151628.84401
+  hps: 180416.98994
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SunsoulStoneofWisdom-101138"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SwordguardEmbroidery(Rank3)-4894"
  value: {
-  dps: 388567.10503
-  tps: 1.92877782702e+06
-  dtps: 151539.99186
-  hps: 176790.06096
+  dps: 387062.50874
+  tps: 1.91467704114e+06
+  dtps: 153123.04176
+  hps: 178615.33114
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SymboloftheCatacombs-83735"
  value: {
-  dps: 389826.54076
-  tps: 1.94142407176e+06
-  dtps: 151559.70092
-  hps: 177011.60108
+  dps: 387537.01966
+  tps: 1.92079122019e+06
+  dtps: 155225.25544
+  hps: 180122.82997
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SynapseSprings(MarkII)-4898"
  value: {
-  dps: 385604.93932
-  tps: 1.91441873596e+06
-  dtps: 149909.29561
-  hps: 175042.27751
+  dps: 384378.24573
+  tps: 1.91674045953e+06
+  dtps: 153280.75355
+  hps: 177491.74026
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TalismanofBloodlust-96864"
  value: {
-  dps: 393457.47701
-  tps: 1.94584388116e+06
-  dtps: 152907.03753
-  hps: 176950.382
+  dps: 394457.36229
+  tps: 1.94177856676e+06
+  dtps: 151647.16204
+  hps: 175043.33795
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TerrorintheMists-87167"
  value: {
-  dps: 396775.92385
-  tps: 1.95969417762e+06
-  dtps: 152201.63472
-  hps: 174953.05956
+  dps: 397282.62553
+  tps: 1.95973972357e+06
+  dtps: 154066.54558
+  hps: 177589.06847
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thok'sAcid-GroovedTooth-105607"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thok'sTailTip-105609"
  value: {
-  dps: 404621.17816
-  tps: 1.9849016287e+06
-  dtps: 146651.42342
-  hps: 174977.82274
+  dps: 407449.81492
+  tps: 1.98742616155e+06
+  dtps: 147249.52485
+  hps: 176007.99064
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Thousand-YearPickledEgg-257881"
  value: {
-  dps: 392585.4809
-  tps: 1.94192936981e+06
-  dtps: 151961.64752
-  hps: 173983.13887
+  dps: 390543.23205
+  tps: 1.93579274356e+06
+  dtps: 151720.53981
+  hps: 173341.55992
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TickingEbonDetonator-105612"
  value: {
-  dps: 387130.63103
-  tps: 1.91481200594e+06
-  dtps: 152169.86762
-  hps: 183707.72215
+  dps: 386648.87308
+  tps: 1.90362051417e+06
+  dtps: 154322.75749
+  hps: 183852.56344
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Time-LostArtifact-103678"
  value: {
-  dps: 394080.65766
-  tps: 1.93979616728e+06
-  dtps: 152466.95016
-  hps: 178407.91545
+  dps: 392326.59034
+  tps: 1.92851434002e+06
+  dtps: 153230.12806
+  hps: 181056.31784
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrailseekerIdolofRage-101054"
  value: {
-  dps: 385272.10595
-  tps: 1.91956485274e+06
-  dtps: 151912.16267
-  hps: 180516.82017
+  dps: 383242.78441
+  tps: 1.90852872464e+06
+  dtps: 153440.14388
+  hps: 179310.87894
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TrailseekerStoneofRage-101057"
  value: {
-  dps: 386453.1237
-  tps: 1.90738626368e+06
-  dtps: 152435.25385
-  hps: 179170.15687
+  dps: 386375.79285
+  tps: 1.90648533035e+06
+  dtps: 151337.75326
+  hps: 179850.42776
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TyrannicalGladiator'sBadgeofConquest-100043"
  value: {
-  dps: 384371.96116
-  tps: 1.90928360389e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 384046.07334
+  tps: 1.91103914845e+06
+  dtps: 154129.20945
+  hps: 175318.42285
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TyrannicalGladiator'sBadgeofDominance-100016"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TyrannicalGladiator'sBadgeofVictory-100019"
  value: {
-  dps: 388928.41066
-  tps: 1.92550396738e+06
-  dtps: 149335.35274
-  hps: 173989.3057
+  dps: 387128.19534
+  tps: 1.91827831751e+06
+  dtps: 152092.12538
+  hps: 174424.70835
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TyrannicalGladiator'sEmblemofCruelty-100066"
  value: {
-  dps: 390551.48908
-  tps: 1.94014541786e+06
-  dtps: 151637.69438
-  hps: 174944.70857
+  dps: 390076.42461
+  tps: 1.94163407866e+06
+  dtps: 153994.24809
+  hps: 175503.243
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TyrannicalGladiator'sEmblemofMeditation-99990"
  value: {
-  dps: 384023.78495
-  tps: 1.90733358115e+06
-  dtps: 151637.69438
-  hps: 174874.21669
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175432.75111
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TyrannicalGladiator'sEmblemofTenacity-100092"
  value: {
-  dps: 385868.03655
-  tps: 1.91982007111e+06
-  dtps: 151110.12204
-  hps: 174786.02095
+  dps: 385665.8098
+  tps: 1.91520853977e+06
+  dtps: 154576.11351
+  hps: 179027.8035
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TyrannicalGladiator'sInsigniaofConquest-100026"
  value: {
-  dps: 384357.9033
-  tps: 1.90914366113e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 384061.8078
+  tps: 1.91103914845e+06
+  dtps: 154129.20945
+  hps: 175318.42285
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TyrannicalGladiator'sInsigniaofDominance-100152"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TyrannicalGladiator'sInsigniaofVictory-100085"
  value: {
-  dps: 388648.51889
-  tps: 1.91016762685e+06
-  dtps: 148716.80789
-  hps: 172392.34942
+  dps: 388379.90416
+  tps: 1.91826927293e+06
+  dtps: 149947.80275
+  hps: 173746.38826
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TyrannicalPrimalDiamond"
  value: {
-  dps: 387331.03211
-  tps: 1.9087399289e+06
-  dtps: 169920.22055
-  hps: 188334.58647
+  dps: 388546.41519
+  tps: 1.91104008074e+06
+  dtps: 169474.45491
+  hps: 187729.90625
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UnerringVisionofLeiShen-96930"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-VaporshieldMedallion-93262"
  value: {
-  dps: 388276.76122
-  tps: 1.93230908912e+06
-  dtps: 149844.25986
-  hps: 173788.24298
+  dps: 388918.33242
+  tps: 1.9291740846e+06
+  dtps: 151408.10717
+  hps: 174480.96105
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-VialofDragon'sBlood-87063"
  value: {
-  dps: 387366.03184
-  tps: 1.91237556518e+06
-  dtps: 149723.09729
-  hps: 178439.36549
+  dps: 387923.31381
+  tps: 1.91496322116e+06
+  dtps: 148770.44628
+  hps: 175826.37138
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-VialofIchorousBlood-100963"
  value: {
-  dps: 384059.79084
-  tps: 1.90749452925e+06
-  dtps: 151487.09957
-  hps: 174197.79622
+  dps: 383640.53558
+  tps: 1.90970208413e+06
+  dtps: 153994.24809
+  hps: 175245.53109
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-VialofLivingCorruption-105568"
  value: {
-  dps: 390913.46328
-  tps: 1.91052782661e+06
-  dtps: 150207.83985
-  hps: 175729.31314
+  dps: 392591.60459
+  tps: 1.91217575827e+06
+  dtps: 152417.05285
+  hps: 178802.78913
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousTalismanoftheShado-PanAssault-94511"
  value: {
-  dps: 387524.45743
-  tps: 1.92152842715e+06
-  dtps: 151420.74079
-  hps: 172886.24403
+  dps: 386947.26338
+  tps: 1.91516225205e+06
+  dtps: 152467.54566
+  hps: 173923.37499
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-VisionofthePredator-81192"
  value: {
-  dps: 388846.63689
-  tps: 1.92084201092e+06
-  dtps: 151808.4138
-  hps: 174935.07701
+  dps: 389203.01235
+  tps: 1.92385479599e+06
+  dtps: 154305.29914
+  hps: 175996.16779
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-VolatileTalismanoftheShado-PanAssault-94510"
  value: {
-  dps: 390059.16586
-  tps: 1.91980758919e+06
-  dtps: 152753.68621
-  hps: 172919.70098
+  dps: 390497.94331
+  tps: 1.93200154323e+06
+  dtps: 152482.06398
+  hps: 172371.5375
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WindsweptPages-81125"
  value: {
-  dps: 392008.83843
-  tps: 1.94838253525e+06
-  dtps: 150739.46793
-  hps: 173541.27189
+  dps: 394598.34361
+  tps: 1.93643923121e+06
+  dtps: 152931.56594
+  hps: 175035.77414
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WoundripperMedallion-93253"
  value: {
-  dps: 390900.44801
-  tps: 1.93183828541e+06
-  dtps: 151305.91937
-  hps: 172372.60624
+  dps: 390886.70601
+  tps: 1.93845162283e+06
+  dtps: 154456.74241
+  hps: 175668.51982
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Wushoolay'sFinalChoice-96785"
  value: {
-  dps: 389460.72619
-  tps: 1.93373704686e+06
-  dtps: 149735.65664
-  hps: 173108.36718
+  dps: 384925.09522
+  tps: 1.90430278749e+06
+  dtps: 152237.70842
+  hps: 174212.5211
  }
 }
 dps_results: {
@@ -2652,252 +2652,252 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-Yu'lon'sBite-103987"
  value: {
-  dps: 398566.36681
-  tps: 1.95843904095e+06
-  dtps: 153097.41169
-  hps: 176282.18815
+  dps: 396593.27516
+  tps: 1.95308656687e+06
+  dtps: 154021.80961
+  hps: 177226.25462
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ZenAlchemistStone-75274"
  value: {
-  dps: 389460.57054
-  tps: 1.93114103007e+06
-  dtps: 149761.11884
-  hps: 177495.50556
+  dps: 386951.82199
+  tps: 1.91378504199e+06
+  dtps: 151846.12513
+  hps: 177070.99025
  }
 }
 dps_results: {
  key: "TestBlood-Average-Default"
  value: {
-  dps: 380049.50967
-  tps: 1.89499337427e+06
-  dtps: 148458.60533
-  hps: 171218.06533
+  dps: 380010.41191
+  tps: 1.89424111513e+06
+  dtps: 148335.25285
+  hps: 171029.94813
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p5-DefaultTalents-Basic-iron_juggernaut-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 8.10902081563e+06
-  tps: 5.146415260402e+07
-  dtps: 975271.3865
-  hps: 295153.96554
+  dps: 8.12545101065e+06
+  tps: 5.145718380498e+07
+  dtps: 975529.46524
+  hps: 295183.62349
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p5-DefaultTalents-Basic-iron_juggernaut-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 264146.89085
-  tps: 1.63433728512e+06
-  dtps: 51334.71048
-  hps: 95407.67229
+  dps: 266696.15859
+  tps: 1.65102227134e+06
+  dtps: 51348.69151
+  hps: 95427.75441
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p5-DefaultTalents-Basic-iron_juggernaut-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 338292.1533
-  tps: 1.79708755294e+06
+  dps: 339249.48771
+  tps: 1.79843096046e+06
   dtps: 52284.98172
-  hps: 98927.1365
+  hps: 98837.90975
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p5-DefaultTalents-Basic-iron_juggernaut-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 6.50896283718e+06
-  tps: 4.091587966386e+07
-  dtps: 1.0153310815e+06
-  hps: 231263.8681
+  dps: 6.54954660657e+06
+  tps: 4.11739185734e+07
+  dtps: 1.01583072479e+06
+  hps: 230630.37573
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p5-DefaultTalents-Basic-iron_juggernaut-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 228500.96825
-  tps: 1.45213794644e+06
-  dtps: 53590.01464
-  hps: 84368.44082
+  dps: 229516.21348
+  tps: 1.45868535601e+06
+  dtps: 53596.1509
+  hps: 84507.21053
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p5-DefaultTalents-Basic-iron_juggernaut-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 243904.03991
-  tps: 1.39858653003e+06
-  dtps: 55091.99395
-  hps: 82084.7769
+  dps: 245996.77224
+  tps: 1.41114468023e+06
+  dtps: 55112.99975
+  hps: 82498.87771
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p5-RC-example-build-Basic-iron_juggernaut-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 8.98953778893e+06
-  tps: 5.174502130886e+07
-  dtps: 967335.65601
-  hps: 280692.25481
+  dps: 8.93015744837e+06
+  tps: 5.180212864292e+07
+  dtps: 967005.4471
+  hps: 281044.53398
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p5-RC-example-build-Basic-iron_juggernaut-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 281137.90856
-  tps: 1.75098834575e+06
-  dtps: 51203.77571
-  hps: 97303.90803
+  dps: 279458.52932
+  tps: 1.73676465519e+06
+  dtps: 51233.01439
+  hps: 97417.74905
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p5-RC-example-build-Basic-iron_juggernaut-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 352284.08661
-  tps: 1.89383170486e+06
+  dps: 351447.61517
+  tps: 1.88265505055e+06
   dtps: 52284.98172
-  hps: 101157.6386
+  hps: 101199.59226
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p5-RC-example-build-Basic-iron_juggernaut-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 6.8901849374e+06
-  tps: 4.047583785728e+07
-  dtps: 1.0096683301e+06
-  hps: 219154.13461
+  dps: 6.92529398433e+06
+  tps: 4.068169755988e+07
+  dtps: 1.00943027336e+06
+  hps: 218090.25489
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p5-RC-example-build-Basic-iron_juggernaut-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 235359.14652
-  tps: 1.4985009229e+06
-  dtps: 52710.92765
-  hps: 81529.72104
+  dps: 235651.20719
+  tps: 1.49995073884e+06
+  dtps: 52810.56452
+  hps: 81345.99977
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p5-RC-example-build-Basic-iron_juggernaut-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 247758.50934
-  tps: 1.42327941266e+06
+  dps: 248278.16511
+  tps: 1.42731344203e+06
   dtps: 54508.22293
-  hps: 80192.79057
+  hps: 80156.94952
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Worgen-p5-DefaultTalents-Basic-iron_juggernaut-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 8.14511614511e+06
-  tps: 5.178896227654e+07
-  dtps: 975231.77258
-  hps: 295094.68151
+  dps: 8.14916562375e+06
+  tps: 5.173238292775e+07
+  dtps: 975461.14006
+  hps: 295128.33764
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Worgen-p5-DefaultTalents-Basic-iron_juggernaut-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 264291.54307
-  tps: 1.63970454211e+06
-  dtps: 51334.71048
-  hps: 95419.85913
+  dps: 266384.4234
+  tps: 1.65295121611e+06
+  dtps: 51359.14768
+  hps: 95307.8478
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Worgen-p5-DefaultTalents-Basic-iron_juggernaut-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 336345.29586
-  tps: 1.79984870518e+06
+  dps: 336766.20218
+  tps: 1.79774809876e+06
   dtps: 52284.98172
-  hps: 98944.39553
+  hps: 98914.47232
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Worgen-p5-DefaultTalents-Basic-iron_juggernaut-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 6.53353195475e+06
-  tps: 4.116291448604e+07
-  dtps: 1.01540267747e+06
-  hps: 231291.88729
+  dps: 6.5815876761e+06
+  tps: 4.148331482085e+07
+  dtps: 1.01560804963e+06
+  hps: 230627.05538
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Worgen-p5-DefaultTalents-Basic-iron_juggernaut-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 228870.56834
-  tps: 1.45706201087e+06
-  dtps: 53605.83041
-  hps: 84649.06175
+  dps: 229471.01519
+  tps: 1.46126631017e+06
+  dtps: 53577.44321
+  hps: 84510.00638
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Worgen-p5-DefaultTalents-Basic-iron_juggernaut-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 242943.8578
-  tps: 1.40063209693e+06
-  dtps: 55091.99395
-  hps: 82214.56884
+  dps: 244969.89809
+  tps: 1.4126961454e+06
+  dtps: 55112.99975
+  hps: 82628.66772
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Worgen-p5-RC-example-build-Basic-iron_juggernaut-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 8.9971062974e+06
-  tps: 5.205166314226e+07
-  dtps: 967156.46646
-  hps: 280958.10107
+  dps: 8.93228273986e+06
+  tps: 5.21374495724e+07
+  dtps: 967334.08783
+  hps: 281637.47398
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Worgen-p5-RC-example-build-Basic-iron_juggernaut-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 282212.73182
-  tps: 1.76255093783e+06
-  dtps: 51203.77571
-  hps: 97235.29556
+  dps: 280414.12019
+  tps: 1.74815716156e+06
+  dtps: 51233.01439
+  hps: 97284.41939
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Worgen-p5-RC-example-build-Basic-iron_juggernaut-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 350812.67689
-  tps: 1.90051842242e+06
+  dps: 349427.84053
+  tps: 1.88582264536e+06
   dtps: 52284.98172
-  hps: 101272.60755
+  hps: 101314.56603
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Worgen-p5-RC-example-build-Basic-iron_juggernaut-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 6.93519279585e+06
-  tps: 4.075003135563e+07
-  dtps: 1.00968913363e+06
-  hps: 219189.77375
+  dps: 6.94361682464e+06
+  tps: 4.091489719405e+07
+  dtps: 1.00930444078e+06
+  hps: 218105.81047
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Worgen-p5-RC-example-build-Basic-iron_juggernaut-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 235672.88523
-  tps: 1.50355559883e+06
-  dtps: 52774.92227
-  hps: 81413.4339
+  dps: 235786.82565
+  tps: 1.50398122514e+06
+  dtps: 52683.82462
+  hps: 81328.44312
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Worgen-p5-RC-example-build-Basic-iron_juggernaut-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 246906.16586
-  tps: 1.42664604583e+06
+  dps: 247439.59735
+  tps: 1.43065416932e+06
   dtps: 54508.22293
-  hps: 80267.17604
+  hps: 80231.335
  }
 }
 dps_results: {
  key: "TestBlood-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 403408.99392
-  tps: 1.99650042813e+06
-  dtps: 150054.43026
-  hps: 174794.20235
+  dps: 404857.07828
+  tps: 2.00305003636e+06
+  dtps: 150327.33669
+  hps: 175370.62538
  }
 }

--- a/sim/death_knight/frost/TestFrostMasterfrost.results
+++ b/sim/death_knight/frost/TestFrostMasterfrost.results
@@ -33,1577 +33,1577 @@ character_stats_results: {
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-AgilePrimalDiamond"
  value: {
-  dps: 431238.02491
-  tps: 398601.56131
-  hps: 4330.83046
+  dps: 432185.29832
+  tps: 399332.42425
+  hps: 4356.57038
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-AlacrityofXuen-103989"
  value: {
-  dps: 401472.83392
-  tps: 372085.78951
-  hps: 4339.18096
+  dps: 403726.52654
+  tps: 374000.7744
+  hps: 4404.18932
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-ArcaneBadgeoftheShieldwall-93347"
  value: {
-  dps: 383912.15726
-  tps: 357725.39606
-  hps: 4291.27651
+  dps: 385174.77705
+  tps: 358708.56758
+  hps: 4261.3746
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-ArrowflightMedallion-93258"
  value: {
-  dps: 387423.90751
-  tps: 360709.51668
-  hps: 4358.89618
+  dps: 388269.68674
+  tps: 361374.79022
+  hps: 4388.33429
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-AssuranceofConsequence-105472"
  value: {
-  dps: 385028.2743
-  tps: 358901.91672
-  hps: 4294.87242
+  dps: 384483.77187
+  tps: 358222.75809
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-AusterePrimalDiamond"
  value: {
-  dps: 424431.1595
-  tps: 391846.67866
-  hps: 4314.03544
+  dps: 425234.62871
+  tps: 392445.38648
+  hps: 4342.74229
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BadJuju-96781"
  value: {
-  dps: 393176.04384
-  tps: 367112.88424
-  hps: 4294.87242
+  dps: 392663.0331
+  tps: 366476.46539
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BadgeofKypariZar-84079"
  value: {
-  dps: 390597.28339
-  tps: 364233.86765
-  hps: 4333.52519
+  dps: 390056.89809
+  tps: 363595.72749
+  hps: 4316.55346
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BattlegearoftheLostCatacomb"
  value: {
-  dps: 315315.53337
-  tps: 289150.07585
-  hps: 2556.77913
+  dps: 314560.84187
+  tps: 288229.02187
+  hps: 2564.16207
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BattleplateofCyclopeanDread"
  value: {
-  dps: 347093.97416
-  tps: 319270.11613
-  hps: 3817.21123
+  dps: 348127.74511
+  tps: 319988.52719
+  hps: 3781.83069
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BattleplateoftheAll-ConsumingMaw"
  value: {
-  dps: 331469.09433
-  tps: 297043.9129
-  hps: 2797.29334
+  dps: 331447.90894
+  tps: 297064.21865
+  hps: 2769.94395
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BlackBloodofY'Shaarj-105648"
  value: {
-  dps: 389371.47408
-  tps: 362889.83073
-  hps: 4327.8508
+  dps: 389365.69034
+  tps: 362793.58272
+  hps: 4368.84866
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BlossomofPureSnow-89081"
  value: {
-  dps: 386883.16534
-  tps: 360253.3288
-  hps: 4358.74702
+  dps: 387708.74443
+  tps: 360886.95559
+  hps: 4379.26526
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BottleofInfiniteStars-87057"
  value: {
-  dps: 390487.4531
-  tps: 364451.72558
-  hps: 4294.87242
+  dps: 389884.54536
+  tps: 363731.37129
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BraidofTenSongs-84072"
  value: {
-  dps: 387897.85097
-  tps: 361742.55907
-  hps: 4294.50981
+  dps: 389207.31619
+  tps: 363012.64074
+  hps: 4245.41592
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Brawler'sStatue-257885"
  value: {
-  dps: 382391.85587
-  tps: 356391.72647
-  hps: 4254.68465
+  dps: 383253.86213
+  tps: 357061.34774
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BreathoftheHydra-96827"
  value: {
-  dps: 389048.8585
-  tps: 362691.87684
-  hps: 4297.19729
+  dps: 389436.75593
+  tps: 362899.86335
+  hps: 4326.3037
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BroochofMunificentDeeds-87500"
  value: {
-  dps: 382418.16231
-  tps: 356438.38737
-  hps: 4395.8047
+  dps: 384649.19727
+  tps: 358497.06782
+  hps: 4410.88469
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BrutalTalismanoftheShado-PanAssault-94508"
  value: {
-  dps: 399140.60561
-  tps: 370605.80703
-  hps: 4262.82482
+  dps: 400075.35069
+  tps: 371230.7548
+  hps: 4291.10156
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-BurningPrimalDiamond"
  value: {
-  dps: 431187.33328
-  tps: 398554.25977
-  hps: 4330.83046
+  dps: 432126.01676
+  tps: 399278.65717
+  hps: 4356.57038
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CapacitivePrimalDiamond"
  value: {
-  dps: 439133.39803
-  tps: 406272.23079
-  hps: 4373.9791
+  dps: 439748.11208
+  tps: 406763.81175
+  hps: 4348.30743
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CarbonicCarbuncle-81138"
  value: {
-  dps: 395985.5586
-  tps: 368422.04766
-  hps: 4357.65945
+  dps: 395568.48369
+  tps: 367869.86257
+  hps: 4350.35092
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Cha-Ye'sEssenceofBrilliance-96888"
  value: {
-  dps: 391318.60442
-  tps: 364722.10257
-  hps: 4395.56613
+  dps: 390510.72014
+  tps: 363832.55469
+  hps: 4369.86153
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CharmofTenSongs-84071"
  value: {
-  dps: 386106.31287
-  tps: 359570.68348
-  hps: 4344.67765
+  dps: 388960.79738
+  tps: 362512.81019
+  hps: 4343.90651
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CommunalIdolofDestruction-101168"
  value: {
-  dps: 389968.5795
-  tps: 363411.28866
-  hps: 4251.58894
+  dps: 390891.99861
+  tps: 364243.77421
+  hps: 4292.77683
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CommunalStoneofDestruction-101171"
  value: {
-  dps: 390685.32658
-  tps: 364692.8491
-  hps: 4294.87242
+  dps: 390128.35331
+  tps: 364012.51548
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CommunalStoneofWisdom-101183"
  value: {
-  dps: 384340.91287
-  tps: 358348.43539
-  hps: 4294.87242
+  dps: 383752.25172
+  tps: 357636.41389
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-ContemplationofChi-Ji-103988"
  value: {
-  dps: 383581.77064
-  tps: 357552.99831
-  hps: 4293.99289
+  dps: 383936.67606
+  tps: 357787.22337
+  hps: 4277.56622
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Coren'sColdChromiumCoaster-257880"
  value: {
-  dps: 396389.88577
-  tps: 368970.08328
-  hps: 4346.90222
+  dps: 395934.61598
+  tps: 368417.04535
+  hps: 4332.34746
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CoreofDecency-87497"
  value: {
-  dps: 384340.91287
-  tps: 358348.43539
-  hps: 4294.87242
+  dps: 383752.25172
+  tps: 357636.41389
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CourageousPrimalDiamond"
  value: {
-  dps: 424459.21035
-  tps: 391875.42319
-  hps: 4293.48791
+  dps: 425359.22011
+  tps: 392563.54138
+  hps: 4317.94905
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedDreadfulGladiator'sBadgeofConquest-93419"
  value: {
-  dps: 382553.31701
-  tps: 356534.32518
-  hps: 4254.68465
+  dps: 383385.71354
+  tps: 357173.05603
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedDreadfulGladiator'sBadgeofDominance-93600"
  value: {
-  dps: 382391.85587
-  tps: 356391.72647
-  hps: 4254.68465
+  dps: 383253.86213
+  tps: 357061.34774
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedDreadfulGladiator'sBadgeofVictory-93606"
  value: {
-  dps: 389305.80493
-  tps: 362440.03415
-  hps: 4254.68465
+  dps: 390236.91207
+  tps: 363167.3298
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedDreadfulGladiator'sEmblemofCruelty-93485"
  value: {
-  dps: 385108.36036
-  tps: 358828.13444
-  hps: 4323.05556
+  dps: 385903.05121
+  tps: 359450.33091
+  hps: 4345.99752
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedDreadfulGladiator'sEmblemofMeditation-93487"
  value: {
-  dps: 382106.51838
-  tps: 356114.92863
-  hps: 4270.87882
+  dps: 382887.05498
+  tps: 356708.39688
+  hps: 4300.44586
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedDreadfulGladiator'sEmblemofTenacity-93486"
  value: {
-  dps: 382418.16231
-  tps: 356438.38737
-  hps: 4383.17242
+  dps: 384649.19727
+  tps: 358497.06782
+  hps: 4398.12289
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedDreadfulGladiator'sInsigniaofConquest-93424"
  value: {
-  dps: 384588.00946
-  tps: 358561.51079
-  hps: 4294.87242
+  dps: 383991.21489
+  tps: 357843.20866
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedDreadfulGladiator'sInsigniaofDominance-93601"
  value: {
-  dps: 384340.91287
-  tps: 358348.43539
-  hps: 4294.87242
+  dps: 383752.25172
+  tps: 357636.41389
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedDreadfulGladiator'sInsigniaofVictory-93611"
  value: {
-  dps: 393970.2529
-  tps: 366716.45519
-  hps: 4268.53469
+  dps: 394564.56314
+  tps: 367166.99599
+  hps: 4239.12994
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedMalevolentGladiator'sBadgeofConquest-98755"
  value: {
-  dps: 382560.18765
-  tps: 356536.20546
-  hps: 4254.68465
+  dps: 383415.39026
+  tps: 357198.64357
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedMalevolentGladiator'sBadgeofDominance-98910"
  value: {
-  dps: 382391.85587
-  tps: 356391.72647
-  hps: 4254.68465
+  dps: 383253.86213
+  tps: 357061.34774
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedMalevolentGladiator'sBadgeofVictory-98912"
  value: {
-  dps: 390568.17366
-  tps: 363544.35159
-  hps: 4254.68465
+  dps: 391511.89744
+  tps: 364282.17758
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedMalevolentGladiator'sEmblemofCruelty-98811"
  value: {
-  dps: 385660.87285
-  tps: 359327.67428
-  hps: 4327.20865
+  dps: 386577.61996
+  tps: 360069.20647
+  hps: 4350.15061
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedMalevolentGladiator'sEmblemofMeditation-98813"
  value: {
-  dps: 382106.51838
-  tps: 356114.92863
-  hps: 4270.87882
+  dps: 382887.05498
+  tps: 356708.39688
+  hps: 4300.44586
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedMalevolentGladiator'sEmblemofTenacity-98812"
  value: {
-  dps: 382750.80192
-  tps: 356764.84049
-  hps: 4398.49973
+  dps: 384680.44243
+  tps: 358524.39471
+  hps: 4409.58938
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedMalevolentGladiator'sInsigniaofConquest-98760"
  value: {
-  dps: 384583.05084
-  tps: 358547.90862
-  hps: 4294.87242
+  dps: 383987.15677
+  tps: 357831.96661
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedMalevolentGladiator'sInsigniaofDominance-98911"
  value: {
-  dps: 384340.91287
-  tps: 358348.43539
-  hps: 4294.87242
+  dps: 383752.25172
+  tps: 357636.41389
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CraftedMalevolentGladiator'sInsigniaofVictory-98917"
  value: {
-  dps: 396222.30544
-  tps: 368776.1118
-  hps: 4268.53469
+  dps: 396522.05803
+  tps: 368966.42513
+  hps: 4242.57722
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CurseofHubris-105645"
  value: {
-  dps: 394336.51876
-  tps: 366409.25841
-  hps: 4922.31137
+  dps: 394294.24952
+  tps: 366361.39288
+  hps: 4860.04203
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-CutstitcherMedallion-93255"
  value: {
-  dps: 382391.85587
-  tps: 356391.72647
-  hps: 4254.68465
+  dps: 383253.86213
+  tps: 357061.34774
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Daelo'sFinalWords-87496"
  value: {
-  dps: 391667.68134
-  tps: 364278.66654
-  hps: 4294.405
+  dps: 390808.52382
+  tps: 363382.0067
+  hps: 4273.28498
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DarkglowEmbroidery(Rank3)-4893"
  value: {
-  dps: 438208.8418
-  tps: 405410.19419
-  hps: 4353.72283
+  dps: 438729.43236
+  tps: 405810.52401
+  hps: 4340.20492
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DarkmistVortex-87172"
  value: {
-  dps: 397138.91688
-  tps: 368379.03036
-  hps: 4306.04925
+  dps: 397570.59459
+  tps: 368501.6626
+  hps: 4337.32088
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DeadeyeBadgeoftheShieldwall-93346"
  value: {
-  dps: 386439.20071
-  tps: 360421.90787
-  hps: 4254.68465
+  dps: 387321.62139
+  tps: 361106.59423
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DelicateVialoftheSanguinaire-96895"
  value: {
-  dps: 384340.91287
-  tps: 358348.43539
-  hps: 4294.87242
+  dps: 383752.25172
+  tps: 357636.41389
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DestructivePrimalDiamond"
  value: {
-  dps: 426314.10674
-  tps: 393494.873
-  hps: 4325.89796
+  dps: 427238.80028
+  tps: 394203.89669
+  hps: 4346.30784
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DisciplineofXuen-103986"
  value: {
-  dps: 396192.93662
-  tps: 370166.94157
-  hps: 4294.87242
+  dps: 395484.65246
+  tps: 369334.448
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Dominator'sArcaneBadge-93342"
  value: {
-  dps: 383912.15726
-  tps: 357725.39606
-  hps: 4291.27651
+  dps: 385174.77705
+  tps: 358708.56758
+  hps: 4261.3746
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Dominator'sDeadeyeBadge-93341"
  value: {
-  dps: 386439.20071
-  tps: 360421.90787
-  hps: 4254.68465
+  dps: 387321.62139
+  tps: 361106.59423
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Dominator'sDurableBadge-93345"
  value: {
-  dps: 386267.97168
-  tps: 360267.84227
-  hps: 4254.68465
+  dps: 387153.61017
+  tps: 360961.09578
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Dominator'sKnightlyBadge-93344"
  value: {
-  dps: 392869.08693
-  tps: 366289.84009
-  hps: 4254.68465
+  dps: 393769.02015
+  tps: 366993.17075
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Dominator'sMendingBadge-93343"
  value: {
-  dps: 382391.85587
-  tps: 356391.72647
-  hps: 4254.68465
+  dps: 383253.86213
+  tps: 357061.34774
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DreadfulGladiator'sBadgeofConquest-84344"
  value: {
-  dps: 382553.31701
-  tps: 356534.32518
-  hps: 4254.68465
+  dps: 383385.71354
+  tps: 357173.05603
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DreadfulGladiator'sBadgeofDominance-84488"
  value: {
-  dps: 382391.85587
-  tps: 356391.72647
-  hps: 4254.68465
+  dps: 383253.86213
+  tps: 357061.34774
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DreadfulGladiator'sBadgeofVictory-84490"
  value: {
-  dps: 389305.80493
-  tps: 362440.03415
-  hps: 4254.68465
+  dps: 390236.91207
+  tps: 363167.3298
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DreadfulGladiator'sEmblemofCruelty-84399"
  value: {
-  dps: 385108.36036
-  tps: 358828.13444
-  hps: 4323.05556
+  dps: 385903.05121
+  tps: 359450.33091
+  hps: 4345.99752
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DreadfulGladiator'sEmblemofMeditation-84401"
  value: {
-  dps: 382106.51838
-  tps: 356114.92863
-  hps: 4270.87882
+  dps: 382887.05498
+  tps: 356708.39688
+  hps: 4300.44586
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DreadfulGladiator'sEmblemofTenacity-84400"
  value: {
-  dps: 382418.16231
-  tps: 356438.38737
-  hps: 4383.17242
+  dps: 384649.19727
+  tps: 358497.06782
+  hps: 4398.12289
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DreadfulGladiator'sInsigniaofConquest-84349"
  value: {
-  dps: 384541.53314
-  tps: 358515.03447
-  hps: 4294.87242
+  dps: 383962.92201
+  tps: 357816.08528
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DreadfulGladiator'sInsigniaofDominance-84489"
  value: {
-  dps: 384340.91287
-  tps: 358348.43539
-  hps: 4294.87242
+  dps: 383752.25172
+  tps: 357636.41389
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DreadfulGladiator'sInsigniaofVictory-84495"
  value: {
-  dps: 392942.81682
-  tps: 365752.8048
-  hps: 4258.50424
+  dps: 394456.41383
+  tps: 367153.50492
+  hps: 4240.61659
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DurableBadgeoftheShieldwall-93350"
  value: {
-  dps: 386267.97168
-  tps: 360267.84227
-  hps: 4254.68465
+  dps: 387153.61017
+  tps: 360961.09578
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-DysmorphicSamophlangeofDiscontinuity-105615"
  value: {
-  dps: 384340.91287
-  tps: 358348.43539
-  hps: 4294.87242
+  dps: 383752.25172
+  tps: 357636.41389
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EffulgentPrimalDiamond"
  value: {
-  dps: 424431.1595
-  tps: 391846.67866
-  hps: 4314.03544
+  dps: 425234.62871
+  tps: 392445.38648
+  hps: 4342.74229
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EmberPrimalDiamond"
  value: {
-  dps: 424459.21035
-  tps: 391875.42319
-  hps: 4293.48791
+  dps: 425359.22011
+  tps: 392563.54138
+  hps: 4317.94905
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EmblemofKypariZar-84077"
  value: {
-  dps: 387269.97115
-  tps: 360764.54658
-  hps: 4359.10133
+  dps: 388563.2883
+  tps: 362173.06336
+  hps: 4330.9897
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EmblemoftheCatacombs-83733"
  value: {
-  dps: 387737.49312
-  tps: 361769.03112
-  hps: 4243.17816
+  dps: 387359.14167
+  tps: 361269.52859
+  hps: 4276.63846
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EmptyFruitBarrel-81133"
  value: {
-  dps: 384340.91287
-  tps: 358348.43539
-  hps: 4294.87242
+  dps: 383752.25172
+  tps: 357636.41389
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EnchantWeapon-BloodyDancingSteel-5125"
  value: {
-  dps: 410819.15284
-  tps: 380693.33678
+  dps: 411003.5955
+  tps: 380714.94258
   hps: 16.21842
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EnchantWeapon-Colossus-4445"
  value: {
-  dps: 404621.79463
-  tps: 375191.18541
-  hps: 16.77088
+  dps: 406233.04497
+  tps: 376572.15157
+  hps: 17.11972
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EnchantWeapon-DancingSteel-4444"
  value: {
-  dps: 409797.42986
-  tps: 379472.87482
-  hps: 16.99141
+  dps: 411132.42332
+  tps: 380634.59523
+  hps: 16.52179
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EnchantWeapon-ElementalForce-4443"
  value: {
-  dps: 404834.75212
-  tps: 375409.52667
-  hps: 16.52179
+  dps: 406842.30923
+  tps: 377325.35816
+  hps: 16.37459
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EnchantWeapon-JadeSpirit-4442"
  value: {
-  dps: 403698.15877
-  tps: 374179.66712
-  hps: 16.52384
+  dps: 403954.889
+  tps: 374337.05336
+  hps: 17.11972
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EnchantWeapon-River'sSong-4446"
  value: {
-  dps: 403698.15877
-  tps: 374179.66712
-  hps: 16.52384
+  dps: 403954.889
+  tps: 374337.05336
+  hps: 17.11972
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EnchantWeapon-SpiritofConquest-5124"
  value: {
-  dps: 403698.15877
-  tps: 374179.66712
-  hps: 16.52384
+  dps: 403954.889
+  tps: 374337.05336
+  hps: 17.11972
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EnchantWeapon-Windsong-4441"
  value: {
-  dps: 407789.24465
-  tps: 378023.46464
-  hps: 16.52384
+  dps: 409121.04836
+  tps: 379194.03396
+  hps: 17.47369
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EnigmaticPrimalDiamond"
  value: {
-  dps: 426314.10674
-  tps: 393494.873
-  hps: 4325.89796
+  dps: 427238.80028
+  tps: 394203.89669
+  hps: 4346.30784
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EssenceofTerror-87175"
  value: {
-  dps: 388451.2165
-  tps: 361210.18583
-  hps: 4311.51057
+  dps: 388296.1774
+  tps: 360946.89415
+  hps: 4336.14524
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EternalPrimalDiamond"
  value: {
-  dps: 424459.21035
-  tps: 391875.42319
-  hps: 4293.48791
+  dps: 425359.22011
+  tps: 392563.54138
+  hps: 4317.94905
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-EvilEyeofGalakras-105491"
  value: {
-  dps: 423627.85254
-  tps: 393971.2735
-  hps: 4886.82859
+  dps: 423371.18622
+  tps: 393445.54257
+  hps: 4852.4037
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-FabledFeatherofJi-Kun-96842"
  value: {
-  dps: 411050.49628
-  tps: 381682.58028
-  hps: 4372.86294
+  dps: 410333.09787
+  tps: 380913.79206
+  hps: 4446.10399
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-FearwurmBadge-84074"
  value: {
-  dps: 387406.77356
-  tps: 361086.04604
-  hps: 4302.74345
+  dps: 387488.71206
+  tps: 360894.68022
+  hps: 4301.53229
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-FearwurmRelic-84070"
  value: {
-  dps: 387579.8123
-  tps: 361121.82286
-  hps: 4378.12618
+  dps: 386573.10284
+  tps: 360205.27475
+  hps: 4345.2674
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-FelsoulIdolofDestruction-101263"
  value: {
-  dps: 391305.84053
-  tps: 364700.1313
-  hps: 4281.40592
+  dps: 391725.60142
+  tps: 364953.62958
+  hps: 4276.29451
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-FelsoulStoneofDestruction-101266"
  value: {
-  dps: 390709.61895
-  tps: 364717.14147
-  hps: 4294.87242
+  dps: 390135.58434
+  tps: 364019.74651
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Fen-Yu,FuryofXuen-102248"
  value: {
-  dps: 415379.86336
-  tps: 384365.13314
-  hps: 4282.64887
+  dps: 415113.86342
+  tps: 383992.25301
+  hps: 4339.05172
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-FlashfrozenResinGlobule-100951"
  value: {
-  dps: 386516.30751
-  tps: 360525.02643
-  hps: 4308.81885
+  dps: 385081.32951
+  tps: 359084.91255
+  hps: 4288.25153
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-FlashingSteelTalisman-81265"
  value: {
-  dps: 386750.85677
-  tps: 360638.62451
-  hps: 4327.85256
+  dps: 386328.60073
+  tps: 360225.55512
+  hps: 4305.83958
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-FleetPrimalDiamond"
  value: {
-  dps: 426946.58088
-  tps: 394362.79372
-  hps: 4293.48791
+  dps: 427850.58682
+  tps: 395054.90809
+  hps: 4317.94905
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-ForlornPrimalDiamond"
  value: {
-  dps: 424459.21035
-  tps: 391875.42319
-  hps: 4293.48791
+  dps: 425359.22011
+  tps: 392563.54138
+  hps: 4317.94905
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-FortitudeoftheZandalari-96793"
  value: {
-  dps: 390503.13887
-  tps: 364511.54912
-  hps: 4270.87882
+  dps: 391295.13186
+  tps: 365116.47375
+  hps: 4300.44586
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-FrenziedCrystalofRage-105572"
  value: {
-  dps: 384340.91287
-  tps: 358348.43539
-  hps: 4294.87242
+  dps: 383752.25172
+  tps: 357636.41389
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Fusion-FireCore-105459"
  value: {
-  dps: 411100.21477
-  tps: 380701.54857
-  hps: 4254.74695
+  dps: 410493.54934
+  tps: 379833.81906
+  hps: 4274.61194
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-GazeoftheTwins-96915"
  value: {
-  dps: 405319.70449
-  tps: 377149.87399
-  hps: 4390.36564
+  dps: 404180.02234
+  tps: 375837.8986
+  hps: 4394.39394
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Gerp'sPerfectArrow-87495"
  value: {
-  dps: 384999.7083
-  tps: 358723.70573
-  hps: 4306.27798
+  dps: 385999.75782
+  tps: 359540.59719
+  hps: 4322.54466
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-GrievousGladiator'sBadgeofConquest-103145"
  value: {
-  dps: 382636.13987
-  tps: 356598.82776
-  hps: 4254.68465
+  dps: 383478.83044
+  tps: 357250.41302
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-GrievousGladiator'sBadgeofDominance-103308"
  value: {
-  dps: 382391.85587
-  tps: 356391.72647
-  hps: 4254.68465
+  dps: 383253.86213
+  tps: 357061.34774
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-GrievousGladiator'sBadgeofVictory-103314"
  value: {
-  dps: 394947.1221
-  tps: 367375.04621
-  hps: 4254.68465
+  dps: 395934.61091
+  tps: 368149.40026
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-GrievousGladiator'sEmblemofCruelty-103210"
  value: {
-  dps: 387770.92201
-  tps: 361242.79237
-  hps: 4353.33298
+  dps: 388449.07251
+  tps: 361780.97458
+  hps: 4379.99154
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-GrievousGladiator'sEmblemofMeditation-103212"
  value: {
-  dps: 382106.51838
-  tps: 356114.92863
-  hps: 4270.87882
+  dps: 382887.05498
+  tps: 356708.39688
+  hps: 4300.44586
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-GrievousGladiator'sEmblemofTenacity-103211"
  value: {
-  dps: 383431.34191
-  tps: 357416.84068
-  hps: 4460.68398
+  dps: 384926.2768
+  tps: 358770.85246
+  hps: 4485.02621
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-GrievousGladiator'sInsigniaofConquest-103150"
  value: {
-  dps: 384768.62125
-  tps: 358715.47394
-  hps: 4294.87242
+  dps: 384232.97984
+  tps: 358056.4992
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-GrievousGladiator'sInsigniaofDominance-103309"
  value: {
-  dps: 384340.91287
-  tps: 358348.43539
-  hps: 4294.87242
+  dps: 383752.25172
+  tps: 357636.41389
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-GrievousGladiator'sInsigniaofVictory-103319"
  value: {
-  dps: 402359.21065
-  tps: 374212.78142
-  hps: 4278.033
+  dps: 402481.47884
+  tps: 374236.4617
+  hps: 4253.72706
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Haromm'sTalisman-105527"
  value: {
-  dps: 403204.5395
-  tps: 377117.13202
-  hps: 4294.87242
+  dps: 403619.61424
+  tps: 377404.22489
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Hawkmaster'sTalon-89082"
  value: {
-  dps: 383995.93687
-  tps: 357583.31156
-  hps: 4299.96319
+  dps: 384837.80225
+  tps: 358272.29703
+  hps: 4311.20435
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Heart-LesionDefenderIdol-100999"
  value: {
-  dps: 383483.06397
-  tps: 357443.91045
-  hps: 4429.37134
+  dps: 384074.80439
+  tps: 357916.47894
+  hps: 4421.83889
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Heart-LesionDefenderStone-101002"
  value: {
-  dps: 389845.95866
-  tps: 363806.80513
-  hps: 4429.37134
+  dps: 390470.12182
+  tps: 364311.79637
+  hps: 4421.83889
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Heart-LesionIdolofBattle-100991"
  value: {
-  dps: 398800.04373
-  tps: 371064.72782
-  hps: 4294.71952
+  dps: 398894.77549
+  tps: 371121.98153
+  hps: 4297.10632
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Heart-LesionStoneofBattle-100990"
  value: {
-  dps: 399107.84683
-  tps: 372384.70548
-  hps: 4294.87242
+  dps: 398519.65454
+  tps: 371669.72282
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-HeartofFire-81181"
  value: {
-  dps: 386454.87733
-  tps: 360454.74793
-  hps: 4254.68465
+  dps: 387324.49286
+  tps: 361131.97847
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-HeartwarmerMedallion-93260"
  value: {
-  dps: 382391.85587
-  tps: 356391.72647
-  hps: 4254.68465
+  dps: 383253.86213
+  tps: 357061.34774
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-HelmbreakerMedallion-93261"
  value: {
-  dps: 396632.50919
-  tps: 369099.04461
-  hps: 4358.89618
+  dps: 397484.12294
+  tps: 369765.32053
+  hps: 4388.33429
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Horridon'sLastGasp-96757"
  value: {
-  dps: 384340.91287
-  tps: 358348.43539
-  hps: 4294.87242
+  dps: 383752.25172
+  tps: 357636.41389
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-ImpassivePrimalDiamond"
  value: {
-  dps: 426314.10674
-  tps: 393494.873
-  hps: 4325.89796
+  dps: 427238.80028
+  tps: 394203.89669
+  hps: 4346.30784
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-IndomitablePrimalDiamond"
  value: {
-  dps: 424431.1595
-  tps: 391846.67866
-  hps: 4314.03544
+  dps: 425234.62871
+  tps: 392445.38648
+  hps: 4342.74229
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-InscribedBagofHydra-Spawn-96828"
  value: {
-  dps: 382974.57065
-  tps: 357056.00962
-  hps: 4260.86438
+  dps: 383480.87037
+  tps: 357465.81
+  hps: 4269.15156
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-InsigniaofKypariZar-84078"
  value: {
-  dps: 384340.91287
-  tps: 358348.43539
-  hps: 4294.87242
+  dps: 383752.25172
+  tps: 357636.41389
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-IronBellyWok-89083"
  value: {
-  dps: 392568.94548
-  tps: 365404.13706
-  hps: 4299.96319
+  dps: 393409.74679
+  tps: 366085.62489
+  hps: 4311.20435
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-IronProtectorTalisman-85181"
  value: {
-  dps: 383057.71188
-  tps: 357027.40886
-  hps: 4382.06746
+  dps: 383591.86978
+  tps: 357438.36451
+  hps: 4372.76657
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-JadeBanditFigurine-86772"
  value: {
-  dps: 385584.00558
-  tps: 359163.66598
-  hps: 4295.40833
+  dps: 386668.30452
+  tps: 360111.99037
+  hps: 4301.56968
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-JadeCharioteerFigurine-86771"
  value: {
-  dps: 393135.19399
-  tps: 366054.79109
-  hps: 4295.40833
+  dps: 394281.96386
+  tps: 367063.8953
+  hps: 4301.56968
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-JadeCourtesanFigurine-86774"
  value: {
-  dps: 382391.85587
-  tps: 356391.72647
-  hps: 4254.68465
+  dps: 383253.86213
+  tps: 357061.34774
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-JadeMagistrateFigurine-86773"
  value: {
-  dps: 386260.92126
-  tps: 359708.44128
-  hps: 4333.47406
+  dps: 387164.63914
+  tps: 360419.37938
+  hps: 4348.04572
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-JadeWarlordFigurine-86775"
  value: {
-  dps: 387632.8218
-  tps: 361622.08565
-  hps: 4375.8384
+  dps: 388181.76971
+  tps: 362029.44258
+  hps: 4393.5458
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Ji-Kun'sRisingWinds-96843"
  value: {
-  dps: 384340.91287
-  tps: 358348.43539
-  hps: 4294.87242
+  dps: 383752.25172
+  tps: 357636.41389
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Juggernaut'sFocusingCrystal-105514"
  value: {
-  dps: 384340.91287
-  tps: 358348.43539
-  hps: 15608.37761
+  dps: 383752.25172
+  tps: 357636.41389
+  hps: 15565.1877
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Kardris'ToxicTotem-105540"
  value: {
-  dps: 402958.31603
-  tps: 376965.83856
-  hps: 4294.87242
+  dps: 402820.64101
+  tps: 376704.80318
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-KnightlyBadgeoftheShieldwall-93349"
  value: {
-  dps: 392869.08693
-  tps: 366289.84009
-  hps: 4254.68465
+  dps: 393769.02015
+  tps: 366993.17075
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-KnotofTenSongs-84073"
  value: {
-  dps: 384340.91287
-  tps: 358348.43539
-  hps: 4294.87242
+  dps: 383752.25172
+  tps: 357636.41389
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Kor'kronBookofHurting-92785"
  value: {
-  dps: 382391.85587
-  tps: 356391.72647
-  hps: 4254.68465
+  dps: 383253.86213
+  tps: 357061.34774
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Lao-Chin'sLiquidCourage-89079"
  value: {
-  dps: 388362.82664
-  tps: 362360.00995
-  hps: 4402.88966
+  dps: 388925.58453
+  tps: 362773.08469
+  hps: 4421.32287
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-LeiShen'sFinalOrders-87072"
  value: {
-  dps: 399908.36443
-  tps: 372121.65463
-  hps: 4297.69977
+  dps: 399545.03477
+  tps: 371675.94617
+  hps: 4296.65564
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-LessonsoftheDarkmaster-81268"
  value: {
-  dps: 391850.595
-  tps: 364038.04619
-  hps: 4254.68465
+  dps: 392787.05139
+  tps: 364759.13835
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-LightdrinkerIdolofRage-101200"
  value: {
-  dps: 389509.50358
-  tps: 363475.57683
-  hps: 4294.87242
+  dps: 388914.42283
+  tps: 362761.12086
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-LightdrinkerStoneofRage-101203"
  value: {
-  dps: 391004.62385
-  tps: 364996.77841
-  hps: 4294.87242
+  dps: 390379.23924
+  tps: 364243.64691
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-LightoftheCosmos-87065"
  value: {
-  dps: 386386.55043
-  tps: 360175.96808
-  hps: 4283.10801
+  dps: 387870.00988
+  tps: 361520.0205
+  hps: 4325.10963
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-LightweaveEmbroidery(Rank3)-4892"
  value: {
-  dps: 438208.8418
-  tps: 405410.19419
-  hps: 4353.72283
+  dps: 438729.43236
+  tps: 405810.52401
+  hps: 4340.20492
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-LordBlastington'sScopeofDoom-4699"
  value: {
-  dps: 403698.15877
-  tps: 374179.66712
-  hps: 16.52384
+  dps: 403954.889
+  tps: 374337.05336
+  hps: 17.11972
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MalevolentGladiator'sBadgeofConquest-91452"
  value: {
-  dps: 382560.18765
-  tps: 356536.20546
-  hps: 4254.68465
+  dps: 383415.39026
+  tps: 357198.64357
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MalevolentGladiator'sBadgeofDominance-91753"
  value: {
-  dps: 382391.85587
-  tps: 356391.72647
-  hps: 4254.68465
+  dps: 383253.86213
+  tps: 357061.34774
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MalevolentGladiator'sBadgeofVictory-91763"
  value: {
-  dps: 390568.17366
-  tps: 363544.35159
-  hps: 4254.68465
+  dps: 391511.89744
+  tps: 364282.17758
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MalevolentGladiator'sEmblemofCruelty-91562"
  value: {
-  dps: 385660.87285
-  tps: 359327.67428
-  hps: 4327.20865
+  dps: 386577.61996
+  tps: 360069.20647
+  hps: 4350.15061
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MalevolentGladiator'sEmblemofMeditation-91564"
  value: {
-  dps: 382106.51838
-  tps: 356114.92863
-  hps: 4270.87882
+  dps: 382887.05498
+  tps: 356708.39688
+  hps: 4300.44586
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MalevolentGladiator'sEmblemofTenacity-91563"
  value: {
-  dps: 382750.80192
-  tps: 356764.84049
-  hps: 4398.49973
+  dps: 384680.44243
+  tps: 358524.39471
+  hps: 4409.58938
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MalevolentGladiator'sInsigniaofConquest-91457"
  value: {
-  dps: 384592.70062
-  tps: 358559.78783
-  hps: 4294.87242
+  dps: 384010.2667
+  tps: 357853.33916
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MalevolentGladiator'sInsigniaofDominance-91754"
  value: {
-  dps: 384340.91287
-  tps: 358348.43539
-  hps: 4294.87242
+  dps: 383752.25172
+  tps: 357636.41389
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MalevolentGladiator'sInsigniaofVictory-91768"
  value: {
-  dps: 397257.09551
-  tps: 369779.8534
-  hps: 4297.52426
+  dps: 396025.9826
+  tps: 368440.12531
+  hps: 4260.81233
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MarkoftheCatacombs-83731"
  value: {
-  dps: 390448.54502
-  tps: 364232.38976
-  hps: 4337.54588
+  dps: 389878.32755
+  tps: 363560.62776
+  hps: 4317.78786
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MarkoftheHardenedGrunt-92783"
  value: {
-  dps: 382391.85587
-  tps: 356391.72647
-  hps: 4254.68465
+  dps: 383253.86213
+  tps: 357061.34774
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MedallionofMystifyingVapors-93257"
  value: {
-  dps: 387916.00457
-  tps: 361915.87517
-  hps: 4254.68465
+  dps: 388811.69094
+  tps: 362619.17655
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MedallionoftheCatacombs-83734"
  value: {
-  dps: 387313.60142
-  tps: 361321.12394
-  hps: 4294.87242
+  dps: 386719.44798
+  tps: 360603.61016
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MendingBadgeoftheShieldwall-93348"
  value: {
-  dps: 382391.85587
-  tps: 356391.72647
-  hps: 4254.68465
+  dps: 383253.86213
+  tps: 357061.34774
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MirrorScope-4700"
  value: {
-  dps: 403698.15877
-  tps: 374179.66712
-  hps: 16.52384
+  dps: 403954.889
+  tps: 374337.05336
+  hps: 17.11972
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MistdancerDefenderIdol-101089"
  value: {
-  dps: 383483.06397
-  tps: 357443.91045
-  hps: 4429.37134
+  dps: 384074.80439
+  tps: 357916.47894
+  hps: 4421.83889
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MistdancerDefenderStone-101087"
  value: {
-  dps: 389818.20038
-  tps: 363779.04686
-  hps: 4429.37134
+  dps: 390418.21237
+  tps: 364259.88692
+  hps: 4421.83889
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MistdancerIdolofRage-101113"
  value: {
-  dps: 389468.70425
-  tps: 363434.7775
-  hps: 4294.87242
+  dps: 388874.85609
+  tps: 362721.02434
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MistdancerStoneofRage-101117"
  value: {
-  dps: 390886.76551
-  tps: 364878.92008
-  hps: 4294.87242
+  dps: 390358.9251
+  tps: 364223.33277
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MistdancerStoneofWisdom-101107"
  value: {
-  dps: 384340.91287
-  tps: 358348.43539
-  hps: 4294.87242
+  dps: 383752.25172
+  tps: 357636.41389
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MithrilWristwatch-257884"
  value: {
-  dps: 388308.45431
-  tps: 361917.8668
-  hps: 4346.90222
+  dps: 387903.81415
+  tps: 361428.09606
+  hps: 4332.34746
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MountainsageIdolofDestruction-101069"
  value: {
-  dps: 392475.46328
-  tps: 365968.14656
-  hps: 4333.70071
+  dps: 391464.5343
+  tps: 364971.9468
+  hps: 4294.18654
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-MountainsageStoneofDestruction-101072"
  value: {
-  dps: 390709.9962
-  tps: 364717.51872
-  hps: 4294.87242
+  dps: 390144.75249
+  tps: 364028.91466
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-NitroBoosts-4223"
  value: {
-  dps: 439168.54949
-  tps: 406287.38666
-  hps: 4359.40079
+  dps: 437779.19851
+  tps: 404869.95142
+  hps: 4310.69574
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-OathswornDefenderIdol-101303"
  value: {
-  dps: 383483.06397
-  tps: 357443.91045
-  hps: 4429.37134
+  dps: 384074.80439
+  tps: 357916.47894
+  hps: 4421.83889
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-OathswornDefenderStone-101306"
  value: {
-  dps: 389756.57349
-  tps: 363717.41997
-  hps: 4429.37134
+  dps: 390470.75403
+  tps: 364312.42858
+  hps: 4421.83889
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-OathswornIdolofBattle-101295"
  value: {
-  dps: 398636.44891
-  tps: 370929.75651
-  hps: 4312.39438
+  dps: 399445.01338
+  tps: 371675.18177
+  hps: 4301.29692
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-OathswornStoneofBattle-101294"
  value: {
-  dps: 399092.1073
-  tps: 372368.96594
-  hps: 4294.87242
+  dps: 398505.34128
+  tps: 371655.40957
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PhaseFingers-4697"
  value: {
-  dps: 436916.68438
-  tps: 404072.58658
-  hps: 4330.10146
+  dps: 435797.20149
+  tps: 402939.62441
+  hps: 4317.25856
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PlateofCyclopeanDread"
  value: {
-  dps: 318218.95301
-  tps: 292832.0039
-  hps: 2556.59698
+  dps: 318297.94482
+  tps: 292683.53851
+  hps: 2553.02842
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PlateoftheAll-ConsumingMaw"
  value: {
-  dps: 307890.46521
-  tps: 282447.64945
-  hps: 2625.57528
+  dps: 308920.79519
+  tps: 283511.07915
+  hps: 2613.8653
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PlateoftheLostCatacomb"
  value: {
-  dps: 292611.38432
-  tps: 268491.37205
-  hps: 2411.45541
+  dps: 293750.64025
+  tps: 269546.02617
+  hps: 2462.57688
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PouchofWhiteAsh-103639"
  value: {
-  dps: 382391.85587
-  tps: 356391.72647
-  hps: 4254.68465
+  dps: 383253.86213
+  tps: 357061.34774
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PowerfulPrimalDiamond"
  value: {
-  dps: 424431.1595
-  tps: 391846.67866
-  hps: 4314.03544
+  dps: 425234.62871
+  tps: 392445.38648
+  hps: 4342.74229
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PriceofProgress-81266"
  value: {
-  dps: 384340.91287
-  tps: 358348.43539
-  hps: 4294.87242
+  dps: 383752.25172
+  tps: 357636.41389
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PridefulGladiator'sBadgeofConquest-103342"
  value: {
-  dps: 382780.47257
-  tps: 356734.55748
-  hps: 4254.68465
+  dps: 383648.20983
+  tps: 357404.9376
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PridefulGladiator'sBadgeofDominance-103505"
  value: {
-  dps: 382391.85587
-  tps: 356391.72647
-  hps: 4254.68465
+  dps: 383253.86213
+  tps: 357061.34774
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PridefulGladiator'sBadgeofVictory-103511"
  value: {
-  dps: 398693.17565
-  tps: 370652.08575
-  hps: 4254.68465
+  dps: 399718.10408
+  tps: 371457.68841
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PridefulGladiator'sEmblemofCruelty-103407"
  value: {
-  dps: 389518.61214
-  tps: 362844.67719
-  hps: 4377.22733
+  dps: 390325.70442
+  tps: 363508.5172
+  hps: 4398.66874
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PridefulGladiator'sEmblemofMeditation-103409"
  value: {
-  dps: 382106.51838
-  tps: 356114.92863
-  hps: 4270.87882
+  dps: 382887.05498
+  tps: 356708.39688
+  hps: 4300.44586
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PridefulGladiator'sEmblemofTenacity-103408"
  value: {
-  dps: 383221.63358
-  tps: 357218.45129
-  hps: 4512.52651
+  dps: 384212.04671
+  tps: 358044.84532
+  hps: 4512.2979
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PridefulGladiator'sInsigniaofConquest-103347"
  value: {
-  dps: 384853.64328
-  tps: 358792.92062
-  hps: 4294.87242
+  dps: 384228.64115
+  tps: 358044.5198
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PridefulGladiator'sInsigniaofDominance-103506"
  value: {
-  dps: 384340.91287
-  tps: 358348.43539
-  hps: 4294.87242
+  dps: 383752.25172
+  tps: 357636.41389
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PridefulGladiator'sInsigniaofVictory-103516"
  value: {
-  dps: 408191.57256
-  tps: 379335.54382
-  hps: 4263.33143
+  dps: 408218.91542
+  tps: 379234.54216
+  hps: 4242.22927
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Primordius'TalismanofRage-96873"
  value: {
-  dps: 404393.16784
-  tps: 376467.73587
-  hps: 4346.40168
+  dps: 403907.08318
+  tps: 375873.59191
+  hps: 4363.20725
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PrismaticPrisonofPride-105474"
  value: {
-  dps: 401700.51583
-  tps: 375369.34581
-  hps: 4311.81746
+  dps: 403662.36478
+  tps: 377296.80392
+  hps: 4383.30401
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-PurifiedBindingsofImmerseus-105422"
  value: {
-  dps: 401700.51583
-  tps: 375369.34581
-  hps: 4311.81746
+  dps: 403662.36478
+  tps: 377296.80392
+  hps: 4383.30401
  }
 }
 dps_results: {
@@ -1625,721 +1625,721 @@ dps_results: {
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Qin-xi'sPolarizingSeal-87075"
  value: {
-  dps: 384340.91287
-  tps: 358348.43539
-  hps: 4294.87242
+  dps: 383752.25172
+  tps: 357636.41389
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RelicofChi-Ji-79330"
  value: {
-  dps: 384340.91287
-  tps: 358348.43539
-  hps: 4294.87242
+  dps: 383752.25172
+  tps: 357636.41389
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RelicofKypariZar-84075"
  value: {
-  dps: 386600.16595
-  tps: 360307.7935
-  hps: 4317.97918
+  dps: 387826.31278
+  tps: 361305.46962
+  hps: 4296.0219
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RelicofNiuzao-79329"
  value: {
-  dps: 383050.80594
-  tps: 357040.0698
-  hps: 4375.8384
+  dps: 383578.4357
+  tps: 357426.10857
+  hps: 4393.5458
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RelicofXuen-79327"
  value: {
-  dps: 397602.00796
-  tps: 369940.41511
-  hps: 4241.65367
+  dps: 398117.92049
+  tps: 370253.41873
+  hps: 4255.55171
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RelicofXuen-79328"
  value: {
-  dps: 384680.95229
-  tps: 358646.46606
-  hps: 4294.87242
+  dps: 384117.72969
+  tps: 357955.75571
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RelicofYu'lon-79331"
  value: {
-  dps: 384340.91287
-  tps: 358348.43539
-  hps: 4294.87242
+  dps: 383752.25172
+  tps: 357636.41389
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Renataki'sSoulCharm-96741"
  value: {
-  dps: 384764.64531
-  tps: 358717.57618
-  hps: 4294.87242
+  dps: 384153.15615
+  tps: 357967.29255
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-ResolveofNiuzao-103990"
  value: {
-  dps: 390340.41143
-  tps: 364340.28203
-  hps: 4254.68465
+  dps: 391217.30382
+  tps: 365024.78943
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-ReverberatingPrimalDiamond"
  value: {
-  dps: 432952.94937
-  tps: 400164.60404
-  hps: 4330.83046
+  dps: 433894.13803
+  tps: 400890.64048
+  hps: 4356.57038
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RevitalizingPrimalDiamond"
  value: {
-  dps: 431187.33328
-  tps: 398554.25977
-  hps: 4330.83046
+  dps: 432126.01676
+  tps: 399278.65717
+  hps: 4356.57038
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RuneofCinderglacier-3369"
  value: {
-  dps: 409635.91832
-  tps: 380117.42668
-  hps: 16.52384
+  dps: 409867.16447
+  tps: 380249.32882
+  hps: 17.11972
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RuneofRe-Origination-96918"
  value: {
-  dps: 402892.17306
-  tps: 378852.4055
-  hps: 4142.93591
+  dps: 404932.74023
+  tps: 381132.10068
+  hps: 4156.95382
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RuneofSpellbreaking-3595"
  value: {
-  dps: 404263.04703
-  tps: 374762.706
-  hps: 16.21842
+  dps: 405428.84018
+  tps: 375808.90714
+  hps: 16.8143
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RuneofSpellshattering-3367"
  value: {
-  dps: 403845.72759
-  tps: 374373.85791
-  hps: 16.46546
+  dps: 405570.17266
+  tps: 375933.71251
+  hps: 16.8143
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RuneofSwordbreaking-3594"
  value: {
-  dps: 403698.15877
-  tps: 374179.66712
-  hps: 16.52384
+  dps: 403954.889
+  tps: 374337.05336
+  hps: 17.11972
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RuneofSwordshattering-3365"
  value: {
-  dps: 403698.15877
-  tps: 374179.66712
-  hps: 16.52384
+  dps: 403954.889
+  tps: 374337.05336
+  hps: 17.11972
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RuneoftheNerubianCarapace-3883"
  value: {
-  dps: 403510.05751
-  tps: 373989.23084
-  hps: 16.52384
+  dps: 403942.70012
+  tps: 374319.42294
+  hps: 17.11972
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-RuneoftheStoneskinGargoyle-3847"
  value: {
-  dps: 403625.52683
-  tps: 374125.09851
-  hps: 16.21842
+  dps: 404374.95974
+  tps: 374751.44713
+  hps: 16.8143
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SI:7Operative'sManual-92784"
  value: {
-  dps: 382391.85587
-  tps: 356391.72647
-  hps: 4254.68465
+  dps: 383253.86213
+  tps: 357061.34774
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-ScrollofReveredAncestors-89080"
  value: {
-  dps: 382391.85587
-  tps: 356391.72647
-  hps: 4254.68465
+  dps: 383253.86213
+  tps: 357061.34774
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SearingWords-81267"
  value: {
-  dps: 387669.11468
-  tps: 361323.57741
-  hps: 4343.18561
+  dps: 387146.14778
+  tps: 360707.48794
+  hps: 4323.42759
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Shock-ChargerMedallion-93259"
  value: {
-  dps: 386188.52864
-  tps: 359956.53382
-  hps: 4289.14861
+  dps: 387802.33157
+  tps: 361455.61931
+  hps: 4386.3943
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SigilofCompassion-83736"
  value: {
-  dps: 387313.60142
-  tps: 361321.12394
-  hps: 4294.87242
+  dps: 386719.44798
+  tps: 360603.61016
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SigilofDevotion-83740"
  value: {
-  dps: 390433.70635
-  tps: 364217.55109
-  hps: 4337.54588
+  dps: 389847.22134
+  tps: 363529.52156
+  hps: 4317.78786
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SigilofFidelity-83737"
  value: {
-  dps: 387004.81217
-  tps: 360641.42774
-  hps: 4295.95405
+  dps: 387085.68855
+  tps: 360569.67513
+  hps: 4316.90113
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SigilofGrace-83738"
  value: {
-  dps: 388254.47884
-  tps: 362056.63187
-  hps: 4322.79546
+  dps: 387911.0881
+  tps: 361679.17757
+  hps: 4298.46618
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SigilofKypariZar-84076"
  value: {
-  dps: 390483.16472
-  tps: 364253.95319
-  hps: 4342.74913
+  dps: 389973.49788
+  tps: 363641.54872
+  hps: 4317.78786
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SigilofPatience-83739"
  value: {
-  dps: 387987.40814
-  tps: 361994.93066
-  hps: 4294.87242
+  dps: 387376.76469
+  tps: 361260.92686
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SigilofRampage-105580"
  value: {
-  dps: 384851.03288
-  tps: 358756.42341
-  hps: 4294.87242
+  dps: 384302.20831
+  tps: 358086.09436
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SigiloftheCatacombs-83732"
  value: {
-  dps: 387988.05788
-  tps: 361538.50008
-  hps: 4355.72602
+  dps: 388383.13278
+  tps: 361784.05269
+  hps: 4298.05602
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SinisterPrimalDiamond"
  value: {
-  dps: 425940.35351
-  tps: 393171.94621
-  hps: 4321.8467
+  dps: 426814.91336
+  tps: 393823.83678
+  hps: 4342.25658
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Skeer'sBloodsoakedTalisman-105632"
  value: {
-  dps: 415761.34816
-  tps: 385963.34546
-  hps: 4563.59348
+  dps: 415363.1236
+  tps: 385528.48641
+  hps: 4533.15682
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SkullrenderMedallion-93256"
  value: {
-  dps: 396632.50919
-  tps: 369099.04461
-  hps: 4358.89618
+  dps: 397484.12294
+  tps: 369765.32053
+  hps: 4388.33429
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SoothingTalismanoftheShado-PanAssault-94509"
  value: {
-  dps: 383131.96349
-  tps: 357105.64304
-  hps: 4255.84383
+  dps: 382542.91441
+  tps: 356433.57429
+  hps: 4223.10769
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SoulBarrier-96927"
  value: {
-  dps: 382788.55401
-  tps: 356776.94858
-  hps: 4494.37542
+  dps: 383472.96273
+  tps: 357351.14147
+  hps: 4474.79984
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SparkofZandalar-96770"
  value: {
-  dps: 401448.46638
-  tps: 374624.55596
-  hps: 4297.19729
+  dps: 402312.54439
+  tps: 375302.13367
+  hps: 4326.3037
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SpiritsoftheSun-87163"
  value: {
-  dps: 384340.91287
-  tps: 358348.43539
-  hps: 4294.87242
+  dps: 383752.25172
+  tps: 357636.41389
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SpringrainIdolofDestruction-101023"
  value: {
-  dps: 388964.43124
-  tps: 362632.99254
-  hps: 4276.36573
+  dps: 388724.84168
+  tps: 362241.31086
+  hps: 4287.14461
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SpringrainIdolofRage-101009"
  value: {
-  dps: 389506.56155
-  tps: 363474.99137
-  hps: 4294.87242
+  dps: 388936.97486
+  tps: 362782.42793
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SpringrainStoneofDestruction-101026"
  value: {
-  dps: 390726.61171
-  tps: 364734.13423
-  hps: 4294.87242
+  dps: 390177.82426
+  tps: 364061.98644
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SpringrainStoneofRage-101012"
  value: {
-  dps: 390944.03348
-  tps: 364936.18804
-  hps: 4294.87242
+  dps: 390373.12342
+  tps: 364237.53109
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SpringrainStoneofWisdom-101041"
  value: {
-  dps: 384340.91287
-  tps: 358348.43539
-  hps: 4294.87242
+  dps: 383752.25172
+  tps: 357636.41389
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Static-Caster'sMedallion-93254"
  value: {
-  dps: 386188.52864
-  tps: 359956.53382
-  hps: 4289.14861
+  dps: 387802.33157
+  tps: 361455.61931
+  hps: 4386.3943
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SteadfastFootman'sMedallion-92782"
  value: {
-  dps: 382391.85587
-  tps: 356391.72647
-  hps: 4254.68465
+  dps: 383253.86213
+  tps: 357061.34774
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SteadfastTalismanoftheShado-PanAssault-94507"
  value: {
-  dps: 389428.98985
-  tps: 363428.86045
-  hps: 4254.68465
+  dps: 390304.17532
+  tps: 364111.66093
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-StreamtalkerIdolofDestruction-101222"
  value: {
-  dps: 389211.92788
-  tps: 362679.24778
-  hps: 4279.70638
+  dps: 389660.4556
+  tps: 363026.80954
+  hps: 4275.94989
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-StreamtalkerIdolofRage-101217"
  value: {
-  dps: 389468.17919
-  tps: 363438.14775
-  hps: 4294.87242
+  dps: 388875.13314
+  tps: 362720.29977
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-StreamtalkerStoneofDestruction-101225"
  value: {
-  dps: 390750.47448
-  tps: 364757.997
-  hps: 4294.87242
+  dps: 390197.17854
+  tps: 364081.34071
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-StreamtalkerStoneofRage-101220"
  value: {
-  dps: 390877.14012
-  tps: 364869.29469
-  hps: 4294.87242
+  dps: 390338.96766
+  tps: 364203.37533
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-StreamtalkerStoneofWisdom-101250"
  value: {
-  dps: 384340.91287
-  tps: 358348.43539
-  hps: 4294.87242
+  dps: 383752.25172
+  tps: 357636.41389
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-StuffofNightmares-87160"
  value: {
-  dps: 390604.27609
-  tps: 364611.79861
-  hps: 4294.87242
+  dps: 390004.04287
+  tps: 363888.20505
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SunsoulDefenderIdol-101160"
  value: {
-  dps: 383483.06397
-  tps: 357443.91045
-  hps: 4429.37134
+  dps: 384074.80439
+  tps: 357916.47894
+  hps: 4421.83889
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SunsoulDefenderStone-101163"
  value: {
-  dps: 389849.13504
-  tps: 363809.98152
-  hps: 4429.37134
+  dps: 390467.41786
+  tps: 364309.09241
+  hps: 4421.83889
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SunsoulIdolofBattle-101152"
  value: {
-  dps: 398316.18523
-  tps: 370632.72519
-  hps: 4309.74595
+  dps: 399143.04823
+  tps: 371378.49951
+  hps: 4306.50018
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SunsoulStoneofBattle-101151"
  value: {
-  dps: 399071.9279
-  tps: 372348.78654
-  hps: 4294.87242
+  dps: 398453.61493
+  tps: 371603.68322
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SunsoulStoneofWisdom-101138"
  value: {
-  dps: 384340.91287
-  tps: 358348.43539
-  hps: 4294.87242
+  dps: 383752.25172
+  tps: 357636.41389
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SwordguardEmbroidery(Rank3)-4894"
  value: {
-  dps: 441999.7771
-  tps: 408741.1716
-  hps: 4353.72283
+  dps: 442514.97785
+  tps: 409134.58775
+  hps: 4340.20492
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SymboloftheCatacombs-83735"
  value: {
-  dps: 390419.73911
-  tps: 364050.39658
-  hps: 4329.80857
+  dps: 389749.9897
+  tps: 363291.11688
+  hps: 4316.55346
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-SynapseSprings(MarkII)-4898"
  value: {
-  dps: 441355.13803
-  tps: 408089.86245
-  hps: 4373.9791
+  dps: 441974.29271
+  tps: 408581.18432
+  hps: 4348.30743
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TalismanofBloodlust-96864"
  value: {
-  dps: 388008.54145
-  tps: 361646.51495
-  hps: 4342.73478
+  dps: 387766.14729
+  tps: 361059.85509
+  hps: 4344.27974
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TerrorintheMists-87167"
  value: {
-  dps: 392135.48456
-  tps: 364522.16351
-  hps: 4424.78414
+  dps: 391936.94524
+  tps: 364190.91327
+  hps: 4434.93497
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Thok'sAcid-GroovedTooth-105607"
  value: {
-  dps: 384340.91287
-  tps: 358348.43539
-  hps: 4294.87242
+  dps: 383752.25172
+  tps: 357636.41389
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Thok'sTailTip-105609"
  value: {
-  dps: 433833.87498
-  tps: 401390.18984
-  hps: 4363.49544
+  dps: 433489.45938
+  tps: 401028.08421
+  hps: 4318.71395
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Thousand-YearPickledEgg-257881"
  value: {
-  dps: 384134.79089
-  tps: 357638.55112
-  hps: 4287.47398
+  dps: 384438.19796
+  tps: 357794.96783
+  hps: 4334.54065
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TickingEbonDetonator-105612"
  value: {
-  dps: 396155.73758
-  tps: 370032.24754
-  hps: 4294.87242
+  dps: 395517.0004
+  tps: 369280.49284
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Time-LostArtifact-103678"
  value: {
-  dps: 392544.4524
-  tps: 365885.24667
-  hps: 4287.08142
+  dps: 393086.71879
+  tps: 366608.8538
+  hps: 4320.70081
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TrailseekerIdolofRage-101054"
  value: {
-  dps: 389452.40967
-  tps: 363423
-  hps: 4294.87242
+  dps: 388872.38372
+  tps: 362715.31577
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TrailseekerStoneofRage-101057"
  value: {
-  dps: 390897.76207
-  tps: 364889.91664
-  hps: 4294.87242
+  dps: 390340.91373
+  tps: 364205.3214
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TyrannicalGladiator'sBadgeofConquest-100043"
  value: {
-  dps: 382577.29141
-  tps: 356545.8207
-  hps: 4254.68465
+  dps: 383436.20735
+  tps: 357211.67318
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TyrannicalGladiator'sBadgeofDominance-100016"
  value: {
-  dps: 382391.85587
-  tps: 356391.72647
-  hps: 4254.68465
+  dps: 383253.86213
+  tps: 357061.34774
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TyrannicalGladiator'sBadgeofVictory-100019"
  value: {
-  dps: 392247.91091
-  tps: 365013.7821
-  hps: 4254.68465
+  dps: 393208.42269
+  tps: 365765.62003
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TyrannicalGladiator'sEmblemofCruelty-100066"
  value: {
-  dps: 386499.51611
-  tps: 360089.10019
-  hps: 4338.35849
+  dps: 387245.43883
+  tps: 360681.91804
+  hps: 4361.30044
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TyrannicalGladiator'sEmblemofMeditation-99990"
  value: {
-  dps: 382106.51838
-  tps: 356114.92863
-  hps: 4270.87882
+  dps: 382887.05498
+  tps: 356708.39688
+  hps: 4300.44586
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TyrannicalGladiator'sEmblemofTenacity-100092"
  value: {
-  dps: 382589.62337
-  tps: 356581.30908
-  hps: 4415.00655
+  dps: 384376.15183
+  tps: 358202.45617
+  hps: 4429.96777
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TyrannicalGladiator'sInsigniaofConquest-100026"
  value: {
-  dps: 384584.38061
-  tps: 358547.39431
-  hps: 4294.87242
+  dps: 384038.29007
+  tps: 357871.85523
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TyrannicalGladiator'sInsigniaofDominance-100152"
  value: {
-  dps: 384340.91287
-  tps: 358348.43539
-  hps: 4294.87242
+  dps: 383752.25172
+  tps: 357636.41389
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TyrannicalGladiator'sInsigniaofVictory-100085"
  value: {
-  dps: 397736.48975
-  tps: 370009.05874
-  hps: 4247.04492
+  dps: 398858.19427
+  tps: 371058.13836
+  hps: 4231.07944
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-TyrannicalPrimalDiamond"
  value: {
-  dps: 424459.21035
-  tps: 391875.42319
-  hps: 4293.48791
+  dps: 425359.22011
+  tps: 392563.54138
+  hps: 4317.94905
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-UnerringVisionofLeiShen-96930"
  value: {
-  dps: 384340.91287
-  tps: 358348.43539
-  hps: 4294.87242
+  dps: 383752.25172
+  tps: 357636.41389
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-VaporshieldMedallion-93262"
  value: {
-  dps: 387916.00457
-  tps: 361915.87517
-  hps: 4254.68465
+  dps: 388811.69094
+  tps: 362619.17655
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-VialofDragon'sBlood-87063"
  value: {
-  dps: 390209.20241
-  tps: 364216.72493
-  hps: 4294.87242
+  dps: 389609.69912
+  tps: 363493.8613
+  hps: 4272.69744
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-VialofIchorousBlood-100963"
  value: {
-  dps: 382391.85587
-  tps: 356391.72647
-  hps: 4254.68465
+  dps: 383253.86213
+  tps: 357061.34774
+  hps: 4277.64124
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-VialofLivingCorruption-105568"
  value: {
-  dps: 382671.5379
-  tps: 356632.98752
-  hps: 4589.75247
+  dps: 382772.15669
+  tps: 356624.45246
+  hps: 4580.21131
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-ViciousTalismanoftheShado-PanAssault-94511"
  value: {
-  dps: 388696.65111
-  tps: 362564.97592
-  hps: 4362.10647
+  dps: 389036.39866
+  tps: 362841.2754
+  hps: 4355.03594
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-VisionofthePredator-81192"
  value: {
-  dps: 388786.31481
-  tps: 362019.4291
-  hps: 4346.16167
+  dps: 388417.8896
+  tps: 361517.43386
+  hps: 4329.93326
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-VolatileTalismanoftheShado-PanAssault-94510"
  value: {
-  dps: 385273.11778
-  tps: 358615.28519
-  hps: 4318.91853
+  dps: 385021.10577
+  tps: 358316.18491
+  hps: 4252.59795
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-WindsweptPages-81125"
  value: {
-  dps: 385933.74313
-  tps: 359320.49476
-  hps: 4294.01932
+  dps: 386220.47449
+  tps: 359456.64995
+  hps: 4311.9388
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-WoundripperMedallion-93253"
  value: {
-  dps: 387423.90751
-  tps: 360709.51668
-  hps: 4358.89618
+  dps: 388269.68674
+  tps: 361374.79022
+  hps: 4388.33429
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Wushoolay'sFinalChoice-96785"
  value: {
-  dps: 390243.39239
-  tps: 364357.51955
-  hps: 4387.35299
+  dps: 388762.77047
+  tps: 362690.46452
+  hps: 4360.55956
  }
 }
 dps_results: {
@@ -2353,280 +2353,280 @@ dps_results: {
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-YaungolFireCarrier-86518"
  value: {
-  dps: 439133.39803
-  tps: 406272.23079
-  hps: 4373.9791
+  dps: 439748.11208
+  tps: 406763.81175
+  hps: 4348.30743
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-Yu'lon'sBite-103987"
  value: {
-  dps: 393666.98483
-  tps: 365665.68203
-  hps: 4477.27439
+  dps: 393418.69371
+  tps: 365321.65921
+  hps: 4464.76088
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-AllItems-ZenAlchemistStone-75274"
  value: {
-  dps: 396862.5916
-  tps: 369371.83178
-  hps: 4237.93706
+  dps: 397804.38262
+  tps: 370155.33062
+  hps: 4245.88852
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Average-Default"
  value: {
-  dps: 447193.43951
-  tps: 413940.27117
-  hps: 4157.3196
+  dps: 447331.29206
+  tps: 413997.1191
+  hps: 4156.8137
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.0026021477e+06
-  tps: 1.9700685705e+06
-  hps: 9871.56025
+  dps: 2.00548973805e+06
+  tps: 1.97249715261e+06
+  hps: 9809.23785
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 441204.47025
-  tps: 408672.85109
-  hps: 4300.92563
+  dps: 441682.45792
+  tps: 409020.95958
+  hps: 4328.67496
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 608572.60229
-  tps: 479089.71993
-  hps: 5220.95149
+  dps: 607963.4818
+  tps: 478191.54919
+  hps: 5228.71935
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-DefaultTalents-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.52513622693e+06
-  tps: 1.50517716701e+06
-  hps: 8573.9363
+  dps: 1.53747628845e+06
+  tps: 1.51733242409e+06
+  hps: 8709.13423
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-DefaultTalents-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 346989.27097
-  tps: 326963.06928
-  hps: 3804.16293
+  dps: 346581.57214
+  tps: 326498.29069
+  hps: 3781.62994
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-DefaultTalents-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 424129.13707
-  tps: 351415.83716
-  hps: 4100.9461
+  dps: 424459.90369
+  tps: 351450.16203
+  hps: 4213.61105
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RoilingBlood-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.90863265038e+06
-  tps: 1.8759728775e+06
-  hps: 9541.30714
+  dps: 1.91133282216e+06
+  tps: 1.87828778299e+06
+  hps: 9590.19703
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RoilingBlood-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 449715.42506
-  tps: 417096.55322
-  hps: 4449.43494
+  dps: 449262.2725
+  tps: 416601.33633
+  hps: 4440.38832
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RoilingBlood-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 619443.83589
-  tps: 489759.44264
-  hps: 5354.37934
+  dps: 616150.0555
+  tps: 486233.03158
+  hps: 5281.1221
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RoilingBlood-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.46691550115e+06
-  tps: 1.44701982828e+06
-  hps: 8450.15037
+  dps: 1.47663281552e+06
+  tps: 1.45657267183e+06
+  hps: 8506.48284
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RoilingBlood-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 354366.20578
-  tps: 334349.50098
-  hps: 3928.81362
+  dps: 353998.27324
+  tps: 333956.75945
+  hps: 3958.8576
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RoilingBlood-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 439379.82132
-  tps: 366559.21336
-  hps: 4241.85964
+  dps: 438758.38815
+  tps: 365813.78432
+  hps: 4260.63713
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicCorruption-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.78993782293e+06
-  tps: 1.75736397014e+06
-  hps: 9193.6899
+  dps: 1.79779600849e+06
+  tps: 1.76481309035e+06
+  hps: 9241.14586
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicCorruption-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 438213.15973
-  tps: 405686.5107
-  hps: 4494.89428
+  dps: 439740.96962
+  tps: 406976.93493
+  hps: 4545.06292
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicCorruption-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 604773.24175
-  tps: 475054.62286
-  hps: 5395.66779
+  dps: 604559.28897
+  tps: 474129.33569
+  hps: 5484.46076
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicCorruption-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.38048837981e+06
-  tps: 1.36047917035e+06
-  hps: 8130.08202
+  dps: 1.38492210325e+06
+  tps: 1.36479407279e+06
+  hps: 8207.05326
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicCorruption-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 345169.59393
-  tps: 325227.94706
-  hps: 3944.79919
+  dps: 346667.68107
+  tps: 326631.71467
+  hps: 3951.37955
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicCorruption-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 423483.74329
-  tps: 350858.58152
-  hps: 4274.76142
+  dps: 421171.12473
+  tps: 348494.44934
+  hps: 4406.20385
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicEmpowerment-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.83465871291e+06
-  tps: 1.80208848918e+06
-  hps: 9379.05497
+  dps: 1.83368448139e+06
+  tps: 1.80072597901e+06
+  hps: 9395.86945
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicEmpowerment-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 438772.34737
-  tps: 406365.79299
-  hps: 4424.24312
+  dps: 439571.83981
+  tps: 406928.49634
+  hps: 4482.51426
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicEmpowerment-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 603204.83432
-  tps: 473918.41184
-  hps: 5341.59182
+  dps: 604907.2002
+  tps: 474749.01113
+  hps: 5430.3848
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicEmpowerment-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.40944224117e+06
-  tps: 1.38950339003e+06
-  hps: 8079.33339
+  dps: 1.40926827298e+06
+  tps: 1.38923729617e+06
+  hps: 8056.8004
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicEmpowerment-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 347230.03688
-  tps: 327303.88421
-  hps: 3905.97042
+  dps: 346831.39627
+  tps: 326799.36491
+  hps: 3909.72591
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-RunicEmpowerment-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 428852.51624
-  tps: 356211.08752
-  hps: 4274.76142
+  dps: 427146.72212
+  tps: 354268.16356
+  hps: 4312.3164
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-UnholyBlight-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.97261458044e+06
-  tps: 1.93982492323e+06
-  hps: 9585.51202
+  dps: 1.98302225324e+06
+  tps: 1.94993459544e+06
+  hps: 9637.8437
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-UnholyBlight-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 451144.07437
-  tps: 418513.84339
-  hps: 4452.20744
+  dps: 451008.07673
+  tps: 418258.50026
+  hps: 4457.81227
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-UnholyBlight-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 626001.68239
-  tps: 496258.71378
-  hps: 5374.63562
+  dps: 623803.8261
+  tps: 493548.04886
+  hps: 5329.40252
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-UnholyBlight-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.52090623884e+06
-  tps: 1.50089583281e+06
-  hps: 8378.1096
+  dps: 1.52336914598e+06
+  tps: 1.50316945591e+06
+  hps: 8404.39809
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-UnholyBlight-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 352644.6889
-  tps: 332606.35415
+  dps: 353019.59864
+  tps: 332901.6108
   hps: 3877.13434
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-Settings-Troll-p5.masterfrost-UnholyBlight-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 440047.94328
-  tps: 367275.93535
+  dps: 438623.53895
+  tps: 365719.15362
   hps: 4262.18819
  }
 }
 dps_results: {
  key: "TestFrostMasterfrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 407408.0675
-  tps: 376823.9139
-  hps: 3966.92832
+  dps: 408521.33923
+  tps: 377799.10975
+  hps: 3930.40051
  }
 }

--- a/sim/death_knight/frost/TestFrostTwoHand.results
+++ b/sim/death_knight/frost/TestFrostTwoHand.results
@@ -33,1577 +33,1577 @@ character_stats_results: {
 dps_results: {
  key: "TestFrostTwoHand-AllItems-AgilePrimalDiamond"
  value: {
-  dps: 411945.92089
-  tps: 371289.4601
-  hps: 7140.28046
+  dps: 413228.04043
+  tps: 372656.66016
+  hps: 7232.10216
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-AlacrityofXuen-103989"
  value: {
-  dps: 395702.55311
-  tps: 359807.77806
-  hps: 6994.96045
+  dps: 395191.15515
+  tps: 359482.98557
+  hps: 6997.61343
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-ArcaneBadgeoftheShieldwall-93347"
  value: {
-  dps: 379005.18658
-  tps: 346169.6803
-  hps: 6937.13914
+  dps: 378784.3303
+  tps: 346219.93508
+  hps: 6912.50285
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-ArrowflightMedallion-93258"
  value: {
-  dps: 381879.84978
-  tps: 349053.34158
-  hps: 6961.74382
+  dps: 382638.9508
+  tps: 349668.82639
+  hps: 6993.35467
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-AssuranceofConsequence-105472"
  value: {
-  dps: 378103.87448
-  tps: 345849.38849
-  hps: 6821.0924
+  dps: 378559.17592
+  tps: 346142.1345
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-AusterePrimalDiamond"
  value: {
-  dps: 404690.2577
-  tps: 364090.96122
-  hps: 7104.07841
+  dps: 405822.93833
+  tps: 365294.26845
+  hps: 7187.44123
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-BadJuju-96781"
  value: {
-  dps: 383226.06788
-  tps: 351053.76385
-  hps: 6821.0924
+  dps: 383882.20353
+  tps: 351558.47912
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-BadgeofKypariZar-84079"
  value: {
-  dps: 381892.55492
-  tps: 349422.75629
-  hps: 6876.75125
+  dps: 382675.00913
+  tps: 350024.42445
+  hps: 6925.66148
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-BattlegearoftheLostCatacomb"
  value: {
-  dps: 327697.73027
-  tps: 297861.94769
-  hps: 4371.09553
+  dps: 328468.35822
+  tps: 298867.83392
+  hps: 4369.19187
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-BattleplateofCyclopeanDread"
  value: {
-  dps: 349282.4766
-  tps: 316829.018
-  hps: 5714.08537
+  dps: 348932.34956
+  tps: 316661.03733
+  hps: 5752.84087
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-BattleplateoftheAll-ConsumingMaw"
  value: {
-  dps: 340336.06718
-  tps: 301043.57012
-  hps: 4690.08977
+  dps: 340090.74097
+  tps: 300915.3343
+  hps: 4682.05299
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-BlackBloodofY'Shaarj-105648"
  value: {
-  dps: 383860.29678
-  tps: 350673.64313
-  hps: 7031.48477
+  dps: 383621.13479
+  tps: 350693.98999
+  hps: 6981.55053
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-BlossomofPureSnow-89081"
  value: {
-  dps: 381460.27917
-  tps: 348696.96534
-  hps: 6942.94015
+  dps: 382147.50464
+  tps: 349243.96956
+  hps: 6976.80745
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-BottleofInfiniteStars-87057"
  value: {
-  dps: 381509.94668
-  tps: 349374.34321
-  hps: 6821.0924
+  dps: 382081.24282
+  tps: 349779.72296
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-BraidofTenSongs-84072"
  value: {
-  dps: 380698.46302
-  tps: 348016.17748
-  hps: 6917.23809
+  dps: 380258.66816
+  tps: 347617.68703
+  hps: 6871.07937
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Brawler'sStatue-257885"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-BreathoftheHydra-96827"
  value: {
-  dps: 381511.12489
-  tps: 348564.44604
-  hps: 6911.1206
+  dps: 382448.48184
+  tps: 349616.16512
+  hps: 6984.07883
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-BroochofMunificentDeeds-87500"
  value: {
-  dps: 376687.9159
-  tps: 344577.35209
-  hps: 7037.77946
+  dps: 377194.06265
+  tps: 344953.14501
+  hps: 7143.45011
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-BrutalTalismanoftheShado-PanAssault-94508"
  value: {
-  dps: 391594.45019
-  tps: 356211.87212
-  hps: 6821.0924
+  dps: 392143.06626
+  tps: 356667.94556
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-BurningPrimalDiamond"
  value: {
-  dps: 411936.73556
-  tps: 371282.95247
-  hps: 7140.28046
+  dps: 413198.24858
+  tps: 372626.86831
+  hps: 7232.10216
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CapacitivePrimalDiamond"
  value: {
-  dps: 425903.11477
-  tps: 385126.55692
-  hps: 7191.96087
+  dps: 424569.99215
+  tps: 383944.36257
+  hps: 7073.00129
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CarbonicCarbuncle-81138"
  value: {
-  dps: 387177.32596
-  tps: 353281.4741
-  hps: 6917.92357
+  dps: 387852.06187
+  tps: 353807.63009
+  hps: 6983.73069
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Cha-Ye'sEssenceofBrilliance-96888"
  value: {
-  dps: 383469.97696
-  tps: 350709.65167
-  hps: 6969.61431
+  dps: 383844.68176
+  tps: 350923.61911
+  hps: 7024.13924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CharmofTenSongs-84071"
  value: {
-  dps: 380381.55094
-  tps: 347467.56633
-  hps: 7017.52487
+  dps: 381950.93813
+  tps: 348922.96253
+  hps: 6951.98642
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CommunalIdolofDestruction-101168"
  value: {
-  dps: 380918.19912
-  tps: 348484.515
-  hps: 6914.31874
+  dps: 382303.41608
+  tps: 349757.12264
+  hps: 6971.38956
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CommunalStoneofDestruction-101171"
  value: {
-  dps: 381470.47484
-  tps: 349383.61307
-  hps: 6821.0924
+  dps: 382076.16629
+  tps: 349819.31079
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CommunalStoneofWisdom-101183"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-ContemplationofChi-Ji-103988"
  value: {
-  dps: 377011.19516
-  tps: 344846.40381
-  hps: 6852.50816
+  dps: 377230.79753
+  tps: 344930.79426
+  hps: 6896.91525
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Coren'sColdChromiumCoaster-257880"
  value: {
-  dps: 387369.87335
-  tps: 353698.5653
-  hps: 6907.4355
+  dps: 387872.97681
+  tps: 354024.32778
+  hps: 6961.96042
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CoreofDecency-87497"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CourageousPrimalDiamond"
  value: {
-  dps: 404631.04518
-  tps: 364041.23633
-  hps: 7041.16898
+  dps: 405817.34287
+  tps: 365315.10483
+  hps: 7128.24167
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedDreadfulGladiator'sBadgeofConquest-93419"
  value: {
-  dps: 377367.57974
-  tps: 345239.41342
-  hps: 6821.0924
+  dps: 377863.01089
+  tps: 345581.43746
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedDreadfulGladiator'sBadgeofDominance-93600"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedDreadfulGladiator'sBadgeofVictory-93606"
  value: {
-  dps: 383001.9157
-  tps: 349860.31584
-  hps: 6821.0924
+  dps: 383522.84502
+  tps: 350207.10759
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedDreadfulGladiator'sEmblemofCruelty-93485"
  value: {
-  dps: 379443.92533
-  tps: 347090.88409
-  hps: 6956.3755
+  dps: 380947.53048
+  tps: 348430.23868
+  hps: 7042.01676
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedDreadfulGladiator'sEmblemofMeditation-93487"
  value: {
-  dps: 376731.55284
-  tps: 344690.41008
-  hps: 6881.05336
+  dps: 378303.60429
+  tps: 346070.34604
+  hps: 6974.21609
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedDreadfulGladiator'sEmblemofTenacity-93486"
  value: {
-  dps: 376355.52034
-  tps: 344228.19853
-  hps: 7014.34634
+  dps: 376929.99601
+  tps: 344669.09772
+  hps: 7129.72885
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedDreadfulGladiator'sInsigniaofConquest-93424"
  value: {
-  dps: 377533.27757
-  tps: 345406.21139
-  hps: 6821.0924
+  dps: 378035.45066
+  tps: 345745.41305
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedDreadfulGladiator'sInsigniaofDominance-93601"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedDreadfulGladiator'sInsigniaofVictory-93611"
  value: {
-  dps: 385320.42422
-  tps: 351838.02551
-  hps: 6821.0924
+  dps: 385890.01129
+  tps: 352215.99452
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedMalevolentGladiator'sBadgeofConquest-98755"
  value: {
-  dps: 377431.13749
-  tps: 345298.4283
-  hps: 6821.0924
+  dps: 377938.14552
+  tps: 345649.75377
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedMalevolentGladiator'sBadgeofDominance-98910"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedMalevolentGladiator'sBadgeofVictory-98912"
  value: {
-  dps: 384054.72229
-  tps: 350720.54531
-  hps: 6821.0924
+  dps: 384574.86863
+  tps: 351065.79748
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedMalevolentGladiator'sEmblemofCruelty-98811"
  value: {
-  dps: 379946.44405
-  tps: 347524.04117
-  hps: 6960.39358
+  dps: 381421.09624
+  tps: 348839.70647
+  hps: 7046.03484
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedMalevolentGladiator'sEmblemofMeditation-98813"
  value: {
-  dps: 376731.55284
-  tps: 344690.41008
-  hps: 6881.05336
+  dps: 378303.60429
+  tps: 346070.34604
+  hps: 6974.21609
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedMalevolentGladiator'sEmblemofTenacity-98812"
  value: {
-  dps: 376355.52034
-  tps: 344228.19853
-  hps: 7038.65031
+  dps: 376929.99601
+  tps: 344669.09772
+  hps: 7154.4294
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedMalevolentGladiator'sInsigniaofConquest-98760"
  value: {
-  dps: 377484.06011
-  tps: 345347.53207
-  hps: 6821.0924
+  dps: 378047.39597
+  tps: 345753.04851
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedMalevolentGladiator'sInsigniaofDominance-98911"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CraftedMalevolentGladiator'sInsigniaofVictory-98917"
  value: {
-  dps: 386918.46868
-  tps: 353123.91368
-  hps: 6821.0924
+  dps: 387465.26358
+  tps: 353477.81309
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CurseofHubris-105645"
  value: {
-  dps: 387020.53382
-  tps: 353168.56969
-  hps: 7597.71251
+  dps: 388038.14229
+  tps: 354054.5965
+  hps: 7678.13456
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-CutstitcherMedallion-93255"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Daelo'sFinalWords-87496"
  value: {
-  dps: 383519.05911
-  tps: 349826.90369
-  hps: 6852.50816
+  dps: 383752.10737
+  tps: 349895.89438
+  hps: 6896.91525
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DarkglowEmbroidery(Rank3)-4893"
  value: {
-  dps: 425178.15865
-  tps: 384466.88163
-  hps: 7179.66283
+  dps: 423651.50928
+  tps: 383118.63167
+  hps: 7059.13123
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DarkmistVortex-87172"
  value: {
-  dps: 390941.65322
-  tps: 355737.47549
-  hps: 6979.92754
+  dps: 390388.26686
+  tps: 355326.59815
+  hps: 6989.32407
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DeadeyeBadgeoftheShieldwall-93346"
  value: {
-  dps: 380070.31156
-  tps: 347956.55549
-  hps: 6821.0924
+  dps: 380594.24768
+  tps: 348319.26647
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DelicateVialoftheSanguinaire-96895"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DestructivePrimalDiamond"
  value: {
-  dps: 406067.30484
-  tps: 365277.2444
-  hps: 7090.97787
+  dps: 407430.19288
+  tps: 366736.06224
+  hps: 7172.37919
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DisciplineofXuen-103986"
  value: {
-  dps: 385266.55946
-  tps: 353131.9383
-  hps: 6821.0924
+  dps: 385808.29142
+  tps: 353515.562
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Dominator'sArcaneBadge-93342"
  value: {
-  dps: 379005.18658
-  tps: 346169.6803
-  hps: 6937.13914
+  dps: 378784.3303
+  tps: 346219.93508
+  hps: 6912.50285
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Dominator'sDeadeyeBadge-93341"
  value: {
-  dps: 380070.31156
-  tps: 347956.55549
-  hps: 6821.0924
+  dps: 380594.24768
+  tps: 348319.26647
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Dominator'sDurableBadge-93345"
  value: {
-  dps: 379986.20295
-  tps: 347899.34118
-  hps: 6821.0924
+  dps: 380495.71411
+  tps: 348238.85861
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Dominator'sKnightlyBadge-93344"
  value: {
-  dps: 385309.00061
-  tps: 352511.46415
-  hps: 6821.0924
+  dps: 385824.3702
+  tps: 352852.79419
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Dominator'sMendingBadge-93343"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DreadfulGladiator'sBadgeofConquest-84344"
  value: {
-  dps: 377367.57974
-  tps: 345239.41342
-  hps: 6821.0924
+  dps: 377863.01089
+  tps: 345581.43746
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DreadfulGladiator'sBadgeofDominance-84488"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DreadfulGladiator'sBadgeofVictory-84490"
  value: {
-  dps: 383001.9157
-  tps: 349860.31584
-  hps: 6821.0924
+  dps: 383522.84502
+  tps: 350207.10759
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DreadfulGladiator'sEmblemofCruelty-84399"
  value: {
-  dps: 379443.92533
-  tps: 347090.88409
-  hps: 6956.3755
+  dps: 380947.53048
+  tps: 348430.23868
+  hps: 7042.01676
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DreadfulGladiator'sEmblemofMeditation-84401"
  value: {
-  dps: 376731.55284
-  tps: 344690.41008
-  hps: 6881.05336
+  dps: 378303.60429
+  tps: 346070.34604
+  hps: 6974.21609
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DreadfulGladiator'sEmblemofTenacity-84400"
  value: {
-  dps: 376355.52034
-  tps: 344228.19853
-  hps: 7014.34634
+  dps: 376929.99601
+  tps: 344669.09772
+  hps: 7129.72885
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DreadfulGladiator'sInsigniaofConquest-84349"
  value: {
-  dps: 377501.98464
-  tps: 345376.13587
-  hps: 6821.0924
+  dps: 378033.29818
+  tps: 345743.8516
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DreadfulGladiator'sInsigniaofDominance-84489"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DreadfulGladiator'sInsigniaofVictory-84495"
  value: {
-  dps: 385342.17744
-  tps: 351836.04352
-  hps: 6821.0924
+  dps: 385944.70986
+  tps: 352240.23022
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DurableBadgeoftheShieldwall-93350"
  value: {
-  dps: 379986.20295
-  tps: 347899.34118
-  hps: 6821.0924
+  dps: 380495.71411
+  tps: 348238.85861
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-DysmorphicSamophlangeofDiscontinuity-105615"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EffulgentPrimalDiamond"
  value: {
-  dps: 404690.2577
-  tps: 364090.96122
-  hps: 7104.07841
+  dps: 405822.93833
+  tps: 365294.26845
+  hps: 7187.44123
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EmberPrimalDiamond"
  value: {
-  dps: 404631.04518
-  tps: 364041.23633
-  hps: 7041.16898
+  dps: 405817.34287
+  tps: 365315.10483
+  hps: 7128.24167
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EmblemofKypariZar-84077"
  value: {
-  dps: 381220.03647
-  tps: 348337.99498
-  hps: 6987.874
+  dps: 381866.12311
+  tps: 348897.3773
+  hps: 6913.33825
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EmblemoftheCatacombs-83733"
  value: {
-  dps: 381904.97449
-  tps: 349588.28431
-  hps: 6937.79726
+  dps: 382906.52376
+  tps: 350423.5622
+  hps: 6936.17233
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EmptyFruitBarrel-81133"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EnchantWeapon-BloodyDancingSteel-5125"
  value: {
-  dps: 400461.30057
-  tps: 363151.49569
-  hps: 18.92445
+  dps: 399259.22998
+  tps: 362068.90255
+  hps: 18.97502
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EnchantWeapon-Colossus-4445"
  value: {
-  dps: 395111.65816
-  tps: 358539.36282
-  hps: 18.83425
+  dps: 394112.0645
+  tps: 357544.51942
+  hps: 18.97502
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EnchantWeapon-DancingSteel-4444"
  value: {
-  dps: 400791.36047
-  tps: 363423.22152
-  hps: 18.92445
+  dps: 399600.01952
+  tps: 362347.83342
+  hps: 18.97502
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EnchantWeapon-ElementalForce-4443"
  value: {
-  dps: 397213.46668
-  tps: 360630.22972
-  hps: 19.33935
+  dps: 395495.05006
+  tps: 359050.94916
+  hps: 18.97502
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EnchantWeapon-JadeSpirit-4442"
  value: {
-  dps: 395655.5331
-  tps: 359133.06844
-  hps: 18.92445
+  dps: 394450.40772
+  tps: 358046.96785
+  hps: 18.97502
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EnchantWeapon-River'sSong-4446"
  value: {
-  dps: 395659.07838
-  tps: 359152.67469
-  hps: 18.92445
+  dps: 394465.91488
+  tps: 358075.50997
+  hps: 18.97502
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EnchantWeapon-SpiritofConquest-5124"
  value: {
-  dps: 395655.5331
-  tps: 359133.06844
-  hps: 18.92445
+  dps: 394450.40772
+  tps: 358046.96785
+  hps: 18.97502
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EnchantWeapon-Windsong-4441"
  value: {
-  dps: 396237.94169
-  tps: 359195.33155
-  hps: 19.32997
+  dps: 396557.16912
+  tps: 359632.41593
+  hps: 18.67166
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EnigmaticPrimalDiamond"
  value: {
-  dps: 406067.30484
-  tps: 365277.2444
-  hps: 7090.97787
+  dps: 407430.19288
+  tps: 366736.06224
+  hps: 7172.37919
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EssenceofTerror-87175"
  value: {
-  dps: 380614.04981
-  tps: 347703.37852
-  hps: 6961.09825
+  dps: 381106.03676
+  tps: 348112.50861
+  hps: 6980.82199
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EternalPrimalDiamond"
  value: {
-  dps: 404631.04518
-  tps: 364041.23633
-  hps: 7041.16898
+  dps: 405817.34287
+  tps: 365315.10483
+  hps: 7128.24167
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-EvilEyeofGalakras-105491"
  value: {
-  dps: 409461.43076
-  tps: 372914.36
-  hps: 7468.54904
+  dps: 410600.34743
+  tps: 373683.57597
+  hps: 7459.4188
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-FabledFeatherofJi-Kun-96842"
  value: {
-  dps: 394036.30664
-  tps: 358205.5153
-  hps: 6828.61387
+  dps: 395971.65833
+  tps: 359783.12839
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-FearwurmBadge-84074"
  value: {
-  dps: 381322.76654
-  tps: 348532.06902
-  hps: 7002.8229
+  dps: 381494.82729
+  tps: 348756.31583
+  hps: 6954.93126
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-FearwurmRelic-84070"
  value: {
-  dps: 380655.29347
-  tps: 347769.95774
-  hps: 7014.44274
+  dps: 378949.8408
+  tps: 346303.46504
+  hps: 6922.10942
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-FelsoulIdolofDestruction-101263"
  value: {
-  dps: 382882.40903
-  tps: 350204.13244
-  hps: 6920.57517
+  dps: 383000.99302
+  tps: 350437.23384
+  hps: 6894.3758
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-FelsoulStoneofDestruction-101266"
  value: {
-  dps: 381629.52503
-  tps: 349542.66327
-  hps: 6821.0924
+  dps: 382060.7445
+  tps: 349803.889
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Fen-Yu,FuryofXuen-102248"
  value: {
-  dps: 404102.53664
-  tps: 365899.51796
-  hps: 6874.87467
+  dps: 404631.60333
+  tps: 366354.8634
+  hps: 6923.81378
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-FlashfrozenResinGlobule-100951"
  value: {
-  dps: 377050.25209
-  tps: 344897.00561
-  hps: 6871.50585
+  dps: 377351.22108
+  tps: 345042.843
+  hps: 6885.04556
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-FlashingSteelTalisman-81265"
  value: {
-  dps: 377192.45068
-  tps: 344978.52973
-  hps: 6852.50816
+  dps: 377402.78559
+  tps: 345063.87085
+  hps: 6896.91525
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-FleetPrimalDiamond"
  value: {
-  dps: 406278.8068
-  tps: 365688.99795
-  hps: 7041.16898
+  dps: 407471.44605
+  tps: 366969.20801
+  hps: 7128.24167
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-ForlornPrimalDiamond"
  value: {
-  dps: 404631.04518
-  tps: 364041.23633
-  hps: 7041.16898
+  dps: 405817.34287
+  tps: 365315.10483
+  hps: 7128.24167
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-FortitudeoftheZandalari-96793"
  value: {
-  dps: 382368.15157
-  tps: 350327.00881
-  hps: 6881.05336
+  dps: 383962.14568
+  tps: 351728.88743
+  hps: 6974.21609
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-FrenziedCrystalofRage-105572"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Fusion-FireCore-105459"
  value: {
-  dps: 399855.79812
-  tps: 362676.64342
-  hps: 6821.0924
+  dps: 400395.01209
+  tps: 363063.75033
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-GazeoftheTwins-96915"
  value: {
-  dps: 394926.0173
-  tps: 360228.67611
-  hps: 6990.32539
+  dps: 396314.15249
+  tps: 361418.95143
+  hps: 7071.17544
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Gerp'sPerfectArrow-87495"
  value: {
-  dps: 379826.97327
-  tps: 347426.71416
-  hps: 6892.13521
+  dps: 380405.04818
+  tps: 347858.14159
+  hps: 6950.42087
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-GrievousGladiator'sBadgeofConquest-103145"
  value: {
-  dps: 377564.76746
-  tps: 345417.75732
-  hps: 6821.0924
+  dps: 378042.19165
+  tps: 345736.97878
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-GrievousGladiator'sBadgeofDominance-103308"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-GrievousGladiator'sBadgeofVictory-103314"
  value: {
-  dps: 387706.7343
-  tps: 353704.53914
-  hps: 6821.0924
+  dps: 388224.1646
+  tps: 354044.45077
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-GrievousGladiator'sEmblemofCruelty-103210"
  value: {
-  dps: 381812.25014
-  tps: 349193.67099
-  hps: 7006.13321
+  dps: 383315.62986
+  tps: 350513.5094
+  hps: 7080.38424
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-GrievousGladiator'sEmblemofMeditation-103212"
  value: {
-  dps: 376731.55284
-  tps: 344690.41008
-  hps: 6881.05336
+  dps: 378303.60429
+  tps: 346070.34604
+  hps: 6974.21609
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-GrievousGladiator'sEmblemofTenacity-103211"
  value: {
-  dps: 376105.97217
-  tps: 343926.99156
-  hps: 7135.42536
+  dps: 376736.51738
+  tps: 344425.99198
+  hps: 7250.72958
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-GrievousGladiator'sInsigniaofConquest-103150"
  value: {
-  dps: 377616.62472
-  tps: 345459.53888
-  hps: 6821.0924
+  dps: 378166.23164
+  tps: 345850.17971
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-GrievousGladiator'sInsigniaofDominance-103309"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-GrievousGladiator'sInsigniaofVictory-103319"
  value: {
-  dps: 391917.81218
-  tps: 357281.10482
-  hps: 6821.0924
+  dps: 392513.87898
+  tps: 357728.68307
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Haromm'sTalisman-105527"
  value: {
-  dps: 395336.11751
-  tps: 363156.99483
-  hps: 6821.0924
+  dps: 397761.50992
+  tps: 365395.63282
+  hps: 6867.74619
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Hawkmaster'sTalon-89082"
  value: {
-  dps: 380503.9461
-  tps: 347603.76679
-  hps: 6931.33743
+  dps: 380755.12722
+  tps: 347947.53891
+  hps: 6915.06285
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Heart-LesionDefenderIdol-100999"
  value: {
-  dps: 376331.2062
-  tps: 344200.94915
-  hps: 7045.2337
+  dps: 377506.81858
+  tps: 345241.69625
+  hps: 7168.81739
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Heart-LesionDefenderStone-101002"
  value: {
-  dps: 380620.51879
-  tps: 348490.26175
-  hps: 7045.2337
+  dps: 381908.87832
+  tps: 349643.756
+  hps: 7168.81739
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Heart-LesionIdolofBattle-100991"
  value: {
-  dps: 389371.88989
-  tps: 355394.60719
-  hps: 6907.4355
+  dps: 390122.14918
+  tps: 355965.58859
+  hps: 6958.19969
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Heart-LesionStoneofBattle-100990"
  value: {
-  dps: 388283.26997
-  tps: 355299.49985
-  hps: 6821.0924
+  dps: 388865.95601
+  tps: 355707.08612
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-HeartofFire-81181"
  value: {
-  dps: 379962.99709
-  tps: 347876.13533
-  hps: 6821.0924
+  dps: 380486.56049
+  tps: 348229.70499
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-HeartwarmerMedallion-93260"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-HelmbreakerMedallion-93261"
  value: {
-  dps: 389346.37258
-  tps: 355510.44545
-  hps: 6961.74382
+  dps: 390091.34616
+  tps: 356109.19946
+  hps: 6993.35467
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Horridon'sLastGasp-96757"
  value: {
-  dps: 377073.99188
-  tps: 344978.27013
-  hps: 6806.04947
+  dps: 377722.05675
+  tps: 345443.7111
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-ImpassivePrimalDiamond"
  value: {
-  dps: 406067.30484
-  tps: 365277.2444
-  hps: 7090.97787
+  dps: 407430.19288
+  tps: 366736.06224
+  hps: 7172.37919
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-IndomitablePrimalDiamond"
  value: {
-  dps: 404690.2577
-  tps: 364090.96122
-  hps: 7104.07841
+  dps: 405822.93833
+  tps: 365294.26845
+  hps: 7187.44123
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-InscribedBagofHydra-Spawn-96828"
  value: {
-  dps: 376600.67025
-  tps: 344478.11972
-  hps: 6769.78144
+  dps: 378290.19613
+  tps: 345957.71722
+  hps: 6877.90269
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-InsigniaofKypariZar-84078"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-IronBellyWok-89083"
  value: {
-  dps: 387337.8387
-  tps: 353493.82886
-  hps: 6931.33743
+  dps: 387654.95675
+  tps: 353903.22519
+  hps: 6915.06285
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-IronProtectorTalisman-85181"
  value: {
-  dps: 376740.85663
-  tps: 344645.86795
-  hps: 6965.64187
+  dps: 377564.75599
+  tps: 345317.95353
+  hps: 7084.16604
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-JadeBanditFigurine-86772"
  value: {
-  dps: 381554.19108
-  tps: 348687.80616
-  hps: 6876.54031
+  dps: 382161.14933
+  tps: 349435.02814
+  hps: 6939.2818
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-JadeCharioteerFigurine-86771"
  value: {
-  dps: 387666.03277
-  tps: 353970.40648
-  hps: 6876.54031
+  dps: 388334.08293
+  tps: 354781.94343
+  hps: 6939.2818
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-JadeCourtesanFigurine-86774"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-JadeMagistrateFigurine-86773"
  value: {
-  dps: 380816.86649
-  tps: 348120.87641
-  hps: 6924.88863
+  dps: 381541.92094
+  tps: 348715.83492
+  hps: 6962.51666
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-JadeWarlordFigurine-86775"
  value: {
-  dps: 379559.54554
-  tps: 347429.28849
-  hps: 7031.69987
+  dps: 380747.7561
+  tps: 348482.63378
+  hps: 7155.04754
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Ji-Kun'sRisingWinds-96843"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Juggernaut'sFocusingCrystal-105514"
  value: {
-  dps: 376695.60225
-  tps: 344637.34294
-  hps: 17792.33057
+  dps: 377193.15494
+  tps: 344960.70064
+  hps: 17836.61108
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Kardris'ToxicTotem-105540"
  value: {
-  dps: 394754.95259
-  tps: 362668.09083
-  hps: 6821.0924
+  dps: 395596.09281
+  tps: 363359.12972
+  hps: 6860.22472
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-KnightlyBadgeoftheShieldwall-93349"
  value: {
-  dps: 385309.00061
-  tps: 352511.46415
-  hps: 6821.0924
+  dps: 385824.3702
+  tps: 352852.79419
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-KnotofTenSongs-84073"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Kor'kronBookofHurting-92785"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Lao-Chin'sLiquidCourage-89079"
  value: {
-  dps: 379855.62695
-  tps: 347718.96121
-  hps: 7053.62641
+  dps: 380953.40814
+  tps: 348675.83063
+  hps: 7189.08041
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-LeiShen'sFinalOrders-87072"
  value: {
-  dps: 390704.45876
-  tps: 356208.86982
-  hps: 6909.1921
+  dps: 391366.90243
+  tps: 356611.28901
+  hps: 6912.52726
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-LessonsoftheDarkmaster-81268"
  value: {
-  dps: 385524.18682
-  tps: 351229.58719
-  hps: 6821.0924
+  dps: 386123.55915
+  tps: 351650.09002
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-LightdrinkerIdolofRage-101200"
  value: {
-  dps: 380731.11485
-  tps: 348600.51802
-  hps: 6821.0924
+  dps: 381352.08678
+  tps: 349063.28174
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-LightdrinkerStoneofRage-101203"
  value: {
-  dps: 381674.54759
-  tps: 349556.54881
-  hps: 6821.0924
+  dps: 382195.34435
+  tps: 349915.0515
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-LightoftheCosmos-87065"
  value: {
-  dps: 380357.55355
-  tps: 347712.8696
-  hps: 6909.1921
+  dps: 380931.26499
+  tps: 348047.92005
+  hps: 6912.52726
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-LightweaveEmbroidery(Rank3)-4892"
  value: {
-  dps: 425178.15865
-  tps: 384466.88163
-  hps: 7179.66283
+  dps: 423651.50928
+  tps: 383118.63167
+  hps: 7059.13123
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-LordBlastington'sScopeofDoom-4699"
  value: {
-  dps: 395655.5331
-  tps: 359133.06844
-  hps: 18.92445
+  dps: 394450.40772
+  tps: 358046.96785
+  hps: 18.97502
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MalevolentGladiator'sBadgeofConquest-91452"
  value: {
-  dps: 377431.13749
-  tps: 345298.4283
-  hps: 6821.0924
+  dps: 377938.14552
+  tps: 345649.75377
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MalevolentGladiator'sBadgeofDominance-91753"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MalevolentGladiator'sBadgeofVictory-91763"
  value: {
-  dps: 384054.72229
-  tps: 350720.54531
-  hps: 6821.0924
+  dps: 384574.86863
+  tps: 351065.79748
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MalevolentGladiator'sEmblemofCruelty-91562"
  value: {
-  dps: 379946.44405
-  tps: 347524.04117
-  hps: 6960.39358
+  dps: 381421.09624
+  tps: 348839.70647
+  hps: 7046.03484
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MalevolentGladiator'sEmblemofMeditation-91564"
  value: {
-  dps: 376731.55284
-  tps: 344690.41008
-  hps: 6881.05336
+  dps: 378303.60429
+  tps: 346070.34604
+  hps: 6974.21609
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MalevolentGladiator'sEmblemofTenacity-91563"
  value: {
-  dps: 376355.52034
-  tps: 344228.19853
-  hps: 7038.65031
+  dps: 376929.99601
+  tps: 344669.09772
+  hps: 7154.4294
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MalevolentGladiator'sInsigniaofConquest-91457"
  value: {
-  dps: 377549.72863
-  tps: 345412.00183
-  hps: 6821.0924
+  dps: 378077.8803
+  tps: 345784.66199
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MalevolentGladiator'sInsigniaofDominance-91754"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MalevolentGladiator'sInsigniaofVictory-91768"
  value: {
-  dps: 386854.93442
-  tps: 353079.45533
-  hps: 6821.0924
+  dps: 387383.98099
+  tps: 353433.64426
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MarkoftheCatacombs-83731"
  value: {
-  dps: 381891.2035
-  tps: 349577.12853
-  hps: 6888.37448
+  dps: 382502.87515
+  tps: 350033.77794
+  hps: 6946.66014
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MarkoftheHardenedGrunt-92783"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MedallionofMystifyingVapors-93257"
  value: {
-  dps: 381155.63862
-  tps: 349068.77685
-  hps: 6821.0924
+  dps: 381658.47173
+  tps: 349401.61623
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MedallionoftheCatacombs-83734"
  value: {
-  dps: 379222.41719
-  tps: 347135.55543
-  hps: 6821.0924
+  dps: 379746.42981
+  tps: 347489.57431
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MendingBadgeoftheShieldwall-93348"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MirrorScope-4700"
  value: {
-  dps: 395655.5331
-  tps: 359133.06844
-  hps: 18.92445
+  dps: 394450.40772
+  tps: 358046.96785
+  hps: 18.97502
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MistdancerDefenderIdol-101089"
  value: {
-  dps: 376329.33003
-  tps: 344199.07298
-  hps: 7045.2337
+  dps: 377506.81858
+  tps: 345241.69625
+  hps: 7168.81739
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MistdancerDefenderStone-101087"
  value: {
-  dps: 380651.76414
-  tps: 348521.50709
-  hps: 7045.2337
+  dps: 381883.19733
+  tps: 349618.075
+  hps: 7168.81739
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MistdancerIdolofRage-101113"
  value: {
-  dps: 380711.94999
-  tps: 348582.94633
-  hps: 6821.0924
+  dps: 381313.84601
+  tps: 349022.3912
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MistdancerStoneofRage-101117"
  value: {
-  dps: 381557.58032
-  tps: 349439.58153
-  hps: 6821.0924
+  dps: 382195.20207
+  tps: 349914.90922
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MistdancerStoneofWisdom-101107"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MithrilWristwatch-257884"
  value: {
-  dps: 381106.21361
-  tps: 348603.41363
-  hps: 6907.4355
+  dps: 381606.21123
+  tps: 348945.79644
+  hps: 6961.96042
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MountainsageIdolofDestruction-101069"
  value: {
-  dps: 382592.8407
-  tps: 349960.98438
-  hps: 6883.83448
+  dps: 382822.24868
+  tps: 350288.60685
+  hps: 6924.40617
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-MountainsageStoneofDestruction-101072"
  value: {
-  dps: 381486.23268
-  tps: 349399.37092
-  hps: 6821.0924
+  dps: 382022.03821
+  tps: 349765.1827
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-NitroBoosts-4223"
  value: {
-  dps: 426052.44665
-  tps: 385231.85846
-  hps: 7176.03462
+  dps: 423821.26267
+  tps: 383144.49959
+  hps: 7082.3754
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-OathswornDefenderIdol-101303"
  value: {
-  dps: 376331.2062
-  tps: 344200.94915
-  hps: 7045.2337
+  dps: 377506.81858
+  tps: 345241.69625
+  hps: 7168.81739
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-OathswornDefenderStone-101306"
  value: {
-  dps: 380674.68514
-  tps: 348544.42809
-  hps: 7045.2337
+  dps: 381914.14599
+  tps: 349649.02366
+  hps: 7168.81739
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-OathswornIdolofBattle-101295"
  value: {
-  dps: 389523.27312
-  tps: 355528.69569
-  hps: 6907.4355
+  dps: 390169.76714
+  tps: 355988.39561
+  hps: 6958.19969
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-OathswornStoneofBattle-101294"
  value: {
-  dps: 388222.25723
-  tps: 355238.48711
-  hps: 6821.0924
+  dps: 388740.52623
+  tps: 355581.65634
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-PhaseFingers-4697"
  value: {
-  dps: 424742.11999
-  tps: 384119.04545
-  hps: 7191.96087
+  dps: 423413.09945
+  tps: 382940.30306
+  hps: 7073.00129
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-PlateofCyclopeanDread"
  value: {
-  dps: 322001.70914
-  tps: 293011.18167
-  hps: 4452.21274
+  dps: 321960.03291
+  tps: 293047.7125
+  hps: 4404.35592
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-PlateoftheAll-ConsumingMaw"
  value: {
-  dps: 315860.85116
-  tps: 286903.51521
-  hps: 4430.62298
+  dps: 316261.29618
+  tps: 287405.48839
+  hps: 4411.93731
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-PlateoftheLostCatacomb"
  value: {
-  dps: 304519.42488
-  tps: 277003.29686
-  hps: 4155.50428
+  dps: 305269.09696
+  tps: 277857.65724
+  hps: 4128.31593
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-PouchofWhiteAsh-103639"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-PowerfulPrimalDiamond"
  value: {
-  dps: 404690.2577
-  tps: 364090.96122
-  hps: 7104.07841
+  dps: 405822.93833
+  tps: 365294.26845
+  hps: 7187.44123
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-PriceofProgress-81266"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-PridefulGladiator'sBadgeofConquest-103342"
  value: {
-  dps: 377674.70205
-  tps: 345516.35297
-  hps: 6821.0924
+  dps: 378185.13296
+  tps: 345869.65005
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-PridefulGladiator'sBadgeofDominance-103505"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-PridefulGladiator'sBadgeofVictory-103511"
  value: {
-  dps: 390830.91645
-  tps: 356257.2526
-  hps: 6821.0924
+  dps: 391346.02326
+  tps: 356592.59557
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-PridefulGladiator'sEmblemofCruelty-103407"
  value: {
-  dps: 383282.54306
-  tps: 350494.40112
-  hps: 7043.13965
+  dps: 384934.69148
+  tps: 351973.31964
+  hps: 7113.47869
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-PridefulGladiator'sEmblemofMeditation-103409"
  value: {
-  dps: 376731.55284
-  tps: 344690.41008
-  hps: 6881.05336
+  dps: 378303.60429
+  tps: 346070.34604
+  hps: 6974.21609
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-PridefulGladiator'sEmblemofTenacity-103408"
  value: {
-  dps: 375973.95951
-  tps: 343796.1272
-  hps: 7203.85589
+  dps: 376423.01725
+  tps: 344075.35084
+  hps: 7316.79455
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-PridefulGladiator'sInsigniaofConquest-103347"
  value: {
-  dps: 377767.10405
-  tps: 345589.7125
-  hps: 6821.0924
+  dps: 378318.55778
+  tps: 345988.16643
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-PridefulGladiator'sInsigniaofDominance-103506"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-PridefulGladiator'sInsigniaofVictory-103516"
  value: {
-  dps: 396512.82783
-  tps: 361085.44007
-  hps: 6821.0924
+  dps: 397185.76993
+  tps: 361494.03799
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Primordius'TalismanofRage-96873"
  value: {
-  dps: 395348.05098
-  tps: 361080.66215
-  hps: 6969.61431
+  dps: 395243.69024
+  tps: 360741.38477
+  hps: 7024.13924
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-PrismaticPrisonofPride-105474"
  value: {
-  dps: 394643.69981
-  tps: 361605.99999
-  hps: 7140.73751
+  dps: 394857.55581
+  tps: 362126.60799
+  hps: 7187.15983
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-PurifiedBindingsofImmerseus-105422"
  value: {
-  dps: 394643.69981
-  tps: 361605.99999
-  hps: 7140.73751
+  dps: 394857.55581
+  tps: 362126.60799
+  hps: 7187.15983
  }
 }
 dps_results: {
@@ -1625,729 +1625,729 @@ dps_results: {
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Qin-xi'sPolarizingSeal-87075"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-RelicofChi-Ji-79330"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-RelicofKypariZar-84075"
  value: {
-  dps: 381329.94556
-  tps: 348599.11533
-  hps: 6962.69228
+  dps: 382119.18996
+  tps: 349283.44653
+  hps: 6993.74979
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-RelicofNiuzao-79329"
  value: {
-  dps: 376331.2062
-  tps: 344200.94915
-  hps: 7031.69987
+  dps: 377506.81858
+  tps: 345241.69625
+  hps: 7155.04754
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-RelicofXuen-79327"
  value: {
-  dps: 390011.87365
-  tps: 355907.46501
-  hps: 6821.0924
+  dps: 390555.48222
+  tps: 356245.07388
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-RelicofXuen-79328"
  value: {
-  dps: 377582.37872
-  tps: 345435.67788
-  hps: 6821.0924
+  dps: 378177.70966
+  tps: 345868.10902
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-RelicofYu'lon-79331"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Renataki'sSoulCharm-96741"
  value: {
-  dps: 377539.15813
-  tps: 345369.37044
-  hps: 6821.0924
+  dps: 377561.69575
+  tps: 345187.68274
+  hps: 6886.54985
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-ResolveofNiuzao-103990"
  value: {
-  dps: 382571.12631
-  tps: 350484.26455
-  hps: 6821.0924
+  dps: 383093.10768
+  tps: 350836.25218
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-ReverberatingPrimalDiamond"
  value: {
-  dps: 413316.27022
-  tps: 372468.01191
-  hps: 7140.28046
+  dps: 414582.41931
+  tps: 373816.99703
+  hps: 7232.10216
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-RevitalizingPrimalDiamond"
  value: {
-  dps: 411936.73556
-  tps: 371282.95247
-  hps: 7140.28046
+  dps: 413198.24858
+  tps: 372626.86831
+  hps: 7232.10216
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-RuneofCinderglacier-3369"
  value: {
-  dps: 401966.36406
-  tps: 365443.89939
-  hps: 18.92445
+  dps: 400724.98016
+  tps: 364321.5403
+  hps: 18.97502
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-RuneofRazorice-3370"
  value: {
-  dps: 417513.93978
-  tps: 380991.47511
-  hps: 18.92445
+  dps: 416208.5059
+  tps: 379805.06604
+  hps: 18.97502
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-RuneofRe-Origination-96918"
  value: {
-  dps: 385728.61863
-  tps: 351661.99824
-  hps: 6941.30848
+  dps: 383122.22775
+  tps: 348846.04294
+  hps: 6928.59754
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-RuneofSpellbreaking-3595"
  value: {
-  dps: 395026.06591
-  tps: 358466.78417
-  hps: 19.08704
+  dps: 393962.77567
+  tps: 357473.65756
+  hps: 18.97502
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-RuneofSpellshattering-3367"
  value: {
-  dps: 395133.2414
-  tps: 358560.34668
-  hps: 19.08704
+  dps: 394045.0688
+  tps: 357514.67614
+  hps: 18.97502
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-RuneofSwordbreaking-3594"
  value: {
-  dps: 395655.5331
-  tps: 359133.06844
-  hps: 18.92445
+  dps: 394450.40772
+  tps: 358046.96785
+  hps: 18.97502
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-RuneofSwordshattering-3365"
  value: {
-  dps: 395655.5331
-  tps: 359133.06844
-  hps: 18.92445
+  dps: 394450.40772
+  tps: 358046.96785
+  hps: 18.97502
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-RuneoftheNerubianCarapace-3883"
  value: {
-  dps: 395274.36497
-  tps: 358733.13539
-  hps: 19.08704
+  dps: 394078.80758
+  tps: 357629.67563
+  hps: 18.97502
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-RuneoftheStoneskinGargoyle-3847"
  value: {
-  dps: 395268.47743
-  tps: 358714.24576
-  hps: 19.08704
+  dps: 394061.01366
+  tps: 357581.61085
+  hps: 18.97502
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SI:7Operative'sManual-92784"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-ScrollofReveredAncestors-89080"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SearingWords-81267"
  value: {
-  dps: 380383.72239
-  tps: 347933.46837
-  hps: 6895.89595
+  dps: 380935.94283
+  tps: 348332.9727
+  hps: 6950.42087
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Shock-ChargerMedallion-93259"
  value: {
-  dps: 380872.98028
-  tps: 348275.62937
-  hps: 6956.59374
+  dps: 381086.0014
+  tps: 348401.64797
+  hps: 6905.97329
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SigilofCompassion-83736"
  value: {
-  dps: 379222.41719
-  tps: 347135.55543
-  hps: 6821.0924
+  dps: 379746.42981
+  tps: 347489.57431
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SigilofDevotion-83740"
  value: {
-  dps: 381899.36179
-  tps: 349585.28682
-  hps: 6888.37448
+  dps: 382469.16274
+  tps: 350000.06554
+  hps: 6946.66014
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SigilofFidelity-83737"
  value: {
-  dps: 382268.49557
-  tps: 349564.22258
-  hps: 6993.7656
+  dps: 383012.21085
+  tps: 350130.42307
+  hps: 7014.39558
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SigilofGrace-83738"
  value: {
-  dps: 381245.05146
-  tps: 348551.31248
-  hps: 6931.37762
+  dps: 381705.75925
+  tps: 349157.12537
+  hps: 6857.15926
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SigilofKypariZar-84076"
  value: {
-  dps: 381950.56159
-  tps: 349607.77531
-  hps: 6892.13521
+  dps: 382544.49777
+  tps: 350058.85388
+  hps: 6946.66014
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SigilofPatience-83739"
  value: {
-  dps: 379728.30315
-  tps: 347641.44138
-  hps: 6821.0924
+  dps: 380229.03961
+  tps: 347972.1841
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SigilofRampage-105580"
  value: {
-  dps: 377838.88052
-  tps: 345635.29678
-  hps: 6821.0924
+  dps: 378413.02644
+  tps: 346036.07857
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SigiloftheCatacombs-83732"
  value: {
-  dps: 382911.60275
-  tps: 349942.65968
-  hps: 7014.85828
+  dps: 382009.08258
+  tps: 349186.75551
+  hps: 6952.08836
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SinisterPrimalDiamond"
  value: {
-  dps: 405699.95982
-  tps: 364953.71876
-  hps: 7070.48112
+  dps: 406973.53091
+  tps: 366320.61816
+  hps: 7155.9818
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Skeer'sBloodsoakedTalisman-105632"
  value: {
-  dps: 403622.42648
-  tps: 367774.59683
-  hps: 7082.83942
+  dps: 404494.13754
+  tps: 368434.10327
+  hps: 7196.47225
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SkullrenderMedallion-93256"
  value: {
-  dps: 389346.37258
-  tps: 355510.44545
-  hps: 6961.74382
+  dps: 390091.34616
+  tps: 356109.19946
+  hps: 6993.35467
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SoothingTalismanoftheShado-PanAssault-94509"
  value: {
-  dps: 376804.90635
-  tps: 344656.58221
-  hps: 6852.91006
+  dps: 377049.47784
+  tps: 344642.59226
+  hps: 6863.2902
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SoulBarrier-96927"
  value: {
-  dps: 376770.01051
-  tps: 344607.05216
-  hps: 7210.57829
+  dps: 378048.31933
+  tps: 345707.56982
+  hps: 7275.01594
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SparkofZandalar-96770"
  value: {
-  dps: 391331.12491
-  tps: 357787.00306
-  hps: 6911.1206
+  dps: 391617.56031
+  tps: 358279.68538
+  hps: 6984.07883
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SpiritsoftheSun-87163"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SpringrainIdolofDestruction-101023"
  value: {
-  dps: 382033.82452
-  tps: 349310.7956
-  hps: 6912.9483
+  dps: 382620.47104
+  tps: 349983.59309
+  hps: 7008.14913
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SpringrainIdolofRage-101009"
  value: {
-  dps: 380741.76698
-  tps: 348609.60711
-  hps: 6821.0924
+  dps: 381373.53223
+  tps: 349079.47817
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SpringrainStoneofDestruction-101026"
  value: {
-  dps: 381504.37099
-  tps: 349417.50922
-  hps: 6821.0924
+  dps: 382049.03296
+  tps: 349792.17745
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SpringrainStoneofRage-101012"
  value: {
-  dps: 381672.87027
-  tps: 349554.87148
-  hps: 6821.0924
+  dps: 382244.0533
+  tps: 349963.76046
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SpringrainStoneofWisdom-101041"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Static-Caster'sMedallion-93254"
  value: {
-  dps: 380872.98028
-  tps: 348275.62937
-  hps: 6956.59374
+  dps: 381086.0014
+  tps: 348401.64797
+  hps: 6905.97329
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SteadfastFootman'sMedallion-92782"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SteadfastTalismanoftheShado-PanAssault-94507"
  value: {
-  dps: 381959.34291
-  tps: 349872.48115
-  hps: 6821.0924
+  dps: 382481.69538
+  tps: 350224.83988
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-StreamtalkerIdolofDestruction-101222"
  value: {
-  dps: 383756.74227
-  tps: 351036.31737
-  hps: 6907.87557
+  dps: 383977.33715
+  tps: 351246.47455
+  hps: 6922.8799
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-StreamtalkerIdolofRage-101217"
  value: {
-  dps: 380741.25853
-  tps: 348612.92919
-  hps: 6821.0924
+  dps: 381274.56404
+  tps: 348985.57888
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-StreamtalkerStoneofDestruction-101225"
  value: {
-  dps: 381457.77586
-  tps: 349370.9141
-  hps: 6821.0924
+  dps: 382025.50169
+  tps: 349768.64619
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-StreamtalkerStoneofRage-101220"
  value: {
-  dps: 381588.65217
-  tps: 349470.65338
-  hps: 6821.0924
+  dps: 382162.93491
+  tps: 349882.64206
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-StreamtalkerStoneofWisdom-101250"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-StuffofNightmares-87160"
  value: {
-  dps: 381421.61751
-  tps: 349334.75574
-  hps: 6821.0924
+  dps: 381944.29614
+  tps: 349687.44064
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SunsoulDefenderIdol-101160"
  value: {
-  dps: 376331.2062
-  tps: 344200.94915
-  hps: 7045.2337
+  dps: 377506.81858
+  tps: 345241.69625
+  hps: 7168.81739
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SunsoulDefenderStone-101163"
  value: {
-  dps: 380677.18687
-  tps: 348546.92982
-  hps: 7045.2337
+  dps: 381858.11846
+  tps: 349592.99614
+  hps: 7168.81739
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SunsoulIdolofBattle-101152"
  value: {
-  dps: 389716.09467
-  tps: 355656.91728
-  hps: 6907.4355
+  dps: 390310.09845
+  tps: 356113.47869
+  hps: 6958.19969
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SunsoulStoneofBattle-101151"
  value: {
-  dps: 388284.73361
-  tps: 355300.96349
-  hps: 6821.0924
+  dps: 388799.07898
+  tps: 355640.20909
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SunsoulStoneofWisdom-101138"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SwordguardEmbroidery(Rank3)-4894"
  value: {
-  dps: 428164.59599
-  tps: 386917.59851
-  hps: 7179.66283
+  dps: 426612.41542
+  tps: 385547.19177
+  hps: 7059.13123
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SymboloftheCatacombs-83735"
  value: {
-  dps: 382115.94934
-  tps: 349629.65638
-  hps: 6872.99052
+  dps: 382598.01227
+  tps: 349944.6655
+  hps: 6942.2087
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-SynapseSprings(MarkII)-4898"
  value: {
-  dps: 427795.49372
-  tps: 386589.40444
-  hps: 7191.96087
+  dps: 426456.86834
+  tps: 385391.71887
+  hps: 7073.00129
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-TalismanofBloodlust-96864"
  value: {
-  dps: 380862.14891
-  tps: 347982.54204
-  hps: 6944.50177
+  dps: 385295.18146
+  tps: 352209.22369
+  hps: 6967.7584
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-TerrorintheMists-87167"
  value: {
-  dps: 385120.9581
-  tps: 351335.95586
-  hps: 7034.90706
+  dps: 385896.03157
+  tps: 352000.44981
+  hps: 7078.61288
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Thok'sAcid-GroovedTooth-105607"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Thok'sTailTip-105609"
  value: {
-  dps: 421742.5472
-  tps: 381567.49909
-  hps: 7140.73751
+  dps: 421902.89946
+  tps: 382043.31433
+  hps: 7187.15983
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Thousand-YearPickledEgg-257881"
  value: {
-  dps: 379999.0285
-  tps: 347354.14648
-  hps: 6898.68564
+  dps: 379879.73669
+  tps: 347020.17708
+  hps: 6880.80556
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-TickingEbonDetonator-105612"
  value: {
-  dps: 385365.12589
-  tps: 353159.66053
-  hps: 6828.61387
+  dps: 385924.1643
+  tps: 353547.32789
+  hps: 6867.74619
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Time-LostArtifact-103678"
  value: {
-  dps: 383709.47067
-  tps: 350582.88234
-  hps: 6901.0361
+  dps: 386653.80368
+  tps: 353392.11524
+  hps: 7007.27692
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-TrailseekerIdolofRage-101054"
  value: {
-  dps: 380835.25139
-  tps: 348702.78692
-  hps: 6821.0924
+  dps: 381375.48699
+  tps: 349084.03218
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-TrailseekerStoneofRage-101057"
  value: {
-  dps: 381590.41729
-  tps: 349472.4185
-  hps: 6821.0924
+  dps: 382186.60582
+  tps: 349906.31297
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-TyrannicalGladiator'sBadgeofConquest-100043"
  value: {
-  dps: 377480.41977
-  tps: 345346.37444
-  hps: 6821.0924
+  dps: 377958.68097
+  tps: 345665.2344
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-TyrannicalGladiator'sBadgeofDominance-100016"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-TyrannicalGladiator'sBadgeofVictory-100019"
  value: {
-  dps: 385455.61127
-  tps: 351865.18669
-  hps: 6821.0924
+  dps: 385974.71575
+  tps: 352208.39026
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-TyrannicalGladiator'sEmblemofCruelty-100066"
  value: {
-  dps: 380665.14301
-  tps: 348159.91018
-  hps: 6975.43651
+  dps: 382176.76312
+  tps: 349514.84293
+  hps: 7061.07778
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-TyrannicalGladiator'sEmblemofMeditation-99990"
  value: {
-  dps: 376731.55284
-  tps: 344690.41008
-  hps: 6881.05336
+  dps: 378303.60429
+  tps: 346070.34604
+  hps: 6974.21609
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-TyrannicalGladiator'sEmblemofTenacity-100092"
  value: {
-  dps: 376448.51833
-  tps: 344315.59447
-  hps: 7071.05561
+  dps: 376934.74042
+  tps: 344675.24879
+  hps: 7195.09484
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-TyrannicalGladiator'sInsigniaofConquest-100026"
  value: {
-  dps: 377560.46248
-  tps: 345416.46999
-  hps: 6821.0924
+  dps: 378217.38715
+  tps: 345911.76074
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-TyrannicalGladiator'sInsigniaofDominance-100152"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-TyrannicalGladiator'sInsigniaofVictory-100085"
  value: {
-  dps: 388713.87072
-  tps: 354643.12405
-  hps: 6821.0924
+  dps: 389369.71553
+  tps: 355073.79778
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-TyrannicalPrimalDiamond"
  value: {
-  dps: 404631.04518
-  tps: 364041.23633
-  hps: 7041.16898
+  dps: 405817.34287
+  tps: 365315.10483
+  hps: 7128.24167
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-UnerringVisionofLeiShen-96930"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-VaporshieldMedallion-93262"
  value: {
-  dps: 381155.63862
-  tps: 349068.77685
-  hps: 6821.0924
+  dps: 381658.47173
+  tps: 349401.61623
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-VialofDragon'sBlood-87063"
  value: {
-  dps: 381157.58467
-  tps: 349070.72291
-  hps: 6821.0924
+  dps: 381680.42347
+  tps: 349423.56796
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-VialofIchorousBlood-100963"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-VialofLivingCorruption-105568"
  value: {
-  dps: 376404.85549
-  tps: 344233.51731
-  hps: 7342.04652
+  dps: 376785.16819
+  tps: 344456.28105
+  hps: 7424.14794
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-ViciousTalismanoftheShado-PanAssault-94511"
  value: {
-  dps: 377785.72131
-  tps: 345591.64497
-  hps: 6821.0924
+  dps: 378279.19926
+  tps: 345920.3652
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-VisionofthePredator-81192"
  value: {
-  dps: 381290.33401
-  tps: 348331.07959
-  hps: 6930.71006
+  dps: 381661.83652
+  tps: 348544.77363
+  hps: 6969.09023
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-VolatileTalismanoftheShado-PanAssault-94510"
  value: {
-  dps: 380683.41656
-  tps: 347835.09375
-  hps: 6935.54462
+  dps: 379616.36754
+  tps: 346836.83818
+  hps: 6942.09857
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-WindsweptPages-81125"
  value: {
-  dps: 381275.06209
-  tps: 348251.15156
-  hps: 6903.7033
+  dps: 381920.45003
+  tps: 349033.27069
+  hps: 6954.83963
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-WoundripperMedallion-93253"
  value: {
-  dps: 381879.84978
-  tps: 349053.34158
-  hps: 6961.74382
+  dps: 382638.9508
+  tps: 349668.82639
+  hps: 6993.35467
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Wushoolay'sFinalChoice-96785"
  value: {
-  dps: 377235.73111
-  tps: 345148.86935
-  hps: 6821.0924
+  dps: 377760.94881
+  tps: 345504.0933
+  hps: 6882.78912
  }
 }
 dps_results: {
@@ -2361,272 +2361,272 @@ dps_results: {
 dps_results: {
  key: "TestFrostTwoHand-AllItems-Yu'lon'sBite-103987"
  value: {
-  dps: 386205.23033
-  tps: 352228.46216
-  hps: 7060.27502
+  dps: 386519.30753
+  tps: 352322.76825
+  hps: 7130.9975
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-AllItems-ZenAlchemistStone-75274"
  value: {
-  dps: 389386.9927
-  tps: 355600.26562
-  hps: 6821.0924
+  dps: 389826.81385
+  tps: 355862.46081
+  hps: 6882.78912
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Average-Default"
  value: {
-  dps: 428826.34909
-  tps: 387193.55875
-  hps: 6858.33259
+  dps: 429101.60059
+  tps: 387336.97493
+  hps: 6869.14802
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-DefaultTalents-Basic-obliterate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.55888998392e+06
-  tps: 1.51868836191e+06
-  hps: 13033.91445
+  dps: 1.56283581044e+06
+  tps: 1.52243555594e+06
+  hps: 13132.79446
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-DefaultTalents-Basic-obliterate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 425873.78903
-  tps: 385063.82114
-  hps: 7105.05317
+  dps: 424769.00378
+  tps: 384250.2405
+  hps: 7153.29004
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-DefaultTalents-Basic-obliterate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 620626.21935
-  tps: 461535.89675
-  hps: 8248.83983
+  dps: 615892.42277
+  tps: 458124.93151
+  hps: 8313.41357
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-DefaultTalents-Basic-obliterate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.10365481238e+06
-  tps: 1.07934480521e+06
-  hps: 11356.5557
+  dps: 1.10691718793e+06
+  tps: 1.08271441542e+06
+  hps: 11330.90264
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-DefaultTalents-Basic-obliterate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 331309.95263
-  tps: 306614.90762
-  hps: 6109.77253
+  dps: 331370.4885
+  tps: 306846.69046
+  hps: 6068.92259
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-DefaultTalents-Basic-obliterate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 410231.95311
-  tps: 322583.70757
-  hps: 6660.47885
+  dps: 409071.36212
+  tps: 322279.01205
+  hps: 6603.49056
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RoilingBlood-Basic-obliterate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.52946978176e+06
-  tps: 1.48920861793e+06
-  hps: 12860.12244
+  dps: 1.53493209642e+06
+  tps: 1.49452064488e+06
+  hps: 12905.71091
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RoilingBlood-Basic-obliterate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 432617.79704
-  tps: 391820.57311
-  hps: 7282.50942
+  dps: 432136.05907
+  tps: 391522.88129
+  hps: 7326.64695
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RoilingBlood-Basic-obliterate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 630507.66945
-  tps: 471698.98593
-  hps: 8447.03496
+  dps: 623883.97344
+  tps: 466139.89652
+  hps: 8327.13799
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RoilingBlood-Basic-obliterate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.08236304471e+06
-  tps: 1.05812998009e+06
-  hps: 11233.6254
+  dps: 1.08782086889e+06
+  tps: 1.06368144731e+06
+  hps: 11315.63911
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RoilingBlood-Basic-obliterate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 344295.07642
-  tps: 319244.78161
-  hps: 6239.98745
+  dps: 344894.51036
+  tps: 319880.83737
+  hps: 6190.59759
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RoilingBlood-Basic-obliterate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 419829.33755
-  tps: 331744.62205
-  hps: 6761.90245
+  dps: 418844.7499
+  tps: 331293.05041
+  hps: 6780.89855
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RunicCorruption-Basic-obliterate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.50799528929e+06
-  tps: 1.46758604497e+06
-  hps: 12445.82511
+  dps: 1.50357110101e+06
+  tps: 1.4630844421e+06
+  hps: 12396.17324
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RunicCorruption-Basic-obliterate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 421876.39176
-  tps: 381260.87419
-  hps: 7146.38527
+  dps: 421190.94537
+  tps: 380914.85516
+  hps: 7099.93797
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RunicCorruption-Basic-obliterate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 618948.38899
-  tps: 460475.7455
-  hps: 8390.62397
+  dps: 613621.88637
+  tps: 456448.82799
+  hps: 8299.08383
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RunicCorruption-Basic-obliterate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.08632970977e+06
-  tps: 1.06168402701e+06
-  hps: 10891.14854
+  dps: 1.07122158766e+06
+  tps: 1.04684802822e+06
+  hps: 10767.93774
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RunicCorruption-Basic-obliterate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 328355.62067
-  tps: 303545.5919
-  hps: 6046.12727
+  dps: 328896.20736
+  tps: 304328.91813
+  hps: 6019.84656
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RunicCorruption-Basic-obliterate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 409660.30464
-  tps: 322035.41826
-  hps: 6717.46714
+  dps: 406436.93365
+  tps: 320321.76095
+  hps: 6508.51006
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RunicEmpowerment-Basic-obliterate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.57221054579e+06
-  tps: 1.53127408628e+06
-  hps: 13117.19536
+  dps: 1.56877193428e+06
+  tps: 1.52767378678e+06
+  hps: 13144.2223
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RunicEmpowerment-Basic-obliterate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 421386.99189
-  tps: 380491.32337
-  hps: 7061.71394
+  dps: 420484.14275
+  tps: 380014.43926
+  hps: 7034.65104
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RunicEmpowerment-Basic-obliterate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 617315.50662
-  tps: 457866.92905
-  hps: 8384.15431
+  dps: 613322.98306
+  tps: 455539.86662
+  hps: 8346.24432
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RunicEmpowerment-Basic-obliterate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.11242550923e+06
-  tps: 1.08796378801e+06
-  hps: 11510.19358
+  dps: 1.11705886236e+06
+  tps: 1.09280267608e+06
+  hps: 11586.24462
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RunicEmpowerment-Basic-obliterate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 327733.35493
-  tps: 303058.13229
-  hps: 6051.49562
+  dps: 328932.10549
+  tps: 304368.24917
+  hps: 6002.10576
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-RunicEmpowerment-Basic-obliterate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 410235.20041
-  tps: 322831.16535
-  hps: 6695.3328
+  dps: 410412.23601
+  tps: 323640.97249
+  hps: 6619.34841
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-UnholyBlight-Basic-obliterate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.53812166628e+06
-  tps: 1.49791274586e+06
-  hps: 12887.52395
+  dps: 1.53940779292e+06
+  tps: 1.4991363765e+06
+  hps: 12894.64627
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-UnholyBlight-Basic-obliterate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 433570.88707
-  tps: 392830.39337
-  hps: 7244.50295
+  dps: 433030.9879
+  tps: 392570.89469
+  hps: 7296.83917
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-UnholyBlight-Basic-obliterate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 631098.01269
-  tps: 472316.00106
-  hps: 8447.03496
+  dps: 624972.7918
+  tps: 467296.59144
+  hps: 8327.13799
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-UnholyBlight-Basic-obliterate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.09090759807e+06
-  tps: 1.06661779265e+06
-  hps: 11205.14792
+  dps: 1.09851530963e+06
+  tps: 1.0742415339e+06
+  hps: 11394.8284
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-UnholyBlight-Basic-obliterate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 342836.58346
-  tps: 317756.26105
-  hps: 6199.76515
+  dps: 343733.70498
+  tps: 318655.36368
+  hps: 6195.96593
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-Settings-Troll-p5.2h-obliterate-UnholyBlight-Basic-obliterate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 421015.71326
-  tps: 332866.69211
-  hps: 6692.19455
+  dps: 420099.1875
+  tps: 332433.83246
+  hps: 6654.20236
  }
 }
 dps_results: {
  key: "TestFrostTwoHand-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 390362.5633
-  tps: 352616.06805
-  hps: 6540.24108
+  dps: 389079.50312
+  tps: 351270.34226
+  hps: 6581.87065
  }
 }

--- a/sim/death_knight/runeforging.go
+++ b/sim/death_knight/runeforging.go
@@ -241,7 +241,7 @@ func init() {
 			switch {
 			case itemSlot == proto.ItemSlot_ItemSlotMainHand:
 				weapon = character.GetMHWeapon()
-				procMask |= core.ProcMaskMeleeMH | core.ProcMaskMeleeProc
+				procMask |= core.ProcMaskMeleeMH
 			case itemSlot == proto.ItemSlot_ItemSlotOffHand:
 				procMask |= core.ProcMaskMeleeOH
 				weapon = character.GetOHWeapon()

--- a/sim/death_knight/unholy/TestUnholy.results
+++ b/sim/death_knight/unholy/TestUnholy.results
@@ -33,17 +33,17 @@ character_stats_results: {
 dps_results: {
  key: "TestUnholy-AllItems-AgilePrimalDiamond"
  value: {
-  dps: 420721.98488
-  tps: 296890.81503
-  hps: 3971.94913
+  dps: 420636.23474
+  tps: 298044.69561
+  hps: 3969.74521
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-AlacrityofXuen-103989"
  value: {
-  dps: 398479.35974
-  tps: 288955.95005
-  hps: 4011.93765
+  dps: 398168.09399
+  tps: 287658.51873
+  hps: 4004.846
  }
 }
 dps_results: {
@@ -65,57 +65,57 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-AssuranceofConsequence-105472"
  value: {
-  dps: 372124.73157
-  tps: 273695.49704
+  dps: 372237.33218
+  tps: 273800.52628
   hps: 3857.43348
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-AusterePrimalDiamond"
  value: {
-  dps: 416186.93459
-  tps: 292594.1645
-  hps: 3943.13401
+  dps: 415118.9439
+  tps: 292263.42167
+  hps: 3941.24894
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BadJuju-96781"
  value: {
-  dps: 379598.77287
-  tps: 279488.32991
-  hps: 3849.91202
+  dps: 379184.72361
+  tps: 279215.85306
+  hps: 3849.77831
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BadgeofKypariZar-84079"
  value: {
-  dps: 379283.4031
-  tps: 278850.36823
-  hps: 3902.73434
+  dps: 378855.33489
+  tps: 278543.44339
+  hps: 3908.06709
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BattlegearoftheLostCatacomb"
  value: {
-  dps: 310202.06581
-  tps: 219434.88953
-  hps: 2991.41514
+  dps: 309895.05773
+  tps: 220271.37256
+  hps: 2986.53868
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BattleplateofCyclopeanDread"
  value: {
-  dps: 331058.43211
-  tps: 232456.58966
-  hps: 3307.26116
+  dps: 332555.37898
+  tps: 234271.01892
+  hps: 3288.02243
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BattleplateoftheAll-ConsumingMaw"
  value: {
-  dps: 330770.5735
-  tps: 229314.03152
-  hps: 3160.52435
+  dps: 331619.2084
+  tps: 230465.90065
+  hps: 3170.84264
  }
 }
 dps_results: {
@@ -137,17 +137,17 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BottleofInfiniteStars-87057"
  value: {
-  dps: 376757.28042
-  tps: 277277.44149
+  dps: 377258.17469
+  tps: 277720.13299
   hps: 3857.43348
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BraidofTenSongs-84072"
  value: {
-  dps: 377103.17542
-  tps: 276201.50072
-  hps: 3927.78522
+  dps: 378360.60585
+  tps: 277388.51841
+  hps: 3933.92773
  }
 }
 dps_results: {
@@ -177,33 +177,33 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-BrutalTalismanoftheShado-PanAssault-94508"
  value: {
-  dps: 386660.43837
-  tps: 284839.80681
-  hps: 3834.88491
+  dps: 386555.42392
+  tps: 285421.19728
+  hps: 3844.31701
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BurningPrimalDiamond"
  value: {
-  dps: 420637.47715
-  tps: 296820.73537
-  hps: 3971.94913
+  dps: 420580.01996
+  tps: 298000.23229
+  hps: 3969.74521
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CapacitivePrimalDiamond"
  value: {
-  dps: 431341.65091
-  tps: 307622.12531
-  hps: 3943.15244
+  dps: 430884.70514
+  tps: 307386.96746
+  hps: 3958.44813
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CarbonicCarbuncle-81138"
  value: {
-  dps: 386448.28019
-  tps: 283492.38119
-  hps: 3891.62411
+  dps: 386510.6696
+  tps: 283216.55835
+  hps: 3903.26969
  }
 }
 dps_results: {
@@ -217,9 +217,9 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-CharmofTenSongs-84071"
  value: {
-  dps: 378547.24189
-  tps: 277844.32309
-  hps: 3993.65712
+  dps: 378659.72543
+  tps: 277971.2314
+  hps: 3994.63006
  }
 }
 dps_results: {
@@ -233,9 +233,9 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-CommunalStoneofDestruction-101171"
  value: {
-  dps: 380663.95701
-  tps: 280325.47506
-  hps: 3872.30644
+  dps: 380262.6285
+  tps: 279838.66959
+  hps: 3852.71851
  }
 }
 dps_results: {
@@ -273,9 +273,9 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-CourageousPrimalDiamond"
  value: {
-  dps: 416286.98737
-  tps: 292503.41475
-  hps: 3917.12815
+  dps: 416199.55711
+  tps: 293654.11479
+  hps: 3915.41232
  }
 }
 dps_results: {
@@ -329,8 +329,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-CraftedDreadfulGladiator'sInsigniaofConquest-93424"
  value: {
-  dps: 371370.78684
-  tps: 272947.71141
+  dps: 371521.07315
+  tps: 273118.14749
   hps: 3857.43348
  }
 }
@@ -345,9 +345,9 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-CraftedDreadfulGladiator'sInsigniaofVictory-93611"
  value: {
-  dps: 376987.30603
-  tps: 280065.79315
-  hps: 3851.96355
+  dps: 377644.47519
+  tps: 280499.06216
+  hps: 3840.35389
  }
 }
 dps_results: {
@@ -401,8 +401,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-CraftedMalevolentGladiator'sInsigniaofConquest-98760"
  value: {
-  dps: 371360.2432
-  tps: 272896.77065
+  dps: 371556.37268
+  tps: 273151.21599
   hps: 3857.43348
  }
 }
@@ -417,9 +417,9 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-CraftedMalevolentGladiator'sInsigniaofVictory-98917"
  value: {
-  dps: 379095.20027
-  tps: 281342.74807
-  hps: 3844.23443
+  dps: 378355.47718
+  tps: 280709.14206
+  hps: 3856.03084
  }
 }
 dps_results: {
@@ -449,17 +449,17 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DarkglowEmbroidery(Rank3)-4893"
  value: {
-  dps: 430292.41436
-  tps: 306861.09876
-  hps: 3934.95374
+  dps: 429738.44316
+  tps: 306585.61392
+  hps: 3950.24943
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmistVortex-87172"
  value: {
-  dps: 392077.37579
-  tps: 284991.72846
-  hps: 3983.24961
+  dps: 392970.29456
+  tps: 284800.71272
+  hps: 3975.68549
  }
 }
 dps_results: {
@@ -481,17 +481,17 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DestructivePrimalDiamond"
  value: {
-  dps: 418658.5327
-  tps: 294186.29273
-  hps: 3939.19691
+  dps: 418464.98222
+  tps: 295298.87769
+  hps: 3937.48108
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DisciplineofXuen-103986"
  value: {
-  dps: 393607.87907
-  tps: 288936.50312
-  hps: 3860.87217
+  dps: 393116.53948
+  tps: 288594.13217
+  hps: 3841.35602
  }
 }
 dps_results: {
@@ -585,25 +585,25 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DreadfulGladiator'sInsigniaofConquest-84349"
  value: {
-  dps: 371338.12281
-  tps: 272930.51832
+  dps: 371506.62004
+  tps: 273099.61084
   hps: 3857.43348
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DreadfulGladiator'sInsigniaofDominance-84489"
  value: {
-  dps: 370751.14887
-  tps: 272478.73749
+  dps: 370750.8226
+  tps: 272478.41122
   hps: 3857.43348
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DreadfulGladiator'sInsigniaofVictory-84495"
  value: {
-  dps: 376770.89593
-  tps: 279782.35108
-  hps: 3847.13418
+  dps: 378044.63866
+  tps: 280438.70364
+  hps: 3846.08058
  }
 }
 dps_results: {
@@ -625,33 +625,33 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-EffulgentPrimalDiamond"
  value: {
-  dps: 416186.93459
-  tps: 292594.1645
-  hps: 3943.13401
+  dps: 415118.9439
+  tps: 292263.42167
+  hps: 3941.24894
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EmberPrimalDiamond"
  value: {
-  dps: 416286.98737
-  tps: 292503.41475
-  hps: 3917.12815
+  dps: 416199.55711
+  tps: 293654.11479
+  hps: 3915.41232
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EmblemofKypariZar-84077"
  value: {
-  dps: 377064.24776
-  tps: 276599.1777
-  hps: 3973.13028
+  dps: 379466.60314
+  tps: 279131.01138
+  hps: 3989.07248
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EmblemoftheCatacombs-83733"
  value: {
-  dps: 378787.53568
-  tps: 278435.40435
-  hps: 3900.8129
+  dps: 378732.33346
+  tps: 278485.18333
+  hps: 3902.38492
  }
 }
 dps_results: {
@@ -665,73 +665,73 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-EnchantWeapon-BloodyDancingSteel-5125"
  value: {
-  dps: 400363.05783
-  tps: 286313.25112
+  dps: 400874.91825
+  tps: 286702.29493
   hps: 20.83558
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnchantWeapon-Colossus-4445"
  value: {
-  dps: 392520.01166
-  tps: 281038.69851
+  dps: 392975.17007
+  tps: 281760.66111
   hps: 20.83558
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnchantWeapon-DancingSteel-4444"
  value: {
-  dps: 399679.68677
-  tps: 285455.04254
+  dps: 400606.9007
+  tps: 286645.55127
   hps: 20.83558
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnchantWeapon-ElementalForce-4443"
  value: {
-  dps: 391584.20248
-  tps: 279491.4337
+  dps: 392450.06793
+  tps: 280841.16548
   hps: 20.83558
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnchantWeapon-JadeSpirit-4442"
  value: {
-  dps: 393499.78379
-  tps: 281823.15225
+  dps: 393625.33281
+  tps: 281901.30152
   hps: 20.83558
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnchantWeapon-River'sSong-4446"
  value: {
-  dps: 393499.78379
-  tps: 281823.15225
+  dps: 393625.33281
+  tps: 281901.30152
   hps: 20.83558
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnchantWeapon-SpiritofConquest-5124"
  value: {
-  dps: 393499.78379
-  tps: 281823.15225
+  dps: 393617.16419
+  tps: 281895.85396
   hps: 20.83558
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnchantWeapon-Windsong-4441"
  value: {
-  dps: 396110.65
-  tps: 282490.55677
+  dps: 397593.0761
+  tps: 284216.21191
   hps: 21.27214
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticPrimalDiamond"
  value: {
-  dps: 418658.5327
-  tps: 294186.29273
-  hps: 3939.19691
+  dps: 418464.98222
+  tps: 295298.87769
+  hps: 3937.48108
  }
 }
 dps_results: {
@@ -745,33 +745,33 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-EternalPrimalDiamond"
  value: {
-  dps: 416286.98737
-  tps: 292503.41475
-  hps: 3917.12815
+  dps: 416199.55711
+  tps: 293654.11479
+  hps: 3915.41232
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EvilEyeofGalakras-105491"
  value: {
-  dps: 425013.37766
-  tps: 304571.40473
-  hps: 3953.13734
+  dps: 423427.49922
+  tps: 303598.45657
+  hps: 3938.81949
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FabledFeatherofJi-Kun-96842"
  value: {
-  dps: 398572.55213
-  tps: 295359.59137
-  hps: 3839.60143
+  dps: 395283.81395
+  tps: 291806.98496
+  hps: 3831.97183
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FearwurmBadge-84074"
  value: {
-  dps: 377212.31538
-  tps: 277309.31476
-  hps: 3987.50556
+  dps: 379415.12623
+  tps: 279440.21453
+  hps: 3991.97419
  }
 }
 dps_results: {
@@ -793,17 +793,17 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-FelsoulStoneofDestruction-101266"
  value: {
-  dps: 381244.97736
-  tps: 280676.6556
-  hps: 3856.77282
+  dps: 380608.32099
+  tps: 280556.15812
+  hps: 3848.91274
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Fen-Yu,FuryofXuen-102248"
  value: {
-  dps: 407516.36015
-  tps: 289949.87594
-  hps: 3841.10723
+  dps: 407012.63011
+  tps: 290625.15159
+  hps: 3858.67617
  }
 }
 dps_results: {
@@ -825,17 +825,17 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-FleetPrimalDiamond"
  value: {
-  dps: 418730.06524
-  tps: 294342.71592
-  hps: 3917.12815
+  dps: 418638.68231
+  tps: 295502.75146
+  hps: 3915.41232
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornPrimalDiamond"
  value: {
-  dps: 416286.98737
-  tps: 292503.41475
-  hps: 3917.12815
+  dps: 416199.55711
+  tps: 293654.11479
+  hps: 3915.41232
  }
 }
 dps_results: {
@@ -857,17 +857,17 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Fusion-FireCore-105459"
  value: {
-  dps: 399117.61603
-  tps: 292705.58513
-  hps: 3852.13686
+  dps: 399516.43299
+  tps: 293700.42276
+  hps: 3876.25826
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GazeoftheTwins-96915"
  value: {
-  dps: 395745.99625
-  tps: 289834.88092
-  hps: 3911.5589
+  dps: 395533.75842
+  tps: 289767.24902
+  hps: 3938.21611
  }
 }
 dps_results: {
@@ -929,8 +929,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-GrievousGladiator'sInsigniaofConquest-103150"
  value: {
-  dps: 371429.72804
-  tps: 273191.89669
+  dps: 371570.19021
+  tps: 273360.30816
   hps: 3857.43348
  }
 }
@@ -945,17 +945,17 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-GrievousGladiator'sInsigniaofVictory-103319"
  value: {
-  dps: 386210.44736
-  tps: 286199.64732
-  hps: 3834.20673
+  dps: 385765.63989
+  tps: 285932.42984
+  hps: 3830.10981
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Haromm'sTalisman-105527"
  value: {
-  dps: 383644.49093
-  tps: 285424.00038
-  hps: 3842.23213
+  dps: 384451.4693
+  tps: 286094.3189
+  hps: 3849.77831
  }
 }
 dps_results: {
@@ -977,25 +977,25 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Heart-LesionDefenderStone-101002"
  value: {
-  dps: 381284.52927
-  tps: 281079.53082
-  hps: 3959.50627
+  dps: 381059.90875
+  tps: 281402.09941
+  hps: 3977.03256
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Heart-LesionIdolofBattle-100991"
  value: {
-  dps: 380311.31342
-  tps: 282233.40552
-  hps: 3902.63639
+  dps: 382570.94382
+  tps: 284589.0945
+  hps: 3931.26914
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Heart-LesionStoneofBattle-100990"
  value: {
-  dps: 389266.82252
-  tps: 286202.35225
-  hps: 3841.05266
+  dps: 389121.80574
+  tps: 286165.98706
+  hps: 3852.82554
  }
 }
 dps_results: {
@@ -1033,17 +1033,17 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ImpassivePrimalDiamond"
  value: {
-  dps: 418658.5327
-  tps: 294186.29273
-  hps: 3939.19691
+  dps: 418464.98222
+  tps: 295298.87769
+  hps: 3937.48108
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IndomitablePrimalDiamond"
  value: {
-  dps: 416186.93459
-  tps: 292594.1645
-  hps: 3943.13401
+  dps: 415118.9439
+  tps: 292263.42167
+  hps: 3941.24894
  }
 }
 dps_results: {
@@ -1057,8 +1057,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-InsigniaofKypariZar-84078"
  value: {
-  dps: 370735.65659
-  tps: 272478.73749
+  dps: 370751.29375
+  tps: 272478.88237
   hps: 3857.43348
  }
 }
@@ -1073,7 +1073,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-IronProtectorTalisman-85181"
  value: {
-  dps: 371459.67399
+  dps: 371444.18171
   tps: 273386.3467
   hps: 3942.01208
  }
@@ -1137,8 +1137,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Kardris'ToxicTotem-105540"
  value: {
-  dps: 383099.57941
-  tps: 284842.66032
+  dps: 384092.32456
+  tps: 285819.91318
   hps: 3857.43348
  }
 }
@@ -1177,9 +1177,9 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-LeiShen'sFinalOrders-87072"
  value: {
-  dps: 383801.33551
-  tps: 283346.39194
-  hps: 4023.48719
+  dps: 385199.90329
+  tps: 284951.41679
+  hps: 4043.36426
  }
 }
 dps_results: {
@@ -1193,17 +1193,17 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-LightdrinkerIdolofRage-101200"
  value: {
-  dps: 375802.81835
-  tps: 276518.13996
+  dps: 376298.95791
+  tps: 276960.9098
   hps: 3857.43348
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LightdrinkerStoneofRage-101203"
  value: {
-  dps: 381959.96351
-  tps: 281301.70103
-  hps: 3844.03542
+  dps: 381131.31224
+  tps: 280752.33596
+  hps: 3856.77282
  }
 }
 dps_results: {
@@ -1217,16 +1217,16 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-LightweaveEmbroidery(Rank3)-4892"
  value: {
-  dps: 430292.41436
-  tps: 306861.09876
-  hps: 3934.95374
+  dps: 429738.74511
+  tps: 306585.91587
+  hps: 3950.24943
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LordBlastington'sScopeofDoom-4699"
  value: {
-  dps: 393499.78379
-  tps: 281823.15225
+  dps: 393617.16419
+  tps: 281895.85396
   hps: 20.83558
  }
 }
@@ -1281,8 +1281,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-MalevolentGladiator'sInsigniaofConquest-91457"
  value: {
-  dps: 371042.93499
-  tps: 272686.70657
+  dps: 371570.63869
+  tps: 273158.02672
   hps: 3857.43348
  }
 }
@@ -1297,9 +1297,9 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-MalevolentGladiator'sInsigniaofVictory-91768"
  value: {
-  dps: 378467.69153
-  tps: 280801.65083
-  hps: 3844.1144
+  dps: 379094.2176
+  tps: 281305.5596
+  hps: 3858.34163
  }
 }
 dps_results: {
@@ -1329,7 +1329,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-MedallionoftheCatacombs-83734"
  value: {
-  dps: 373636.52901
+  dps: 373620.86589
   tps: 274793.99669
   hps: 3857.43348
  }
@@ -1345,8 +1345,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-MirrorScope-4700"
  value: {
-  dps: 393499.78379
-  tps: 281823.15225
+  dps: 393617.16419
+  tps: 281895.85396
   hps: 20.83558
  }
 }
@@ -1361,25 +1361,25 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-MistdancerDefenderStone-101087"
  value: {
-  dps: 381603.312
-  tps: 281244.82099
-  hps: 3965.84618
+  dps: 381068.55233
+  tps: 281279.96914
+  hps: 3965.00524
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MistdancerIdolofRage-101113"
  value: {
-  dps: 375704.21361
-  tps: 276429.81573
+  dps: 376062.46415
+  tps: 276650.96948
   hps: 3857.43348
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MistdancerStoneofRage-101117"
  value: {
-  dps: 380923.26618
-  tps: 280390.68117
-  hps: 3842.32862
+  dps: 380847.5531
+  tps: 280748.95759
+  hps: 3853.64607
  }
 }
 dps_results: {
@@ -1409,9 +1409,9 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-MountainsageStoneofDestruction-101072"
  value: {
-  dps: 380869.09012
-  tps: 280170.62509
-  hps: 3853.30764
+  dps: 380381.54288
+  tps: 279747.39652
+  hps: 3856.77282
  }
 }
 dps_results: {
@@ -1425,57 +1425,57 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-OathswornDefenderStone-101306"
  value: {
-  dps: 380707.21279
-  tps: 280685.14679
-  hps: 3965.00524
+  dps: 381610.65256
+  tps: 281553.4867
+  hps: 3968.79518
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-OathswornIdolofBattle-101295"
  value: {
-  dps: 380863.97418
-  tps: 282406.95227
-  hps: 3919.4185
+  dps: 381797.47983
+  tps: 283313.08822
+  hps: 3895.44026
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-OathswornStoneofBattle-101294"
  value: {
-  dps: 390540.57024
-  tps: 287600.38928
-  hps: 3847.49279
+  dps: 389915.59739
+  tps: 287024.61881
+  hps: 3841.39128
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PhaseFingers-4697"
  value: {
-  dps: 429805.01363
-  tps: 306575.53645
-  hps: 3943.15244
+  dps: 429349.69223
+  tps: 306344.87874
+  hps: 3958.44813
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PlateofCyclopeanDread"
  value: {
-  dps: 311207.80878
-  tps: 220890.20191
-  hps: 2934.05738
+  dps: 312756.00229
+  tps: 223113.83932
+  hps: 2929.3295
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PlateoftheAll-ConsumingMaw"
  value: {
-  dps: 303818.43449
-  tps: 216191.58216
-  hps: 2947.67617
+  dps: 302209.1895
+  tps: 215277.97088
+  hps: 2946.20008
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PlateoftheLostCatacomb"
  value: {
-  dps: 286094.98761
-  tps: 203994.31748
-  hps: 2763.03741
+  dps: 283612.48691
+  tps: 202837.1964
+  hps: 2771.03164
  }
 }
 dps_results: {
@@ -1489,9 +1489,9 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulPrimalDiamond"
  value: {
-  dps: 416186.93459
-  tps: 292594.1645
-  hps: 3943.13401
+  dps: 415118.9439
+  tps: 292263.42167
+  hps: 3941.24894
  }
 }
 dps_results: {
@@ -1553,8 +1553,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-PridefulGladiator'sInsigniaofConquest-103347"
  value: {
-  dps: 372038.60242
-  tps: 273552.4451
+  dps: 372106.84972
+  tps: 273615.31598
   hps: 3857.43348
  }
 }
@@ -1569,17 +1569,17 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-PridefulGladiator'sInsigniaofVictory-103516"
  value: {
-  dps: 391776.77176
-  tps: 289809.7943
-  hps: 3863.68349
+  dps: 393886.62302
+  tps: 291971.38282
+  hps: 3852.10711
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Primordius'TalismanofRage-96873"
  value: {
-  dps: 395710.34486
-  tps: 291270.84322
-  hps: 3955.93604
+  dps: 394556.05125
+  tps: 289988.54376
+  hps: 3936.2266
  }
 }
 dps_results: {
@@ -1649,17 +1649,17 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-RelicofXuen-79327"
  value: {
-  dps: 382979.24266
-  tps: 284462.39672
-  hps: 3838.71078
+  dps: 382573.08299
+  tps: 284334.88853
+  hps: 3860.11732
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelicofXuen-79328"
  value: {
-  dps: 371216.98429
-  tps: 272915.69427
-  hps: 3853.64804
+  dps: 371671.03596
+  tps: 273325.4387
+  hps: 3861.19421
  }
 }
 dps_results: {
@@ -1673,9 +1673,9 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Renataki'sSoulCharm-96741"
  value: {
-  dps: 371175.5615
-  tps: 272715.19887
-  hps: 3853.87766
+  dps: 372146.02645
+  tps: 273945.26559
+  hps: 3849.77831
  }
 }
 dps_results: {
@@ -1689,88 +1689,88 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ReverberatingPrimalDiamond"
  value: {
-  dps: 422516.50414
-  tps: 298075.87813
-  hps: 3971.94913
+  dps: 422461.93857
+  tps: 299260.10768
+  hps: 3969.74521
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RevitalizingPrimalDiamond"
  value: {
-  dps: 420637.47715
-  tps: 296820.73537
-  hps: 3971.94913
+  dps: 420580.01996
+  tps: 298000.23229
+  hps: 3969.74521
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuneofCinderglacier-3369"
  value: {
-  dps: 398952.28562
-  tps: 287136.93926
+  dps: 398317.22964
+  tps: 286813.09342
   hps: 20.83558
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuneofRazorice-3370"
  value: {
-  dps: 398881.18184
-  tps: 287204.5503
+  dps: 399204.48244
+  tps: 287483.17221
   hps: 20.83558
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuneofRe-Origination-96918"
  value: {
-  dps: 389898.45004
-  tps: 287091.73273
-  hps: 4095.30647
+  dps: 393201.1373
+  tps: 290582.28659
+  hps: 4183.84504
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuneofSpellbreaking-3595"
  value: {
-  dps: 392734.01109
-  tps: 281449.877
+  dps: 394282.22407
+  tps: 282731.43528
   hps: 20.83558
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuneofSpellshattering-3367"
  value: {
-  dps: 392599.71163
-  tps: 280981.45968
+  dps: 393041.94172
+  tps: 281362.3631
   hps: 20.83558
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuneofSwordbreaking-3594"
  value: {
-  dps: 393499.78379
-  tps: 281823.15225
+  dps: 393617.16419
+  tps: 281895.85396
   hps: 20.83558
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuneofSwordshattering-3365"
  value: {
-  dps: 393499.78379
-  tps: 281823.15225
+  dps: 393617.16419
+  tps: 281895.85396
   hps: 20.83558
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuneoftheNerubianCarapace-3883"
  value: {
-  dps: 393079.93129
-  tps: 281263.24295
+  dps: 393716.6137
+  tps: 282082.26103
   hps: 20.83558
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuneoftheStoneskinGargoyle-3847"
  value: {
-  dps: 392787.01024
-  tps: 281408.62083
+  dps: 394595.53661
+  tps: 282911.43463
   hps: 20.83558
  }
 }
@@ -1793,8 +1793,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SearingWords-81267"
  value: {
-  dps: 375353.62743
-  tps: 275982.43611
+  dps: 375354.2077
+  tps: 275994.74569
   hps: 3910.90475
  }
 }
@@ -1817,73 +1817,73 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SigilofDevotion-83740"
  value: {
-  dps: 378618.14639
-  tps: 278564.5174
-  hps: 3898.26809
+  dps: 377837.16369
+  tps: 277949.47743
+  hps: 3898.44828
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofFidelity-83737"
  value: {
-  dps: 378080.43004
-  tps: 277569.22363
-  hps: 3958.30173
+  dps: 378852.1791
+  tps: 278357.56089
+  hps: 3968.07245
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofGrace-83738"
  value: {
-  dps: 377755.32815
-  tps: 277947.52189
-  hps: 3931.62798
+  dps: 377310.76343
+  tps: 277081.34825
+  hps: 3952.49591
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofKypariZar-84076"
  value: {
-  dps: 377971.63501
-  tps: 278274.9419
+  dps: 377663.12433
+  tps: 277786.25235
   hps: 3906.44315
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofPatience-83739"
  value: {
-  dps: 375491.76283
-  tps: 276178.67091
-  hps: 3865.15986
+  dps: 374999.26936
+  tps: 275604.59203
+  hps: 3857.61368
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigilofRampage-105580"
  value: {
-  dps: 370984.25338
-  tps: 272539.37474
-  hps: 3850.03061
+  dps: 371170.27466
+  tps: 272749.3887
+  hps: 3853.87766
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SigiloftheCatacombs-83732"
  value: {
-  dps: 378631.19715
-  tps: 278167.70707
-  hps: 3988.05984
+  dps: 379893.52697
+  tps: 279423.95509
+  hps: 3995.83708
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SinisterPrimalDiamond"
  value: {
-  dps: 421166.09174
-  tps: 293634.02118
-  hps: 3958.67781
+  dps: 420727.85394
+  tps: 294420.09521
+  hps: 3949.26307
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Skeer'sBloodsoakedTalisman-105632"
  value: {
-  dps: 418574.64484
-  tps: 308348.97745
-  hps: 4020.46315
+  dps: 419208.50892
+  tps: 308648.47947
+  hps: 4076.64835
  }
 }
 dps_results: {
@@ -1913,9 +1913,9 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SparkofZandalar-96770"
  value: {
-  dps: 392709.79032
-  tps: 288549.14744
-  hps: 4077.10549
+  dps: 393861.10527
+  tps: 289317.10081
+  hps: 4082.77685
  }
 }
 dps_results: {
@@ -1937,25 +1937,25 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SpringrainIdolofRage-101009"
  value: {
-  dps: 376067.48179
-  tps: 276664.02917
+  dps: 376272.43838
+  tps: 276925.26648
   hps: 3857.43348
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SpringrainStoneofDestruction-101026"
  value: {
-  dps: 381466.36645
-  tps: 281282.51195
-  hps: 3857.54159
+  dps: 381156.28564
+  tps: 281099.62023
+  hps: 3852.82554
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SpringrainStoneofRage-101012"
  value: {
-  dps: 380261.58507
-  tps: 279781.38162
-  hps: 3852.82554
+  dps: 380307.66139
+  tps: 280150.68053
+  hps: 3856.77282
  }
 }
 dps_results: {
@@ -2001,25 +2001,25 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-StreamtalkerIdolofRage-101217"
  value: {
-  dps: 375759.86238
-  tps: 276455.45967
+  dps: 375762.76196
+  tps: 276471.39293
   hps: 3857.43348
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-StreamtalkerStoneofDestruction-101225"
  value: {
-  dps: 380523.38013
-  tps: 280522.92477
-  hps: 3831.92392
+  dps: 381004.99055
+  tps: 281019.9969
+  hps: 3841.69464
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-StreamtalkerStoneofRage-101220"
  value: {
-  dps: 379486.79582
-  tps: 279043.10612
-  hps: 3860.88195
+  dps: 380137.68789
+  tps: 279795.10833
+  hps: 3856.77282
  }
 }
 dps_results: {
@@ -2033,7 +2033,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-StuffofNightmares-87160"
  value: {
-  dps: 376831.25337
+  dps: 376815.40114
   tps: 277357.61472
   hps: 3857.43348
  }
@@ -2049,25 +2049,25 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SunsoulDefenderStone-101163"
  value: {
-  dps: 381424.40971
-  tps: 281359.22302
-  hps: 3952.87583
+  dps: 380765.50777
+  tps: 280953.26328
+  hps: 3960.81962
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SunsoulIdolofBattle-101152"
  value: {
-  dps: 382400.58814
-  tps: 283856.96128
-  hps: 3898.24568
+  dps: 382601.53739
+  tps: 283857.50765
+  hps: 3897.60321
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SunsoulStoneofBattle-101151"
  value: {
-  dps: 388088.93312
-  tps: 285012.10041
-  hps: 3837.74735
+  dps: 388506.1307
+  tps: 285641.40057
+  hps: 3855.20081
  }
 }
 dps_results: {
@@ -2081,41 +2081,41 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-SwordguardEmbroidery(Rank3)-4894"
  value: {
-  dps: 433271.27844
-  tps: 308536.65735
-  hps: 3927.09366
+  dps: 432660.40799
+  tps: 308384.92908
+  hps: 3946.15008
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SymboloftheCatacombs-83735"
  value: {
-  dps: 378909.56791
-  tps: 278883.23411
-  hps: 3936.28974
+  dps: 377802.72436
+  tps: 277677.81397
+  hps: 3925.72259
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SynapseSprings(MarkII)-4898"
  value: {
-  dps: 434904.44663
-  tps: 310074.38615
-  hps: 3934.95374
+  dps: 432851.59027
+  tps: 307992.38856
+  hps: 3942.90541
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TalismanofBloodlust-96864"
  value: {
-  dps: 379078.19322
-  tps: 277408.02534
-  hps: 4012.18112
+  dps: 379474.38666
+  tps: 277857.45227
+  hps: 4002.45343
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TerrorintheMists-87167"
  value: {
-  dps: 388002.98622
-  tps: 284190.81064
-  hps: 3951.41833
+  dps: 388425.10223
+  tps: 284644.13582
+  hps: 3932.62199
  }
 }
 dps_results: {
@@ -2153,25 +2153,25 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Time-LostArtifact-103678"
  value: {
-  dps: 384252.39094
-  tps: 282289.55571
-  hps: 3995.7446
+  dps: 384086.34447
+  tps: 282075.37503
+  hps: 3991.17423
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrailseekerIdolofRage-101054"
  value: {
-  dps: 375753.96885
-  tps: 276455.43403
+  dps: 376251.63266
+  tps: 276912.26552
   hps: 3857.43348
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrailseekerStoneofRage-101057"
  value: {
-  dps: 380482.07396
-  tps: 280191.12098
-  hps: 3860.57859
+  dps: 380122.91348
+  tps: 280160.81565
+  hps: 3856.77282
  }
 }
 dps_results: {
@@ -2225,8 +2225,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TyrannicalGladiator'sInsigniaofConquest-100026"
  value: {
-  dps: 370892.9973
-  tps: 272771.42835
+  dps: 370915.51799
+  tps: 272777.42128
   hps: 3857.43348
  }
 }
@@ -2241,17 +2241,17 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TyrannicalGladiator'sInsigniaofVictory-100085"
  value: {
-  dps: 380026.81672
-  tps: 281671.141
-  hps: 3849.72372
+  dps: 381235.37784
+  tps: 282646.27966
+  hps: 3863.35581
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TyrannicalPrimalDiamond"
  value: {
-  dps: 416286.98737
-  tps: 292503.41475
-  hps: 3917.12815
+  dps: 416199.55711
+  tps: 293654.11479
+  hps: 3915.41232
  }
 }
 dps_results: {
@@ -2273,8 +2273,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-VialofDragon'sBlood-87063"
  value: {
-  dps: 376447.73909
-  tps: 277049.87016
+  dps: 376447.40348
+  tps: 277049.53455
   hps: 3857.43348
  }
 }
@@ -2297,8 +2297,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ViciousTalismanoftheShado-PanAssault-94511"
  value: {
-  dps: 371623.12832
-  tps: 273256.50286
+  dps: 371726.01997
+  tps: 273350.27686
   hps: 3857.43348
  }
 }
@@ -2321,9 +2321,9 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-WindsweptPages-81125"
  value: {
-  dps: 373175.64547
-  tps: 275170.48498
-  hps: 3940.80576
+  dps: 371063.43054
+  tps: 274213.56596
+  hps: 3961.49925
  }
 }
 dps_results: {
@@ -2361,312 +2361,312 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ZenAlchemistStone-75274"
  value: {
-  dps: 384839.10396
-  tps: 286514.16261
-  hps: 3867.68382
+  dps: 385578.75891
+  tps: 287051.55872
+  hps: 3844.59854
  }
 }
 dps_results: {
  key: "TestUnholy-Average-Default"
  value: {
-  dps: 438417.83759
-  tps: 310663.18212
-  hps: 3757.82976
+  dps: 437537.69352
+  tps: 310818.53761
+  hps: 3757.54589
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-DefaultTalents-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.13806599794e+06
-  tps: 984485.78069
-  hps: 3878.80988
+  dps: 1.17044510249e+06
+  tps: 1.01764430769e+06
+  hps: 3879.42658
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-DefaultTalents-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 430988.88242
-  tps: 308109.97265
-  hps: 3878.80988
+  dps: 429410.3444
+  tps: 308294.60562
+  hps: 3877.85456
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-DefaultTalents-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 629247.23869
-  tps: 341333.59781
+  dps: 630914.99713
+  tps: 342847.21106
   hps: 4541.12261
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-DefaultTalents-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 800428.07689
-  tps: 694477.91436
-  hps: 3295.67568
+  dps: 842246.19565
+  tps: 737796.30897
+  hps: 3292.19029
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-DefaultTalents-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 319394.14884
-  tps: 237614.83219
-  hps: 3292.19029
+  dps: 317279.54267
+  tps: 236627.65767
+  hps: 3288.39107
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-DefaultTalents-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 390264.23806
-  tps: 234557.17245
+  dps: 391295.58659
+  tps: 236728.77807
   hps: 3541.88343
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-GlyphOfOutbreak-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.12856543504e+06
-  tps: 974894.82171
-  hps: 3859.32898
+  dps: 1.16760002907e+06
+  tps: 1.01663950977e+06
+  hps: 3846.75285
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-GlyphOfOutbreak-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 428194.52211
-  tps: 306236.22061
-  hps: 3843.60882
+  dps: 428151.85593
+  tps: 306938.82381
+  hps: 3842.37542
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-GlyphOfOutbreak-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 629247.23869
-  tps: 341333.59781
+  dps: 630914.99713
+  tps: 342847.21106
   hps: 4541.12261
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-GlyphOfOutbreak-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 809370.13855
-  tps: 703482.75283
-  hps: 3288.70489
+  dps: 816616.94821
+  tps: 713041.00041
+  hps: 3292.19029
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-GlyphOfOutbreak-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 317110.54529
-  tps: 235410.02478
-  hps: 3285.2195
+  dps: 315511.98777
+  tps: 235689.64397
+  hps: 3281.42028
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-GlyphOfOutbreak-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 390605.75517
-  tps: 234541.83698
+  dps: 391663.99662
+  tps: 236882.35221
   hps: 3559.31041
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-PlagueLeech-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 670892.79485
-  tps: 516593.61154
-  hps: 3920.23847
+  dps: 670307.62508
+  tps: 518068.19569
+  hps: 3911.14499
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-PlagueLeech-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 428740.06904
-  tps: 307046.97935
-  hps: 3917.09444
+  dps: 428241.27872
+  tps: 307203.04715
+  hps: 3915.86104
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-PlagueLeech-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 636138.24058
-  tps: 345844.52223
+  dps: 634817.65148
+  tps: 346694.81707
   hps: 4657.33076
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-PlagueLeech-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 495316.71738
-  tps: 389197.82304
-  hps: 3348.89808
+  dps: 491536.54902
+  tps: 386909.76429
+  hps: 3327.67189
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-PlagueLeech-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 315067.19637
-  tps: 233933.89085
-  hps: 3345.41269
+  dps: 311998.08845
+  tps: 231329.91428
+  hps: 3331.15728
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-PlagueLeech-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 373555.80179
-  tps: 217888.04977
+  dps: 371166.73963
+  tps: 216478.32049
   hps: 3594.16436
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-RoilingBlood-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 673837.18028
-  tps: 518855.1511
-  hps: 3864.04503
+  dps: 674409.53678
+  tps: 520756.26657
+  hps: 3884.14263
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-RoilingBlood-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 429192.4465
-  tps: 307824.09765
-  hps: 3864.04503
+  dps: 428056.51853
+  tps: 306895.01759
+  hps: 3878.47126
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-RoilingBlood-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 636138.24058
-  tps: 345844.52223
+  dps: 634817.65148
+  tps: 346694.81707
   hps: 4657.33076
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-RoilingBlood-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 494212.35321
-  tps: 387405.25559
-  hps: 3295.98951
+  dps: 495503.54361
+  tps: 391662.19904
+  hps: 3292.19029
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-RoilingBlood-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 317467.72341
-  tps: 235846.62661
-  hps: 3292.19029
+  dps: 316570.51526
+  tps: 236375.36585
+  hps: 3299.16108
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-RoilingBlood-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 390356.27984
-  tps: 234003.62977
-  hps: 3576.73738
+  dps: 390180.09833
+  tps: 235319.22613
+  hps: 3541.88343
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-RunicCorruption-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.13326290017e+06
-  tps: 978915.0747
-  hps: 3827.61057
+  dps: 1.10680019691e+06
+  tps: 953677.0693
+  hps: 3812.84572
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-RunicCorruption-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 428817.15533
-  tps: 306118.07499
-  hps: 3827.61057
+  dps: 430311.16267
+  tps: 309018.95429
+  hps: 3814.41774
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-RunicCorruption-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 629922.99661
-  tps: 341408.76162
+  dps: 630209.16881
+  tps: 341556.39828
   hps: 4464.21487
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-RunicCorruption-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 846592.71063
-  tps: 739693.61426
-  hps: 3278.24871
+  dps: 845664.62064
+  tps: 741210.32744
+  hps: 3270.96409
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-RunicCorruption-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 319212.83199
-  tps: 237449.55823
-  hps: 3278.24871
+  dps: 318402.70926
+  tps: 238270.90111
+  hps: 3270.96409
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-RunicCorruption-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 387319.47559
-  tps: 232068.19945
+  dps: 387624.29184
+  tps: 233362.91984
   hps: 3416.75636
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-RunicEmpowerment-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 1.10635822062e+06
-  tps: 952548.02689
-  hps: 3813.46242
+  dps: 1.12262708088e+06
+  tps: 971195.56538
+  hps: 3810.65701
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-RunicEmpowerment-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 427105.93432
-  tps: 305076.42055
-  hps: 3812.84572
+  dps: 427439.91946
+  tps: 305971.83831
+  hps: 3817.56177
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-RunicEmpowerment-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 628324.21556
-  tps: 340120.04735
+  dps: 629498.90126
+  tps: 341317.63846
   hps: 4464.21487
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-RunicEmpowerment-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 838938.22065
-  tps: 733068.7378
-  hps: 3256.70869
+  dps: 843404.71685
+  tps: 738723.79656
+  hps: 3274.44949
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-RunicEmpowerment-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 318041.54067
-  tps: 235650.11474
-  hps: 3256.70869
+  dps: 318652.84716
+  tps: 237042.08336
+  hps: 3277.93488
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Troll-p5-RunicEmpowerment-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 392184.6745
-  tps: 234048.07007
+  dps: 393188.26809
+  tps: 236120.18837
   hps: 3488.03338
  }
 }
 dps_results: {
  key: "TestUnholy-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 414401.5233
-  tps: 294949.90842
-  hps: 3768.30774
+  dps: 415030.35683
+  tps: 295604.65147
+  hps: 3754.08655
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -33,1545 +33,1545 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AgilePrimalDiamond"
  value: {
-  dps: 451054.71297
-  tps: 562444.19901
-  hps: 21600.84878
+  dps: 450661.11048
+  tps: 571925.86628
+  hps: 21639.2827
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AlacrityofXuen-103989"
  value: {
-  dps: 396081.44759
-  tps: 444590.5835
-  hps: 22431.47904
+  dps: 400282.73502
+  tps: 464105.12504
+  hps: 22312.62197
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ArcaneBadgeoftheShieldwall-93347"
  value: {
-  dps: 385557.9557
-  tps: 469416.89426
-  hps: 22724.46091
+  dps: 385351.09072
+  tps: 461874.79033
+  hps: 22374.53422
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ArrowflightMedallion-93258"
  value: {
-  dps: 402305.35814
-  tps: 489570.30866
-  hps: 22889.12189
+  dps: 400661.45873
+  tps: 472754.75243
+  hps: 22871.6896
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AssuranceofConsequence-105472"
  value: {
-  dps: 437432.15906
-  tps: 454895.00772
-  hps: 24867.88954
+  dps: 437445.78445
+  tps: 442209.56646
+  hps: 25116.82469
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AusterePrimalDiamond"
  value: {
-  dps: 438354.73872
-  tps: 544876.12357
-  hps: 21462.79396
+  dps: 439646.73361
+  tps: 558915.45709
+  hps: 21409.13224
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BadJuju-96781"
  value: {
-  dps: 416678.06971
-  tps: 498345.69069
-  hps: 23142.73333
+  dps: 421792.79373
+  tps: 505418.26211
+  hps: 22871.59755
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BadgeofKypariZar-84079"
  value: {
-  dps: 388323.67322
-  tps: 460271.29192
-  hps: 22003.43223
+  dps: 390881.20504
+  tps: 473194.70602
+  hps: 22171.43398
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BattlegearoftheEternalBlossom"
  value: {
-  dps: 286216.00286
-  tps: 343653.04967
-  hps: 15903.50158
+  dps: 288935.72966
+  tps: 334001.83271
+  hps: 16066.12707
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BattlegearoftheHauntedForest"
  value: {
-  dps: 303867.83496
-  tps: 348921.71513
-  hps: 18636.12114
+  dps: 308673.67066
+  tps: 339896.42589
+  hps: 18656.95523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BattlegearoftheShatteredVale"
  value: {
-  dps: 310080.78513
-  tps: 348955.78233
-  hps: 19446.79334
+  dps: 313927.26715
+  tps: 351096.66517
+  hps: 19294.59109
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BlackBloodofY'Shaarj-105648"
  value: {
-  dps: 389241.20603
-  tps: 444063.82342
-  hps: 24323.51219
+  dps: 392132.70981
+  tps: 452068.14981
+  hps: 23858.69399
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BlossomofPureSnow-89081"
  value: {
-  dps: 390130.99811
-  tps: 471665.08051
-  hps: 22907.96994
+  dps: 387822.58318
+  tps: 460109.0953
+  hps: 23011.98383
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottleofInfiniteStars-87057"
  value: {
-  dps: 402008.3468
-  tps: 488349.63749
-  hps: 22980.03537
+  dps: 408015.125
+  tps: 502370.41174
+  hps: 22607.1707
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BraidofTenSongs-84072"
  value: {
-  dps: 386709.70217
-  tps: 463709.21087
-  hps: 22433.84087
+  dps: 387770.99872
+  tps: 465223.50253
+  hps: 22007.12898
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Brawler'sStatue-257885"
  value: {
-  dps: 384103.14381
-  tps: 467274.52614
-  hps: 21892.01727
+  dps: 383805.27096
+  tps: 476961.20609
+  hps: 22111.89444
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BreathoftheHydra-96827"
  value: {
-  dps: 390256.037
-  tps: 455543.06883
-  hps: 22053.80622
+  dps: 389896.84658
+  tps: 454645.95389
+  hps: 22426.78994
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BroochofMunificentDeeds-87500"
  value: {
-  dps: 384103.14381
-  tps: 467274.52614
-  hps: 22006.41917
+  dps: 383805.27096
+  tps: 476961.20609
+  hps: 22226.93908
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BrutalTalismanoftheShado-PanAssault-94508"
  value: {
-  dps: 392242.21749
-  tps: 477510.76828
-  hps: 22038.57058
+  dps: 397591.54444
+  tps: 490252.36597
+  hps: 22202.11929
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BurningPrimalDiamond"
  value: {
-  dps: 447280.76913
-  tps: 556422.21141
-  hps: 21706.92425
+  dps: 448166.26167
+  tps: 570241.5786
+  hps: 21678.02699
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CapacitivePrimalDiamond"
  value: {
-  dps: 452823.682
-  tps: 578722.94109
-  hps: 21154.4537
+  dps: 462380.29671
+  tps: 592538.81328
+  hps: 21338.98694
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CarbonicCarbuncle-81138"
  value: {
-  dps: 388743.74437
-  tps: 466336.22278
-  hps: 22303.50286
+  dps: 389845.10648
+  tps: 480006.03808
+  hps: 22390.15444
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Cha-Ye'sEssenceofBrilliance-96888"
  value: {
-  dps: 389874.34727
-  tps: 472880.12949
-  hps: 22259.2342
+  dps: 388926.55059
+  tps: 472935.58833
+  hps: 22639.16825
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CharmofTenSongs-84071"
  value: {
-  dps: 383734.09082
-  tps: 465407.58617
-  hps: 22283.90513
+  dps: 387500.1671
+  tps: 460824.6789
+  hps: 22429.20849
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CommunalIdolofDestruction-101168"
  value: {
-  dps: 389117.12749
-  tps: 472315.6303
-  hps: 21825.16801
+  dps: 389838.09346
+  tps: 488081.38825
+  hps: 21971.36418
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CommunalStoneofDestruction-101171"
  value: {
-  dps: 390624.32493
-  tps: 473870.23556
-  hps: 22542.96125
+  dps: 394342.53869
+  tps: 466559.51633
+  hps: 22782.57876
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CommunalStoneofWisdom-101183"
  value: {
-  dps: 383727.28437
-  tps: 465208.27823
-  hps: 22251.45269
+  dps: 383166.97394
+  tps: 474015.1206
+  hps: 22464.02042
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ContemplationofChi-Ji-103988"
  value: {
-  dps: 382548.88773
-  tps: 463327.05639
-  hps: 22687.03017
+  dps: 382316.43456
+  tps: 472476.86229
+  hps: 22916.56874
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Coren'sColdChromiumCoaster-257880"
  value: {
-  dps: 397715.91918
-  tps: 464788.68219
-  hps: 22351.3948
+  dps: 401514.04572
+  tps: 491632.85464
+  hps: 22473.31132
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CoreofDecency-87497"
  value: {
-  dps: 380791.17491
-  tps: 461466.2546
-  hps: 22047.30695
+  dps: 385121.73884
+  tps: 478680.83338
+  hps: 22155.81161
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CourageousPrimalDiamond"
  value: {
-  dps: 438356.6799
-  tps: 544876.12118
-  hps: 21585.89464
+  dps: 439648.6748
+  tps: 558915.4547
+  hps: 21523.35075
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CraftedDreadfulGladiator'sBadgeofConquest-93419"
  value: {
-  dps: 387763.91828
-  tps: 469779.17203
-  hps: 22203.90519
+  dps: 387816.09576
+  tps: 482525.59448
+  hps: 21890.01016
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CraftedDreadfulGladiator'sBadgeofDominance-93600"
  value: {
-  dps: 383479.74495
-  tps: 461027.00557
-  hps: 22233.40291
+  dps: 382986.61973
+  tps: 480627.80139
+  hps: 22420.41114
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CraftedDreadfulGladiator'sBadgeofVictory-93606"
  value: {
-  dps: 387090.27038
-  tps: 462567.51933
-  hps: 21933.89087
+  dps: 387954.85098
+  tps: 477896.0606
+  hps: 22213.69829
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CraftedDreadfulGladiator'sEmblemofCruelty-93485"
  value: {
-  dps: 386238.56013
-  tps: 465614.07771
-  hps: 21837.95556
+  dps: 387660.47333
+  tps: 479197.99477
+  hps: 22227.77301
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CraftedDreadfulGladiator'sEmblemofMeditation-93487"
  value: {
-  dps: 383778.35437
-  tps: 468814.37574
-  hps: 21869.60227
+  dps: 383679.39707
+  tps: 477085.862
+  hps: 22153.31889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CraftedDreadfulGladiator'sEmblemofTenacity-93486"
  value: {
-  dps: 383778.35437
-  tps: 468814.37574
-  hps: 21962.23425
+  dps: 383679.39707
+  tps: 477085.862
+  hps: 22246.06877
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CraftedDreadfulGladiator'sInsigniaofConquest-93424"
  value: {
-  dps: 395916.40636
-  tps: 486349.86898
-  hps: 22538.25761
+  dps: 396779.82051
+  tps: 481800.31705
+  hps: 22207.14836
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CraftedDreadfulGladiator'sInsigniaofDominance-93601"
  value: {
-  dps: 384736.47351
-  tps: 464081.51367
-  hps: 22442.80067
+  dps: 384232.07535
+  tps: 469171.00028
+  hps: 22598.98973
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CraftedDreadfulGladiator'sInsigniaofVictory-93611"
  value: {
-  dps: 387303.46724
-  tps: 472211.68285
-  hps: 21983.95292
+  dps: 391029.84702
+  tps: 484792.83957
+  hps: 22002.62876
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CraftedMalevolentGladiator'sBadgeofConquest-98755"
  value: {
-  dps: 389632.88548
-  tps: 471041.4087
-  hps: 22216.61796
+  dps: 389931.39152
+  tps: 482844.38358
+  hps: 22076.02578
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CraftedMalevolentGladiator'sBadgeofDominance-98910"
  value: {
-  dps: 383479.74495
-  tps: 461027.00557
-  hps: 22308.32568
+  dps: 382986.61973
+  tps: 480627.80139
+  hps: 22502.83678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CraftedMalevolentGladiator'sBadgeofVictory-98912"
  value: {
-  dps: 387675.45797
-  tps: 463245.11426
-  hps: 21933.89087
+  dps: 388540.27264
+  tps: 478553.9332
+  hps: 22213.69829
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CraftedMalevolentGladiator'sEmblemofCruelty-98811"
  value: {
-  dps: 387232.41477
-  tps: 466977.21962
-  hps: 21902.9302
+  dps: 388237.14882
+  tps: 479814.38419
+  hps: 22261.87807
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CraftedMalevolentGladiator'sEmblemofMeditation-98813"
  value: {
-  dps: 383778.35437
-  tps: 468814.37574
-  hps: 21869.60227
+  dps: 383679.39707
+  tps: 477085.862
+  hps: 22153.31889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CraftedMalevolentGladiator'sEmblemofTenacity-98812"
  value: {
-  dps: 383778.35437
-  tps: 468814.37574
-  hps: 21979.07643
+  dps: 383679.39707
+  tps: 477085.862
+  hps: 22262.93239
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CraftedMalevolentGladiator'sInsigniaofConquest-98760"
  value: {
-  dps: 394604.99347
-  tps: 463558.09262
-  hps: 22602.19314
+  dps: 397107.46564
+  tps: 487880.0916
+  hps: 22740.8623
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CraftedMalevolentGladiator'sInsigniaofDominance-98911"
  value: {
-  dps: 383422.90881
-  tps: 466394.64208
-  hps: 22544.98408
+  dps: 383228.9063
+  tps: 475275.89343
+  hps: 22605.33965
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CraftedMalevolentGladiator'sInsigniaofVictory-98917"
  value: {
-  dps: 389942.06904
-  tps: 468497.67594
-  hps: 21925.67194
+  dps: 389029.50023
+  tps: 477293.02112
+  hps: 22001.49819
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CurseofHubris-105645"
  value: {
-  dps: 395492.50842
-  tps: 490787.88557
-  hps: 23568.25953
+  dps: 395841.51675
+  tps: 479366.82907
+  hps: 23684.15484
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CutstitcherMedallion-93255"
  value: {
-  dps: 383499.41403
-  tps: 460281.69408
-  hps: 22449.25063
+  dps: 383111.4506
+  tps: 481701.73531
+  hps: 22649.48182
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Daelo'sFinalWords-87496"
  value: {
-  dps: 389157.79113
-  tps: 470377.64078
-  hps: 21910.55189
+  dps: 388050.86886
+  tps: 477528.4156
+  hps: 21956.40458
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkglowEmbroidery(Rank3)-4893"
  value: {
-  dps: 458754.97271
-  tps: 603650.78976
-  hps: 21556.53696
+  dps: 453900.51856
+  tps: 574716.64452
+  hps: 21493.10345
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmistVortex-87172"
  value: {
-  dps: 390892.97089
-  tps: 427791.68359
-  hps: 22421.15746
+  dps: 396231.35529
+  tps: 443557.27021
+  hps: 22496.98301
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeadeyeBadgeoftheShieldwall-93346"
  value: {
-  dps: 396096.07251
-  tps: 481645.16482
-  hps: 22207.7814
+  dps: 399980.70522
+  tps: 483751.85009
+  hps: 22268.24528
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DelicateVialoftheSanguinaire-96895"
  value: {
-  dps: 384126.8367
-  tps: 464490.62129
-  hps: 21862.76948
+  dps: 384424.42462
+  tps: 478001.80485
+  hps: 21988.8482
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructivePrimalDiamond"
  value: {
-  dps: 371601.67251
-  tps: 502396.75845
-  hps: 25861.76962
+  dps: 370397.58521
+  tps: 490304.35094
+  hps: 26071.10572
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DisciplineofXuen-103986"
  value: {
-  dps: 415884.36971
-  tps: 505649.66521
-  hps: 22700.5701
+  dps: 421836.60643
+  tps: 497485.34037
+  hps: 22995.81816
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dominator'sArcaneBadge-93342"
  value: {
-  dps: 385557.9557
-  tps: 469416.89426
-  hps: 22724.46091
+  dps: 385351.09072
+  tps: 461874.79033
+  hps: 22374.53422
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dominator'sDeadeyeBadge-93341"
  value: {
-  dps: 396096.07251
-  tps: 481645.16482
-  hps: 22207.7814
+  dps: 399980.70522
+  tps: 483751.85009
+  hps: 22268.24528
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dominator'sDurableBadge-93345"
  value: {
-  dps: 386564.35809
-  tps: 465941.39225
-  hps: 21930.01876
+  dps: 393164.35482
+  tps: 473785.34405
+  hps: 22076.53098
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dominator'sKnightlyBadge-93344"
  value: {
-  dps: 389938.85392
-  tps: 470186.64905
-  hps: 21930.01876
+  dps: 396556.20006
+  tps: 478009.21945
+  hps: 22076.53098
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dominator'sMendingBadge-93343"
  value: {
-  dps: 383499.41403
-  tps: 460281.69408
-  hps: 22288.59698
+  dps: 383111.4506
+  tps: 481701.73531
+  hps: 22478.7071
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DreadfulGladiator'sBadgeofConquest-84344"
  value: {
-  dps: 387763.91828
-  tps: 469779.17203
-  hps: 22203.90519
+  dps: 387816.09576
+  tps: 482525.59448
+  hps: 21890.01016
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DreadfulGladiator'sBadgeofDominance-84488"
  value: {
-  dps: 383479.74495
-  tps: 461027.00557
-  hps: 22233.40291
+  dps: 382986.61973
+  tps: 480627.80139
+  hps: 22420.41114
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DreadfulGladiator'sBadgeofVictory-84490"
  value: {
-  dps: 387090.27038
-  tps: 462567.51933
-  hps: 21933.89087
+  dps: 387954.85098
+  tps: 477896.0606
+  hps: 22213.69829
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DreadfulGladiator'sEmblemofCruelty-84399"
  value: {
-  dps: 386238.56013
-  tps: 465614.07771
-  hps: 21837.95556
+  dps: 387660.47333
+  tps: 479197.99477
+  hps: 22227.77301
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DreadfulGladiator'sEmblemofMeditation-84401"
  value: {
-  dps: 383778.35437
-  tps: 468814.37574
-  hps: 21869.60227
+  dps: 383679.39707
+  tps: 477085.862
+  hps: 22153.31889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DreadfulGladiator'sEmblemofTenacity-84400"
  value: {
-  dps: 383778.35437
-  tps: 468814.37574
-  hps: 21962.23425
+  dps: 383679.39707
+  tps: 477085.862
+  hps: 22246.06877
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DreadfulGladiator'sInsigniaofConquest-84349"
  value: {
-  dps: 390297.07615
-  tps: 469034.05212
-  hps: 22468.19203
+  dps: 400566.18425
+  tps: 470268.83465
+  hps: 22358.98709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DreadfulGladiator'sInsigniaofDominance-84489"
  value: {
-  dps: 383119.73626
-  tps: 462945.1327
-  hps: 22524.16342
+  dps: 384514.29962
+  tps: 475907.76233
+  hps: 22799.40328
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DreadfulGladiator'sInsigniaofVictory-84495"
  value: {
-  dps: 388139.53619
-  tps: 472972.85598
-  hps: 21900.46166
+  dps: 386050.50624
+  tps: 476855.99385
+  hps: 21856.997
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DurableBadgeoftheShieldwall-93350"
  value: {
-  dps: 386564.35809
-  tps: 465941.39225
-  hps: 21930.01876
+  dps: 393164.35482
+  tps: 473785.34405
+  hps: 22076.53098
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DysmorphicSamophlangeofDiscontinuity-105615"
  value: {
-  dps: 384130.67989
-  tps: 464491.0226
-  hps: 22975.30385
+  dps: 384427.70259
+  tps: 478001.80485
+  hps: 23116.5751
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentPrimalDiamond"
  value: {
-  dps: 438354.73872
-  tps: 544876.12357
-  hps: 21462.79396
+  dps: 439646.73361
+  tps: 558915.45709
+  hps: 21409.13224
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberPrimalDiamond"
  value: {
-  dps: 438354.73872
-  tps: 544876.12187
-  hps: 21543.23147
+  dps: 439646.73361
+  tps: 558915.45539
+  hps: 21480.75718
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmblemofKypariZar-84077"
  value: {
-  dps: 388044.45113
-  tps: 447675.0675
-  hps: 22120.83801
+  dps: 390602.99664
+  tps: 467146.23894
+  hps: 22417.39693
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmblemoftheCatacombs-83733"
  value: {
-  dps: 390435.41654
-  tps: 453167.33787
-  hps: 22065.3159
+  dps: 393074.33388
+  tps: 462669.04084
+  hps: 22221.34134
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmptyFruitBarrel-81133"
  value: {
-  dps: 382336.2398
-  tps: 463252.99715
-  hps: 21938.22986
+  dps: 386404.10809
+  tps: 471734.69107
+  hps: 22430.44792
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnchantWeapon-BloodyDancingSteel-5125"
  value: {
-  dps: 462348.87785
-  tps: 593074.49327
-  hps: 21589.2561
+  dps: 462228.79178
+  tps: 592958.308
+  hps: 21361.25148
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnchantWeapon-Colossus-4445"
  value: {
-  dps: 442415.73338
-  tps: 558594.07102
-  hps: 20548.36177
+  dps: 453655.33258
+  tps: 580835.54176
+  hps: 20935.40867
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnchantWeapon-ElementalForce-4443"
  value: {
-  dps: 443602.71627
-  tps: 559779.82881
-  hps: 20566.69717
+  dps: 454484.47934
+  tps: 582140.20527
+  hps: 20929.68772
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnchantWeapon-JadeSpirit-4442"
  value: {
-  dps: 442164.81564
-  tps: 561297.3663
-  hps: 20826.80991
+  dps: 452257.32936
+  tps: 576062.62415
+  hps: 21165.37802
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnchantWeapon-River'sSong-4446"
  value: {
-  dps: 449618.97909
-  tps: 569888.3288
-  hps: 20986.25955
+  dps: 453450.85679
+  tps: 590488.97168
+  hps: 20878.11879
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnchantWeapon-SpiritofConquest-5124"
  value: {
-  dps: 443930.06604
-  tps: 557248.54559
-  hps: 21016.35925
+  dps: 453989.57718
+  tps: 577712.45297
+  hps: 21333.87874
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnchantWeapon-Windsong-4441"
  value: {
-  dps: 447951.31182
-  tps: 577076.90771
-  hps: 21761.93859
+  dps: 443762.74318
+  tps: 560964.06723
+  hps: 21539.99397
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticPrimalDiamond"
  value: {
-  dps: 371601.67251
-  tps: 502396.75845
-  hps: 25861.76962
+  dps: 370397.58521
+  tps: 490304.35094
+  hps: 26071.10572
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceofTerror-87175"
  value: {
-  dps: 383364.64129
-  tps: 459585.97758
-  hps: 22478.60688
+  dps: 383200.60492
+  tps: 471586.07194
+  hps: 22463.00564
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalPrimalDiamond"
  value: {
-  dps: 438354.73872
-  tps: 544876.12357
-  hps: 21432.02476
+  dps: 439646.73361
+  tps: 558915.45709
+  hps: 21378.31647
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EvilEyeofGalakras-105491"
  value: {
-  dps: 396070.39869
-  tps: 479545.55247
-  hps: 21970.78126
+  dps: 395434.97737
+  tps: 470757.02204
+  hps: 21849.11673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FabledFeatherofJi-Kun-96842"
  value: {
-  dps: 395343.26512
-  tps: 484177.03687
-  hps: 21949.80251
+  dps: 395378.88682
+  tps: 467727.87349
+  hps: 22084.9743
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FearwurmBadge-84074"
  value: {
-  dps: 386761.07343
-  tps: 451378.74526
-  hps: 22395.57886
+  dps: 390228.65401
+  tps: 472698.1421
+  hps: 22319.55839
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FearwurmRelic-84070"
  value: {
-  dps: 386206.3685
-  tps: 458978.82671
-  hps: 22460.95301
+  dps: 387242.84692
+  tps: 467680.81384
+  hps: 22558.84457
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FelsoulIdolofDestruction-101263"
  value: {
-  dps: 389737.22648
-  tps: 474943.33959
-  hps: 21921.55937
+  dps: 389068.21244
+  tps: 486095.21887
+  hps: 21894.81537
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FelsoulStoneofDestruction-101266"
  value: {
-  dps: 392083.5766
-  tps: 478555.37454
-  hps: 22680.4769
+  dps: 394478.06868
+  tps: 462065.79237
+  hps: 23057.72073
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FlashfrozenResinGlobule-100951"
  value: {
-  dps: 384845.31025
-  tps: 474106.16311
-  hps: 22383.90557
+  dps: 383694.08223
+  tps: 483649.78622
+  hps: 22305.00632
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FlashingSteelTalisman-81265"
  value: {
-  dps: 386682.16672
-  tps: 473977.71069
-  hps: 22353.58317
+  dps: 390014.30751
+  tps: 478371.0381
+  hps: 22375.5691
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FleetPrimalDiamond"
  value: {
-  dps: 445508.10926
-  tps: 550541.98428
-  hps: 21573.91336
+  dps: 441686.79333
+  tps: 558138.96293
+  hps: 21338.52642
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornPrimalDiamond"
  value: {
-  dps: 438354.73872
-  tps: 544876.12187
-  hps: 21543.23147
+  dps: 439646.73361
+  tps: 558915.45539
+  hps: 21480.75718
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FortitudeoftheZandalari-96793"
  value: {
-  dps: 390836.06508
-  tps: 476053.61523
-  hps: 21732.9889
+  dps: 394979.14389
+  tps: 488849.02799
+  hps: 22249.84598
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FrenziedCrystalofRage-105572"
  value: {
-  dps: 384906.04786
-  tps: 469186.55761
-  hps: 23382.06634
+  dps: 385564.98968
+  tps: 475003.37259
+  hps: 23611.48881
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Fusion-FireCore-105459"
  value: {
-  dps: 395974.37867
-  tps: 475745.64079
-  hps: 22302.37705
+  dps: 398971.66669
+  tps: 483973.95487
+  hps: 22113.0521
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GazeoftheTwins-96915"
  value: {
-  dps: 399759.27473
-  tps: 485296.60436
-  hps: 22691.19708
+  dps: 398312.54667
+  tps: 494514.09282
+  hps: 22473.33217
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gerp'sPerfectArrow-87495"
  value: {
-  dps: 389293.40507
-  tps: 480634.78875
-  hps: 22824.94673
+  dps: 387012.86626
+  tps: 480083.32536
+  hps: 22243.89295
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 323403.8267
-  tps: 356752.47027
-  hps: 18582.82966
+  dps: 327858.07229
+  tps: 356987.93591
+  hps: 18654.21582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gong-Lu,StrengthofXuen-102249"
  value: {
-  dps: 428043.55033
-  tps: 573862.89232
-  hps: 20535.4724
+  dps: 436761.45946
+  tps: 610200.59543
+  hps: 20522.77129
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GrievousGladiator'sBadgeofConquest-103145"
  value: {
-  dps: 395350.54957
-  tps: 483122.78599
-  hps: 22609.59185
+  dps: 399037.09412
+  tps: 494080.22314
+  hps: 22411.8819
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GrievousGladiator'sBadgeofDominance-103308"
  value: {
-  dps: 383479.74495
-  tps: 461027.00557
-  hps: 22567.60462
+  dps: 382986.61973
+  tps: 480627.80139
+  hps: 22749.15684
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GrievousGladiator'sBadgeofVictory-103314"
  value: {
-  dps: 388711.95887
-  tps: 464607.56042
-  hps: 21904.19173
+  dps: 390584.04999
+  tps: 479147.22123
+  hps: 22229.63578
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GrievousGladiator'sEmblemofCruelty-103210"
  value: {
-  dps: 389330.34183
-  tps: 471165.38323
-  hps: 22072.63571
+  dps: 389539.74177
+  tps: 479579.21117
+  hps: 22281.76095
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GrievousGladiator'sEmblemofMeditation-103212"
  value: {
-  dps: 383778.35437
-  tps: 468814.37574
-  hps: 21869.60227
+  dps: 383679.39707
+  tps: 477085.862
+  hps: 22153.31889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GrievousGladiator'sEmblemofTenacity-103211"
  value: {
-  dps: 383778.35437
-  tps: 468814.37574
-  hps: 22037.63688
+  dps: 383679.39707
+  tps: 477085.862
+  hps: 22321.56738
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GrievousGladiator'sInsigniaofConquest-103150"
  value: {
-  dps: 407186.6018
-  tps: 488496.46314
-  hps: 23223.87915
+  dps: 406618.16883
+  tps: 496401.70062
+  hps: 22916.38688
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GrievousGladiator'sInsigniaofDominance-103309"
  value: {
-  dps: 385585.27196
-  tps: 469791.80062
-  hps: 22996.0148
+  dps: 385230.37521
+  tps: 478408.05072
+  hps: 23279.60499
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GrievousGladiator'sInsigniaofVictory-103319"
  value: {
-  dps: 393279.58946
-  tps: 472050.83352
-  hps: 22015.20647
+  dps: 391753.92854
+  tps: 488076.3385
+  hps: 21961.2952
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Hawkmaster'sTalon-89082"
  value: {
-  dps: 394315.64446
-  tps: 462071.91711
-  hps: 22453.73543
+  dps: 398510.39665
+  tps: 479467.34049
+  hps: 22574.36169
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heart-LesionDefenderIdol-100999"
  value: {
-  dps: 385190.09795
-  tps: 471811.07083
-  hps: 22042.90772
+  dps: 384351.56041
+  tps: 475071.53132
+  hps: 22006.1741
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heart-LesionDefenderStone-101002"
  value: {
-  dps: 394833.95347
-  tps: 468923.28391
-  hps: 22411.65166
+  dps: 396554.05272
+  tps: 473338.39918
+  hps: 22519.69822
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heart-LesionIdolofBattle-100991"
  value: {
-  dps: 390954.70742
-  tps: 465128.09622
-  hps: 21922.03768
+  dps: 390177.61236
+  tps: 472301.05458
+  hps: 22048.70323
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heart-LesionStoneofBattle-100990"
  value: {
-  dps: 397357.99973
-  tps: 478315.15007
-  hps: 22118.70466
+  dps: 398670.53575
+  tps: 488066.26911
+  hps: 22078.11425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofFire-81181"
  value: {
-  dps: 388339.86285
-  tps: 473464.25008
-  hps: 21897.85868
+  dps: 388321.62271
+  tps: 485781.31236
+  hps: 22094.41043
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartwarmerMedallion-93260"
  value: {
-  dps: 383499.41403
-  tps: 460281.69408
-  hps: 22449.25063
+  dps: 383111.4506
+  tps: 481701.73531
+  hps: 22649.48182
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HelmbreakerMedallion-93261"
  value: {
-  dps: 395200.58746
-  tps: 479286.51546
-  hps: 22378.00523
+  dps: 393925.90161
+  tps: 466298.80771
+  hps: 22504.6293
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Horridon'sLastGasp-96757"
  value: {
-  dps: 384130.67989
-  tps: 464506.18992
-  hps: 22693.54352
+  dps: 384427.70259
+  tps: 478017.26365
+  hps: 22810.41068
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassivePrimalDiamond"
  value: {
-  dps: 371601.67251
-  tps: 502396.75845
-  hps: 25861.76962
+  dps: 370397.58521
+  tps: 490304.35094
+  hps: 26071.10572
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePrimalDiamond"
  value: {
-  dps: 438354.73872
-  tps: 544876.12357
-  hps: 21462.79396
+  dps: 439646.73361
+  tps: 558915.45709
+  hps: 21409.13224
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InscribedBagofHydra-Spawn-96828"
  value: {
-  dps: 384126.8367
-  tps: 464490.62129
-  hps: 21862.76948
+  dps: 384424.42462
+  tps: 478001.80485
+  hps: 21988.8482
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaofKypariZar-84078"
  value: {
-  dps: 384126.8367
-  tps: 464490.62129
-  hps: 21862.76948
+  dps: 384424.42462
+  tps: 478001.80485
+  hps: 21988.8482
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IronBellyWok-89083"
  value: {
-  dps: 387170.55603
-  tps: 463054.00422
-  hps: 22136.54442
+  dps: 389556.77878
+  tps: 468887.10838
+  hps: 22070.71814
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IronProtectorTalisman-85181"
  value: {
-  dps: 384613.54544
-  tps: 461989.06537
-  hps: 22050.23846
+  dps: 384405.82722
+  tps: 480063.81068
+  hps: 22111.77331
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JadeBanditFigurine-86772"
  value: {
-  dps: 390829.99428
-  tps: 471964.39768
-  hps: 22326.81438
+  dps: 396295.24557
+  tps: 469119.59972
+  hps: 22610.86711
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JadeCharioteerFigurine-86771"
  value: {
-  dps: 383589.21788
-  tps: 458061.5192
-  hps: 21865.84492
+  dps: 387247.64905
+  tps: 455259.0753
+  hps: 22012.14344
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JadeCourtesanFigurine-86774"
  value: {
-  dps: 383499.41403
-  tps: 460281.69408
-  hps: 22350.46222
+  dps: 383111.4506
+  tps: 481701.73531
+  hps: 22541.31131
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JadeMagistrateFigurine-86773"
  value: {
-  dps: 388985.31162
-  tps: 469572.70909
-  hps: 22696.90591
+  dps: 386923.93246
+  tps: 459482.83634
+  hps: 22842.20511
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JadeWarlordFigurine-86775"
  value: {
-  dps: 387732.8393
-  tps: 466968.40828
-  hps: 22071.12125
+  dps: 393329.85153
+  tps: 476862.33361
+  hps: 22293.45612
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ji-Kun'sRisingWinds-96843"
  value: {
-  dps: 384231.85671
-  tps: 469548.72196
-  hps: 21986.58466
+  dps: 384394.15802
+  tps: 478207.69613
+  hps: 21876.98104
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Juggernaut'sFocusingCrystal-105514"
  value: {
-  dps: 384126.8367
-  tps: 464490.62129
-  hps: 32764.51239
+  dps: 384424.42462
+  tps: 478001.80485
+  hps: 32875.13483
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kardris'ToxicTotem-105540"
  value: {
-  dps: 399851.20799
-  tps: 488972.6657
-  hps: 23304.02565
+  dps: 402953.52692
+  tps: 497156.62013
+  hps: 23731.9458
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KnightlyBadgeoftheShieldwall-93349"
  value: {
-  dps: 389938.85392
-  tps: 470186.64905
-  hps: 21930.01876
+  dps: 396556.20006
+  tps: 478009.21945
+  hps: 22076.53098
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KnotofTenSongs-84073"
  value: {
-  dps: 384126.8367
-  tps: 464490.62129
-  hps: 21862.76948
+  dps: 384424.42462
+  tps: 478001.80485
+  hps: 21988.8482
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kor'kronBookofHurting-92785"
  value: {
-  dps: 384215.3436
-  tps: 463469.3733
-  hps: 21930.05218
+  dps: 382519.70237
+  tps: 478872.40785
+  hps: 22047.37508
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Lao-Chin'sLiquidCourage-89079"
  value: {
-  dps: 388437.99934
-  tps: 467792.38302
-  hps: 22088.98258
+  dps: 393723.636
+  tps: 477644.16896
+  hps: 22312.48169
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeiShen'sFinalOrders-87072"
  value: {
-  dps: 391588.18019
-  tps: 450375.61907
-  hps: 22168.95999
+  dps: 393868.71523
+  tps: 455367.16408
+  hps: 22368.98527
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LessonsoftheDarkmaster-81268"
  value: {
-  dps: 388589.31559
-  tps: 470867.53553
-  hps: 21872.3907
+  dps: 388764.30435
+  tps: 481112.20784
+  hps: 22093.44366
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LightdrinkerIdolofRage-101200"
  value: {
-  dps: 400386.18353
-  tps: 491062.07442
-  hps: 22361.61075
+  dps: 399392.97674
+  tps: 494155.99851
+  hps: 22370.37753
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LightdrinkerStoneofRage-101203"
  value: {
-  dps: 402762.82768
-  tps: 483018.73964
-  hps: 22354.91576
+  dps: 405563.02806
+  tps: 485472.14289
+  hps: 22627.83822
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LightoftheCosmos-87065"
  value: {
-  dps: 385706.90232
-  tps: 442123.67006
-  hps: 22222.72277
+  dps: 388367.61691
+  tps: 455070.04062
+  hps: 21988.37018
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LightweaveEmbroidery(Rank3)-4892"
  value: {
-  dps: 460089.78101
-  tps: 618134.41177
-  hps: 21278.68674
+  dps: 450391.36983
+  tps: 580369.95522
+  hps: 21259.68924
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LordBlastington'sScopeofDoom-4699"
  value: {
-  dps: 442773.64331
-  tps: 558493.85906
-  hps: 20572.5483
+  dps: 453655.33258
+  tps: 580835.54176
+  hps: 20935.40867
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MalevolentGladiator'sBadgeofConquest-91452"
  value: {
-  dps: 389632.88548
-  tps: 471041.4087
-  hps: 22216.61796
+  dps: 389931.39152
+  tps: 482844.38358
+  hps: 22076.02578
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MalevolentGladiator'sBadgeofDominance-91753"
  value: {
-  dps: 383479.74495
-  tps: 461027.00557
-  hps: 22308.32568
+  dps: 382986.61973
+  tps: 480627.80139
+  hps: 22502.83678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MalevolentGladiator'sBadgeofVictory-91763"
  value: {
-  dps: 387675.45797
-  tps: 463245.11426
-  hps: 21933.89087
+  dps: 388540.27264
+  tps: 478553.9332
+  hps: 22213.69829
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MalevolentGladiator'sEmblemofCruelty-91562"
  value: {
-  dps: 387232.41477
-  tps: 466977.21962
-  hps: 21902.9302
+  dps: 388237.14882
+  tps: 479814.38419
+  hps: 22261.87807
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MalevolentGladiator'sEmblemofMeditation-91564"
  value: {
-  dps: 383778.35437
-  tps: 468814.37574
-  hps: 21869.60227
+  dps: 383679.39707
+  tps: 477085.862
+  hps: 22153.31889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MalevolentGladiator'sEmblemofTenacity-91563"
  value: {
-  dps: 383778.35437
-  tps: 468814.37574
-  hps: 21979.07643
+  dps: 383679.39707
+  tps: 477085.862
+  hps: 22262.93239
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MalevolentGladiator'sInsigniaofConquest-91457"
  value: {
-  dps: 398633.65574
-  tps: 482391.75586
-  hps: 22577.82817
+  dps: 400473.45966
+  tps: 498707.19045
+  hps: 22710.2713
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MalevolentGladiator'sInsigniaofDominance-91754"
  value: {
-  dps: 383905.55405
-  tps: 464231.20732
-  hps: 22508.54783
+  dps: 384235.05701
+  tps: 472897.72579
+  hps: 22667.1299
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MalevolentGladiator'sInsigniaofVictory-91768"
  value: {
-  dps: 388690.75067
-  tps: 473861.50642
-  hps: 21688.60537
+  dps: 389119.98008
+  tps: 471421.50921
+  hps: 22351.02251
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkoftheCatacombs-83731"
  value: {
-  dps: 388492.54928
-  tps: 461284.33302
-  hps: 21922.59134
+  dps: 387307.09243
+  tps: 473342.03764
+  hps: 22179.99494
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkoftheHardenedGrunt-92783"
  value: {
-  dps: 383499.41403
-  tps: 460281.69408
-  hps: 21889.45245
+  dps: 383111.4506
+  tps: 481701.73531
+  hps: 22094.86669
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MedallionofMystifyingVapors-93257"
  value: {
-  dps: 388854.91879
-  tps: 468279.55057
-  hps: 21932.6718
+  dps: 394168.67628
+  tps: 478183.65998
+  hps: 22156.4701
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MedallionoftheCatacombs-83734"
  value: {
-  dps: 387171.73435
-  tps: 469026.02529
-  hps: 21868.61089
+  dps: 387749.12802
+  tps: 485142.89927
+  hps: 21971.36418
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MendingBadgeoftheShieldwall-93348"
  value: {
-  dps: 383499.41403
-  tps: 460281.69408
-  hps: 22288.59698
+  dps: 383111.4506
+  tps: 481701.73531
+  hps: 22478.7071
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorScope-4700"
  value: {
-  dps: 442773.64331
-  tps: 558493.85906
-  hps: 20572.5483
+  dps: 453655.33258
+  tps: 580835.54176
+  hps: 20935.40867
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MistdancerDefenderIdol-101089"
  value: {
-  dps: 385655.89789
-  tps: 471294.31259
-  hps: 21987.42223
+  dps: 384491.19251
+  tps: 472971.77793
+  hps: 22403.56661
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MistdancerDefenderStone-101087"
  value: {
-  dps: 391156.89144
-  tps: 470613.78488
-  hps: 22183.60133
+  dps: 394999.58945
+  tps: 474426.53101
+  hps: 22350.64692
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MistdancerIdolofRage-101113"
  value: {
-  dps: 395934.80681
-  tps: 490621.14877
-  hps: 22499.72195
+  dps: 400598.07104
+  tps: 485732.88668
+  hps: 22310.28285
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MistdancerStoneofRage-101117"
  value: {
-  dps: 401314.73728
-  tps: 493714.89488
-  hps: 22615.64926
+  dps: 405392.50961
+  tps: 486732.66579
+  hps: 22501.09999
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MistdancerStoneofWisdom-101107"
  value: {
-  dps: 383054.06756
-  tps: 466044.72056
-  hps: 22499.58274
+  dps: 385393.90661
+  tps: 474935.35681
+  hps: 22581.27304
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MithrilWristwatch-257884"
  value: {
-  dps: 388001.19215
-  tps: 463493.08599
-  hps: 21923.26918
+  dps: 388834.06538
+  tps: 477266.58503
+  hps: 22260.5267
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MountainsageIdolofDestruction-101069"
  value: {
-  dps: 388699.47749
-  tps: 477876.37228
-  hps: 21805.50331
+  dps: 389634.92741
+  tps: 489224.00547
+  hps: 21900.63169
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MountainsageStoneofDestruction-101072"
  value: {
-  dps: 393741.64197
-  tps: 461955.34143
-  hps: 22503.72044
+  dps: 398337.30702
+  tps: 481841.56071
+  hps: 22535.33875
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NitroBoosts-4223"
  value: {
-  dps: 458976.61857
-  tps: 603952.94341
-  hps: 21351.7182
+  dps: 467089.8883
+  tps: 579770.49747
+  hps: 21062.64681
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-OathswornDefenderIdol-101303"
  value: {
-  dps: 385075.77393
-  tps: 469839.88716
-  hps: 21943.3793
+  dps: 383722.58037
+  tps: 478265.62773
+  hps: 22172.97293
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-OathswornDefenderStone-101306"
  value: {
-  dps: 390245.22884
-  tps: 461095.96647
-  hps: 22109.49149
+  dps: 395833.24085
+  tps: 490577.70845
+  hps: 22110.92854
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-OathswornIdolofBattle-101295"
  value: {
-  dps: 391045.16255
-  tps: 479792.90988
-  hps: 21812.10803
+  dps: 394472.0748
+  tps: 483611.5707
+  hps: 22269.69478
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-OathswornStoneofBattle-101294"
  value: {
-  dps: 398291.10686
-  tps: 481069.542
-  hps: 22022.31361
+  dps: 401128.72036
+  tps: 483127.1478
+  hps: 22039.3415
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PhaseFingers-4697"
  value: {
-  dps: 416463.3754
-  tps: 435019.09186
-  hps: 22891.95317
+  dps: 418741.13615
+  tps: 433994.23839
+  hps: 23383.21606
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PouchofWhiteAsh-103639"
  value: {
-  dps: 384215.3436
-  tps: 463469.3733
-  hps: 21930.05218
+  dps: 382519.70237
+  tps: 478872.40785
+  hps: 22047.37508
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulPrimalDiamond"
  value: {
-  dps: 438354.73872
-  tps: 544876.12357
-  hps: 21462.79396
+  dps: 439646.73361
+  tps: 558915.45709
+  hps: 21409.13224
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PriceofProgress-81266"
  value: {
-  dps: 384126.8367
-  tps: 464490.62129
-  hps: 22279.51232
+  dps: 384424.42462
+  tps: 478001.80485
+  hps: 22385.78686
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PridefulGladiator'sBadgeofConquest-103342"
  value: {
-  dps: 401113.99644
-  tps: 490976.51618
-  hps: 22943.91593
+  dps: 403966.37084
+  tps: 501953.10842
+  hps: 22569.13998
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PridefulGladiator'sBadgeofDominance-103505"
  value: {
-  dps: 383481.87384
-  tps: 461027.38345
-  hps: 22739.56422
+  dps: 382988.2164
+  tps: 480627.80139
+  hps: 22924.50388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PridefulGladiator'sBadgeofVictory-103511"
  value: {
-  dps: 389866.20367
-  tps: 461887.25061
-  hps: 21812.13904
+  dps: 391873.25018
+  tps: 483777.42905
+  hps: 22119.69534
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PridefulGladiator'sEmblemofCruelty-103407"
  value: {
-  dps: 389219.56638
-  tps: 476659.29599
-  hps: 22113.16267
+  dps: 390711.72345
+  tps: 477225.98367
+  hps: 22548.87122
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PridefulGladiator'sEmblemofMeditation-103409"
  value: {
-  dps: 383778.35437
-  tps: 468814.37574
-  hps: 21869.60227
+  dps: 383679.39707
+  tps: 477085.862
+  hps: 22153.31889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PridefulGladiator'sEmblemofTenacity-103408"
  value: {
-  dps: 383778.35437
-  tps: 468814.37574
-  hps: 22087.77624
+  dps: 383679.39707
+  tps: 477085.862
+  hps: 22371.77056
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PridefulGladiator'sInsigniaofConquest-103347"
  value: {
-  dps: 413852.23599
-  tps: 495846.41888
-  hps: 23482.99751
+  dps: 417212.81831
+  tps: 505296.20917
+  hps: 23164.27238
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PridefulGladiator'sInsigniaofDominance-103506"
  value: {
-  dps: 384176.86082
-  tps: 464173.84778
-  hps: 23286.91538
+  dps: 384009.15519
+  tps: 472957.22893
+  hps: 23494.22999
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PridefulGladiator'sInsigniaofVictory-103516"
  value: {
-  dps: 388150.5035
-  tps: 470362.54968
-  hps: 21871.67893
+  dps: 395819.9555
+  tps: 482881.02411
+  hps: 22099.8009
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Primordius'TalismanofRage-96873"
  value: {
-  dps: 394055.85046
-  tps: 478480.07822
-  hps: 22354.46188
+  dps: 396796.80019
+  tps: 490985.6639
+  hps: 22615.04791
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PrismaticPrisonofPride-105474"
  value: {
-  dps: 403640.33629
-  tps: 467481.1057
-  hps: 22688.84478
+  dps: 403780.86535
+  tps: 470032.35518
+  hps: 22711.24641
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PurifiedBindingsofImmerseus-105422"
  value: {
-  dps: 403814.84329
-  tps: 465103.89253
-  hps: 24496.42254
+  dps: 403938.95203
+  tps: 469887.79881
+  hps: 24370.93584
  }
 }
 dps_results: {
@@ -1593,665 +1593,665 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-Qin-xi'sPolarizingSeal-87075"
  value: {
-  dps: 383197.64306
-  tps: 462436.57902
-  hps: 22318.23273
+  dps: 380888.71894
+  tps: 465329.85054
+  hps: 22277.81022
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RelicofChi-Ji-79330"
  value: {
-  dps: 381514.44624
-  tps: 469953.00493
-  hps: 22261.76597
+  dps: 382322.41266
+  tps: 466941.84119
+  hps: 22644.78015
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RelicofKypariZar-84075"
  value: {
-  dps: 384364.92175
-  tps: 449201.98965
-  hps: 22233.67586
+  dps: 385971.014
+  tps: 447510.13054
+  hps: 22652.40487
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RelicofNiuzao-79329"
  value: {
-  dps: 380494.36526
-  tps: 457707.55805
-  hps: 21753.27202
+  dps: 382924.70724
+  tps: 478058.15717
+  hps: 22201.67511
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RelicofXuen-79327"
  value: {
-  dps: 389947.4421
-  tps: 467033.07215
-  hps: 21853.78516
+  dps: 390795.72439
+  tps: 480222.02958
+  hps: 22126.84886
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RelicofXuen-79328"
  value: {
-  dps: 402328.73839
-  tps: 493088.12846
-  hps: 22931.96899
+  dps: 402959.60631
+  tps: 480448.85973
+  hps: 22822.34274
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RelicofYu'lon-79331"
  value: {
-  dps: 384126.8367
-  tps: 464490.62129
-  hps: 22342.43684
+  dps: 384424.42462
+  tps: 478001.80485
+  hps: 22450.22271
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Renataki'sSoulCharm-96741"
  value: {
-  dps: 411478.10492
-  tps: 494269.13862
-  hps: 23042.04673
+  dps: 412797.33061
+  tps: 501314.80518
+  hps: 22658.08546
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofNiuzao-103990"
  value: {
-  dps: 391069.2048
-  tps: 476029.9922
-  hps: 21799.36408
+  dps: 394532.9647
+  tps: 487616.52608
+  hps: 22208.82672
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReverberatingPrimalDiamond"
  value: {
-  dps: 448296.73052
-  tps: 557733.89514
-  hps: 21593.33949
+  dps: 449182.44264
+  tps: 571570.12026
+  hps: 21573.56713
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingPrimalDiamond"
  value: {
-  dps: 447280.76913
-  tps: 556422.20572
-  hps: 21593.33949
+  dps: 448166.26167
+  tps: 570241.57291
+  hps: 21573.56713
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofRe-Origination-96918"
  value: {
-  dps: 446033.15427
-  tps: 586306.7271
-  hps: 21033.7825
+  dps: 457029.00078
+  tps: 598923.44036
+  hps: 21074.71939
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SI:7Operative'sManual-92784"
  value: {
-  dps: 384215.3436
-  tps: 463469.3733
-  hps: 21930.05218
+  dps: 382519.70237
+  tps: 478872.40785
+  hps: 22047.37508
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ScrollofReveredAncestors-89080"
  value: {
-  dps: 383499.41403
-  tps: 460281.69408
-  hps: 22402.22701
+  dps: 383111.4506
+  tps: 481701.73531
+  hps: 22593.69442
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SearingWords-81267"
  value: {
-  dps: 399771.4595
-  tps: 489547.6509
-  hps: 22882.31415
+  dps: 398244.0492
+  tps: 489052.6173
+  hps: 22483.47045
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Shock-ChargerMedallion-93259"
  value: {
-  dps: 387862.74257
-  tps: 457113.00339
-  hps: 22775.32521
+  dps: 389036.72678
+  tps: 448402.24844
+  hps: 22782.46585
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SigilofCompassion-83736"
  value: {
-  dps: 387171.73435
-  tps: 469026.02529
-  hps: 21868.61089
+  dps: 387749.12802
+  tps: 485142.89927
+  hps: 21971.36418
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SigilofDevotion-83740"
  value: {
-  dps: 389255.43986
-  tps: 472601.92332
-  hps: 21969.0397
+  dps: 393571.10255
+  tps: 473869.98477
+  hps: 22264.03692
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SigilofFidelity-83737"
  value: {
-  dps: 387821.71764
-  tps: 452435.81683
-  hps: 22548.77039
+  dps: 388261.80657
+  tps: 447119.13878
+  hps: 22465.64083
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SigilofGrace-83738"
  value: {
-  dps: 386453.3062
-  tps: 457580.33672
-  hps: 22260.59524
+  dps: 385691.26081
+  tps: 463215.63825
+  hps: 22002.89705
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SigilofKypariZar-84076"
  value: {
-  dps: 387644.80121
-  tps: 471066.29087
-  hps: 22101.25726
+  dps: 393169.61275
+  tps: 479382.17367
+  hps: 22360.28562
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SigilofPatience-83739"
  value: {
-  dps: 387802.5377
-  tps: 469284.35106
-  hps: 22013.91218
+  dps: 393069.67762
+  tps: 477805.06529
+  hps: 22281.70602
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SigilofRampage-105580"
  value: {
-  dps: 418682.94229
-  tps: 487928.19901
-  hps: 23445.03633
+  dps: 423356.60477
+  tps: 500213.88988
+  hps: 23317.31704
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SigiloftheCatacombs-83732"
  value: {
-  dps: 385477.02827
-  tps: 461464.17946
-  hps: 22568.01871
+  dps: 390120.91944
+  tps: 460719.86618
+  hps: 22435.0991
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SinisterPrimalDiamond"
  value: {
-  dps: 442464.26632
-  tps: 552578.52235
-  hps: 21718.21877
+  dps: 440858.14575
+  tps: 555222.90484
+  hps: 21332.67566
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skeer'sBloodsoakedTalisman-105632"
  value: {
-  dps: 400780.99748
-  tps: 472871.8763
-  hps: 22844.55403
+  dps: 407062.66722
+  tps: 489279.27738
+  hps: 22807.32038
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SkullrenderMedallion-93256"
  value: {
-  dps: 395200.58746
-  tps: 479286.51546
-  hps: 22378.00523
+  dps: 393925.90161
+  tps: 466298.80771
+  hps: 22504.6293
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoothingTalismanoftheShado-PanAssault-94509"
  value: {
-  dps: 384128.41902
-  tps: 464493.87217
-  hps: 22556.88188
+  dps: 384426.00694
+  tps: 478004.06573
+  hps: 22671.23469
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulBarrier-96927"
  value: {
-  dps: 384126.8367
-  tps: 464490.62129
-  hps: 22116.82069
+  dps: 384424.42462
+  tps: 478001.80485
+  hps: 22244.41033
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SparkofZandalar-96770"
  value: {
-  dps: 396478.63316
-  tps: 462549.35845
-  hps: 22315.02957
+  dps: 398778.05658
+  tps: 468310.04689
+  hps: 22335.5518
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpiritsoftheSun-87163"
  value: {
-  dps: 383529.59682
-  tps: 459232.06107
-  hps: 22582.18261
+  dps: 382493.63529
+  tps: 470203.05067
+  hps: 22669.65419
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpringrainIdolofDestruction-101023"
  value: {
-  dps: 386675.93269
-  tps: 472855.50949
-  hps: 21852.34859
+  dps: 389402.71797
+  tps: 489857.94636
+  hps: 21922.56082
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpringrainIdolofRage-101009"
  value: {
-  dps: 400482.60773
-  tps: 481023.75462
-  hps: 22844.76168
+  dps: 402072.99238
+  tps: 485413.50526
+  hps: 22805.09749
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpringrainStoneofDestruction-101026"
  value: {
-  dps: 390532.3631
-  tps: 467693.79246
-  hps: 22286.38099
+  dps: 397051.07234
+  tps: 493490.98532
+  hps: 22433.63396
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpringrainStoneofRage-101012"
  value: {
-  dps: 401990.78298
-  tps: 489467.32997
-  hps: 22516.0415
+  dps: 404472.61203
+  tps: 497789.08711
+  hps: 22253.41906
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpringrainStoneofWisdom-101041"
  value: {
-  dps: 383051.00908
-  tps: 468464.43922
-  hps: 22382.8714
+  dps: 381406.27981
+  tps: 461645.261
+  hps: 22733.35269
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Static-Caster'sMedallion-93254"
  value: {
-  dps: 387862.74257
-  tps: 457113.00339
-  hps: 22775.32521
+  dps: 389036.72678
+  tps: 448402.24844
+  hps: 22782.46585
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SteadfastFootman'sMedallion-92782"
  value: {
-  dps: 383499.41403
-  tps: 460281.69408
-  hps: 21889.45245
+  dps: 383111.4506
+  tps: 481701.73531
+  hps: 22094.86669
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SteadfastTalismanoftheShado-PanAssault-94507"
  value: {
-  dps: 391401.55267
-  tps: 478304.53368
-  hps: 21854.4158
+  dps: 391529.20718
+  tps: 490295.34695
+  hps: 22094.41043
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StreamtalkerIdolofDestruction-101222"
  value: {
-  dps: 389985.458
-  tps: 474165.89823
-  hps: 21889.62954
+  dps: 389897.66859
+  tps: 482657.75027
+  hps: 22041.51272
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StreamtalkerIdolofRage-101217"
  value: {
-  dps: 398896.40989
-  tps: 487625.12285
-  hps: 22550.40976
+  dps: 405079.21018
+  tps: 485360.41264
+  hps: 22652.08027
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StreamtalkerStoneofDestruction-101225"
  value: {
-  dps: 392017.44937
-  tps: 473965.59979
-  hps: 22471.67263
+  dps: 395323.70652
+  tps: 478056.0862
+  hps: 22654.12199
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StreamtalkerStoneofRage-101220"
  value: {
-  dps: 406912.12994
-  tps: 496820.19478
-  hps: 22549.42543
+  dps: 408181.6413
+  tps: 492767.76312
+  hps: 22589.47212
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StreamtalkerStoneofWisdom-101250"
  value: {
-  dps: 384930.78101
-  tps: 461745.07092
-  hps: 22564.50488
+  dps: 384162.57667
+  tps: 474394.70901
+  hps: 22807.96624
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StuffofNightmares-87160"
  value: {
-  dps: 391771.05973
-  tps: 478052.35443
-  hps: 21898.9086
+  dps: 390762.37256
+  tps: 482569.28022
+  hps: 21960.09172
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SunsoulDefenderIdol-101160"
  value: {
-  dps: 386116.54498
-  tps: 467174.16382
-  hps: 22100.19467
+  dps: 384229.33375
+  tps: 475079.77119
+  hps: 22086.64717
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SunsoulDefenderStone-101163"
  value: {
-  dps: 392028.36416
-  tps: 473304.31117
-  hps: 22315.62181
+  dps: 397921.92691
+  tps: 480123.49407
+  hps: 22241.07617
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SunsoulIdolofBattle-101152"
  value: {
-  dps: 390848.76427
-  tps: 463525.69877
-  hps: 21903.31553
+  dps: 391152.51764
+  tps: 468775.85963
+  hps: 22100.86054
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SunsoulStoneofBattle-101151"
  value: {
-  dps: 397561.83354
-  tps: 493665.74298
-  hps: 21843.15749
+  dps: 401555.8056
+  tps: 481037.85288
+  hps: 22261.95737
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SunsoulStoneofWisdom-101138"
  value: {
-  dps: 384541.75214
-  tps: 465432.2987
-  hps: 22625.21192
+  dps: 383311.23819
+  tps: 465173.47343
+  hps: 22431.00059
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwordguardEmbroidery(Rank3)-4894"
  value: {
-  dps: 462632.04113
-  tps: 605752.04852
-  hps: 21263.30744
+  dps: 458334.55552
+  tps: 585967.47027
+  hps: 21073.61287
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymboloftheCatacombs-83735"
  value: {
-  dps: 388166.44778
-  tps: 466521.34812
-  hps: 22098.26854
+  dps: 391253.99671
+  tps: 478751.93178
+  hps: 22223.02449
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SynapseSprings(MarkII)-4898"
  value: {
-  dps: 416814.45045
-  tps: 437530.52174
-  hps: 23235.63186
+  dps: 420948.84
+  tps: 447636.92215
+  hps: 23295.81822
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofBloodlust-96864"
  value: {
-  dps: 403110.73687
-  tps: 456704.71907
-  hps: 22878.30239
+  dps: 409029.96554
+  tps: 460343.85148
+  hps: 23162.04275
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TerrorintheMists-87167"
  value: {
-  dps: 405080.13796
-  tps: 487107.31712
-  hps: 23100.30321
+  dps: 405469.70336
+  tps: 501837.86986
+  hps: 23039.70858
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Thok'sAcid-GroovedTooth-105607"
  value: {
-  dps: 385130.68391
-  tps: 465267.16056
-  hps: 22503.49512
+  dps: 387310.28931
+  tps: 472922.89538
+  hps: 22928.4998
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Thok'sTailTip-105609"
  value: {
-  dps: 414917.10312
-  tps: 481405.47127
-  hps: 22404.95618
+  dps: 419693.9114
+  tps: 483877.12779
+  hps: 22884.22874
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Thousand-YearPickledEgg-257881"
  value: {
-  dps: 385497.16085
-  tps: 471464.96993
-  hps: 22581.90292
+  dps: 382036.67359
+  tps: 452624.02173
+  hps: 22456.01437
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TickingEbonDetonator-105612"
  value: {
-  dps: 436822.13815
-  tps: 531237.17536
-  hps: 23731.33428
+  dps: 440204.95968
+  tps: 534296.78577
+  hps: 23828.67371
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Time-LostArtifact-103678"
  value: {
-  dps: 391726.87974
-  tps: 455564.58713
-  hps: 22094.08456
+  dps: 392397.20261
+  tps: 465447.33602
+  hps: 22061.28018
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrailseekerIdolofRage-101054"
  value: {
-  dps: 398468.97277
-  tps: 484561.88676
-  hps: 22640.56463
+  dps: 403132.26685
+  tps: 494038.46545
+  hps: 22720.24828
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrailseekerStoneofRage-101057"
  value: {
-  dps: 402085.97121
-  tps: 494890.50558
-  hps: 22573.31539
+  dps: 404973.6779
+  tps: 498325.6227
+  hps: 22437.74806
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TyrannicalGladiator'sBadgeofConquest-100043"
  value: {
-  dps: 391984.06586
-  tps: 479092.95872
-  hps: 22290.26484
+  dps: 392880.91862
+  tps: 483174.35044
+  hps: 22223.76864
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TyrannicalGladiator'sBadgeofDominance-100016"
  value: {
-  dps: 383479.74495
-  tps: 461027.00557
-  hps: 22443.69949
+  dps: 382986.61973
+  tps: 480627.80139
+  hps: 22622.81089
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TyrannicalGladiator'sBadgeofVictory-100019"
  value: {
-  dps: 387461.61206
-  tps: 463157.03858
-  hps: 21904.19173
+  dps: 389328.66339
+  tps: 477738.78471
+  hps: 22229.63578
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TyrannicalGladiator'sEmblemofCruelty-100066"
  value: {
-  dps: 388030.3518
-  tps: 470981.88482
-  hps: 21947.55225
+  dps: 389033.81281
+  tps: 481507.04652
+  hps: 22258.71356
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TyrannicalGladiator'sEmblemofMeditation-99990"
  value: {
-  dps: 383778.35437
-  tps: 468814.37574
-  hps: 21869.60227
+  dps: 383679.39707
+  tps: 477085.862
+  hps: 22153.31889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TyrannicalGladiator'sEmblemofTenacity-100092"
  value: {
-  dps: 383778.35437
-  tps: 468814.37574
-  hps: 22001.53267
+  dps: 383679.39707
+  tps: 477085.862
+  hps: 22285.41721
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TyrannicalGladiator'sInsigniaofConquest-100026"
  value: {
-  dps: 398989.39886
-  tps: 472412.10171
-  hps: 22866.25532
+  dps: 404433.0739
+  tps: 494828.90531
+  hps: 22383.46103
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TyrannicalGladiator'sInsigniaofDominance-100152"
  value: {
-  dps: 384714.18324
-  tps: 469695.22978
-  hps: 22639.22347
+  dps: 382803.85249
+  tps: 465362.71302
+  hps: 22781.69984
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TyrannicalGladiator'sInsigniaofVictory-100085"
  value: {
-  dps: 389165.70848
-  tps: 469729.45517
-  hps: 21818.44522
+  dps: 392521.63404
+  tps: 484282.28325
+  hps: 22014.43915
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TyrannicalPrimalDiamond"
  value: {
-  dps: 438354.73872
-  tps: 544876.12357
-  hps: 21432.02476
+  dps: 439646.73361
+  tps: 558915.45709
+  hps: 21378.31647
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnerringVisionofLeiShen-96930"
  value: {
-  dps: 384130.67989
-  tps: 464491.0226
-  hps: 22693.54352
+  dps: 384427.70259
+  tps: 478001.80485
+  hps: 22810.41068
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VaporshieldMedallion-93262"
  value: {
-  dps: 388854.91879
-  tps: 468279.55057
-  hps: 21932.6718
+  dps: 394168.67628
+  tps: 478183.65998
+  hps: 22156.4701
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofDragon'sBlood-87063"
  value: {
-  dps: 390952.40671
-  tps: 479490.91593
-  hps: 21810.03612
+  dps: 390196.78768
+  tps: 482623.37801
+  hps: 22079.53959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofIchorousBlood-100963"
  value: {
-  dps: 383393.05325
-  tps: 464421.13285
-  hps: 22208.46433
+  dps: 383452.02433
+  tps: 479210.66268
+  hps: 22458.92586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofLivingCorruption-105568"
  value: {
-  dps: 384126.8367
-  tps: 464490.62129
-  hps: 22201.89111
+  dps: 384424.42462
+  tps: 478001.80485
+  hps: 22329.9867
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousTalismanoftheShado-PanAssault-94511"
  value: {
-  dps: 399876.32391
-  tps: 485290.42456
-  hps: 22934.3875
+  dps: 402513.79047
+  tps: 490944.56775
+  hps: 22771.42664
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VisionofthePredator-81192"
  value: {
-  dps: 384427.9312
-  tps: 467723.97644
-  hps: 22318.01401
+  dps: 385230.88134
+  tps: 478422.70561
+  hps: 22394.18449
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VolatileTalismanoftheShado-PanAssault-94510"
  value: {
-  dps: 383850.53918
-  tps: 464628.44597
-  hps: 22535.4832
+  dps: 383922.72315
+  tps: 480171.74213
+  hps: 22540.42968
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WindsweptPages-81125"
  value: {
-  dps: 395975.48532
-  tps: 462676.88201
-  hps: 22419.586
+  dps: 398946.83979
+  tps: 478246.07348
+  hps: 22784.38028
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WoundripperMedallion-93253"
  value: {
-  dps: 402305.35814
-  tps: 489570.30866
-  hps: 22889.12189
+  dps: 400661.45873
+  tps: 472754.75243
+  hps: 22871.6896
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Wushoolay'sFinalChoice-96785"
  value: {
-  dps: 384241.52644
-  tps: 469549.50115
-  hps: 22171.20131
+  dps: 384402.73031
+  tps: 478207.69613
+  hps: 22059.81925
  }
 }
 dps_results: {
@@ -2265,25 +2265,25 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-Yu'lon'sBite-103987"
  value: {
-  dps: 383304.69214
-  tps: 457960.66258
-  hps: 22623.20725
+  dps: 385423.95932
+  tps: 477384.87516
+  hps: 23018.20676
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ZenAlchemistStone-75274"
  value: {
-  dps: 400768.54695
-  tps: 473349.91318
-  hps: 22786.98761
+  dps: 407405.07337
+  tps: 499212.51435
+  hps: 22861.80085
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 473980.83668
-  tps: 601034.17567
-  hps: 21957.0776
+  dps: 475152.27335
+  tps: 603080.68591
+  hps: 21894.91071
  }
 }
 dps_results: {
@@ -2577,289 +2577,289 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-DB-Incarn-NV-ExternalBleed-aoe-FullBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 2.15920762265e+06
-  tps: 3.02014052723e+06
-  hps: 5186.54374
+  dps: 2.20162959964e+06
+  tps: 3.13948968626e+06
+  hps: 5151.52937
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-DB-Incarn-NV-ExternalBleed-aoe-FullBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 346137.94631
-  tps: 588083.28569
-  hps: 5083.74443
+  dps: 344274.69408
+  tps: 581228.33009
+  hps: 5043.43163
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-DB-Incarn-NV-ExternalBleed-aoe-FullBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 466338.88703
-  tps: 485770.03514
-  hps: 5552.36514
+  dps: 474228.56259
+  tps: 507678.8599
+  hps: 5616.21999
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-DB-Incarn-NV-ExternalBleed-aoe-NoBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.57899173134e+06
-  tps: 2.08638235913e+06
-  hps: 4678.70444
+  dps: 1.58417882741e+06
+  tps: 2.17126234448e+06
+  hps: 4669.36811
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-DB-Incarn-NV-ExternalBleed-aoe-NoBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 246115.97015
-  tps: 444347.02658
-  hps: 4486.04986
+  dps: 250717.67306
+  tps: 462977.32073
+  hps: 4501.54932
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-DB-Incarn-NV-ExternalBleed-aoe-NoBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 291953.71485
-  tps: 417508.04686
-  hps: 4783.81102
+  dps: 298814.18688
+  tps: 434452.1416
+  hps: 4793.44715
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-DB-Incarn-NV-ExternalBleed-default-FullBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.14031172592e+06
-  tps: 1.68242262462e+06
-  hps: 5787.14276
+  dps: 1.17477595957e+06
+  tps: 1.75214186092e+06
+  hps: 5674.29658
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-DB-Incarn-NV-ExternalBleed-default-FullBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 410849.50499
-  tps: 548200.86626
-  hps: 5656.26767
+  dps: 415592.9198
+  tps: 559834.34687
+  hps: 5635.03659
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-DB-Incarn-NV-ExternalBleed-default-FullBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 570065.88001
-  tps: 499918.33633
-  hps: 7907.28303
+  dps: 582642.60547
+  tps: 510127.0087
+  hps: 8103.78228
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-DB-Incarn-NV-ExternalBleed-default-NoBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 777457.40038
-  tps: 1.15983260867e+06
-  hps: 5155.841
+  dps: 757517.99586
+  tps: 1.0951606236e+06
+  hps: 5159.66592
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-DB-Incarn-NV-ExternalBleed-default-NoBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 303706.5263
-  tps: 442093.21059
-  hps: 5058.07277
+  dps: 299290.1498
+  tps: 419708.43632
+  hps: 5009.11023
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-DB-Incarn-NV-ExternalBleed-default-NoBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 372879.27463
-  tps: 398756.08328
-  hps: 6611.88783
+  dps: 371121.93097
+  tps: 401931.04333
+  hps: 6722.98891
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-DefaultTalents-ExternalBleed-aoe-FullBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 2.20556032081e+06
-  tps: 2.87784197513e+06
-  hps: 15506.94433
+  dps: 2.21446182222e+06
+  tps: 2.86682462968e+06
+  hps: 15558.59395
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-DefaultTalents-ExternalBleed-aoe-FullBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 370278.17449
-  tps: 539505.53579
-  hps: 16208.55801
+  dps: 379838.00015
+  tps: 571633.22562
+  hps: 16088.53599
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-DefaultTalents-ExternalBleed-aoe-FullBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 498304.61471
-  tps: 485998.3633
-  hps: 17400.70342
+  dps: 498885.08603
+  tps: 484307.60601
+  hps: 17068.45435
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-DefaultTalents-ExternalBleed-aoe-NoBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.57310463249e+06
-  tps: 1.97977285781e+06
-  hps: 13140.35289
+  dps: 1.59791533706e+06
+  tps: 2.0571950487e+06
+  hps: 13175.32935
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-DefaultTalents-ExternalBleed-aoe-NoBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 271234.31179
-  tps: 437231.15553
-  hps: 14314.47704
+  dps: 272290.55198
+  tps: 430063.37339
+  hps: 14601.8395
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-DefaultTalents-ExternalBleed-aoe-NoBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 322471.09595
-  tps: 437725.13487
-  hps: 14786.27293
+  dps: 327936.76061
+  tps: 439333.15
+  hps: 14963.8818
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-DefaultTalents-ExternalBleed-default-FullBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.12920404346e+06
-  tps: 1.60848432921e+06
-  hps: 20972.95311
+  dps: 1.14498288819e+06
+  tps: 1.63506719608e+06
+  hps: 21240.09378
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-DefaultTalents-ExternalBleed-default-FullBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 464506.18298
-  tps: 571744.73137
-  hps: 21542.47699
+  dps: 463281.92022
+  tps: 583973.19417
+  hps: 21351.81487
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-DefaultTalents-ExternalBleed-default-FullBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 639989.87714
-  tps: 557451.22777
-  hps: 24816.29465
+  dps: 629762.20003
+  tps: 550420.1849
+  hps: 24758.29886
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-DefaultTalents-ExternalBleed-default-NoBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 745703.88384
-  tps: 978383.3746
-  hps: 18035.76206
+  dps: 739640.63768
+  tps: 947526.93805
+  hps: 18092.1206
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-DefaultTalents-ExternalBleed-default-NoBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 344636.4902
-  tps: 446959.88648
-  hps: 19110.6958
+  dps: 340084.7654
+  tps: 446659.12816
+  hps: 19111.75266
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-DefaultTalents-ExternalBleed-default-NoBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 413938.05665
-  tps: 379202.15115
-  hps: 21200.29486
+  dps: 415160.7635
+  tps: 411633.42012
+  hps: 21238.59965
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-WC-SotF-HotW-ExternalBleed-aoe-FullBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 2.29951219277e+06
-  tps: 3.25091137715e+06
-  hps: 5077.00117
+  dps: 2.31589125713e+06
+  tps: 3.22394658815e+06
+  hps: 5049.7799
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-WC-SotF-HotW-ExternalBleed-aoe-FullBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 359769.10703
-  tps: 595974.24337
-  hps: 4904.7785
+  dps: 363209.33027
+  tps: 603148.83339
+  hps: 4859.13083
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-WC-SotF-HotW-ExternalBleed-aoe-FullBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 466834.6974
-  tps: 528357.60759
-  hps: 5009.12319
+  dps: 470621.11481
+  tps: 512428.45453
+  hps: 4974.33687
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-WC-SotF-HotW-ExternalBleed-aoe-NoBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.66814820313e+06
-  tps: 2.17954548031e+06
-  hps: 4664.10974
+  dps: 1.66868915955e+06
+  tps: 2.16853822324e+06
+  hps: 4683.74875
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-WC-SotF-HotW-ExternalBleed-aoe-NoBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 258114.46133
-  tps: 463147.24142
-  hps: 4485.64611
+  dps: 266575.06888
+  tps: 460129.97769
+  hps: 4478.6752
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-WC-SotF-HotW-ExternalBleed-aoe-NoBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 306596.78349
-  tps: 447037.09821
-  hps: 4568.14656
+  dps: 313958.89728
+  tps: 456394.6446
+  hps: 4583.68226
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-WC-SotF-HotW-ExternalBleed-default-FullBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.07713546507e+06
-  tps: 1.51396588807e+06
-  hps: 4844.43696
+  dps: 1.08701412768e+06
+  tps: 1.52574268169e+06
+  hps: 4868.04844
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-WC-SotF-HotW-ExternalBleed-default-FullBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 420780.48312
-  tps: 524991.36491
-  hps: 4811.88549
+  dps: 425548.67314
+  tps: 538879.01649
+  hps: 4856.82615
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-WC-SotF-HotW-ExternalBleed-default-FullBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 586989.07384
-  tps: 488126.04185
-  hps: 5052.57478
+  dps: 579685.45562
+  tps: 482403.81309
+  hps: 4973.94277
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-WC-SotF-HotW-ExternalBleed-default-NoBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 741873.32688
-  tps: 955983.74922
-  hps: 4461.93267
+  dps: 727297.40071
+  tps: 929210.8202
+  hps: 4475.95427
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-WC-SotF-HotW-ExternalBleed-default-NoBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 310669.96263
-  tps: 393984.08006
-  hps: 4393.18109
+  dps: 314484.58403
+  tps: 408897.31212
+  hps: 4360.14637
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p5-WC-SotF-HotW-ExternalBleed-default-NoBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 389493.37283
-  tps: 328408.27211
-  hps: 4421.08917
+  dps: 387287.56836
+  tps: 326158.69468
+  hps: 4469.68862
  }
 }
 dps_results: {
@@ -3441,289 +3441,289 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-DB-Incarn-NV-ExternalBleed-aoe-FullBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 2.19560816936e+06
-  tps: 3.13280067073e+06
-  hps: 5169.02383
+  dps: 2.18507944907e+06
+  tps: 3.04605792877e+06
+  hps: 5118.95605
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-DB-Incarn-NV-ExternalBleed-aoe-FullBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 345505.58639
-  tps: 600175.71465
-  hps: 4991.77184
+  dps: 350706.89896
+  tps: 633688.81688
+  hps: 5099.08026
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-DB-Incarn-NV-ExternalBleed-aoe-FullBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 452953.64838
-  tps: 511123.4009
-  hps: 5495.09897
+  dps: 462875.52701
+  tps: 527832.64855
+  hps: 5484.8317
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-DB-Incarn-NV-ExternalBleed-aoe-NoBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.57819533795e+06
-  tps: 2.12421311522e+06
-  hps: 4685.99131
+  dps: 1.60073787771e+06
+  tps: 2.12391774696e+06
+  hps: 4659.8707
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-DB-Incarn-NV-ExternalBleed-aoe-NoBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 251724.88046
-  tps: 463099.70711
-  hps: 4535.6326
+  dps: 253390.9636
+  tps: 465715.39289
+  hps: 4507.5858
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-DB-Incarn-NV-ExternalBleed-aoe-NoBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 289000.86877
-  tps: 428824.71849
-  hps: 4772.97411
+  dps: 299025.75976
+  tps: 426143.10688
+  hps: 4745.68292
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-DB-Incarn-NV-ExternalBleed-default-FullBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.13157491003e+06
-  tps: 1.75698701917e+06
-  hps: 5647.63286
+  dps: 1.13499220555e+06
+  tps: 1.72126208017e+06
+  hps: 5665.51755
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-DB-Incarn-NV-ExternalBleed-default-FullBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 410079.28098
-  tps: 578184.31615
-  hps: 5641.56367
+  dps: 421159.06228
+  tps: 578939.77294
+  hps: 5621.03662
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-DB-Incarn-NV-ExternalBleed-default-FullBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 568368.18915
-  tps: 518437.39006
-  hps: 7954.76853
+  dps: 565875.41264
+  tps: 523852.06438
+  hps: 8053.99483
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-DB-Incarn-NV-ExternalBleed-default-NoBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 756686.54184
-  tps: 1.15860136044e+06
-  hps: 5055.49402
+  dps: 768559.21008
+  tps: 1.17845470246e+06
+  hps: 5069.19563
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-DB-Incarn-NV-ExternalBleed-default-NoBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 301349.50619
-  tps: 432778.86746
-  hps: 5099.74042
+  dps: 299369.20746
+  tps: 426977.10781
+  hps: 5137.84877
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-DB-Incarn-NV-ExternalBleed-default-NoBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 365926.83108
-  tps: 382807.59573
-  hps: 6840.95813
+  dps: 369357.91489
+  tps: 381705.47829
+  hps: 6901.90284
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-DefaultTalents-ExternalBleed-aoe-FullBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 2.21240098647e+06
-  tps: 2.96591677437e+06
-  hps: 15366.67792
+  dps: 2.21033046411e+06
+  tps: 2.9716006843e+06
+  hps: 15513.37435
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-DefaultTalents-ExternalBleed-aoe-FullBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 375457.62245
-  tps: 571377.95841
-  hps: 16509.42181
+  dps: 377479.68557
+  tps: 574338.23912
+  hps: 16558.59958
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-DefaultTalents-ExternalBleed-aoe-FullBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 489775.02443
-  tps: 493698.82829
-  hps: 17091.66508
+  dps: 491769.84228
+  tps: 481904.38349
+  hps: 17354.23656
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-DefaultTalents-ExternalBleed-aoe-NoBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.58660210448e+06
-  tps: 2.0315283749e+06
-  hps: 13326.25884
+  dps: 1.59661007957e+06
+  tps: 2.0465655409e+06
+  hps: 13483.1486
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-DefaultTalents-ExternalBleed-aoe-NoBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 275203.80142
-  tps: 438251.16083
-  hps: 14896.87799
+  dps: 279946.27872
+  tps: 446990.42169
+  hps: 14916.22919
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-DefaultTalents-ExternalBleed-aoe-NoBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 326305.96655
-  tps: 465966.66196
-  hps: 14862.29373
+  dps: 332057.12473
+  tps: 456521.71341
+  hps: 15520.62981
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-DefaultTalents-ExternalBleed-default-FullBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.12321268471e+06
-  tps: 1.56326963016e+06
-  hps: 21852.67611
+  dps: 1.12499967721e+06
+  tps: 1.57456227858e+06
+  hps: 21570.92585
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-DefaultTalents-ExternalBleed-default-FullBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 471796.04985
-  tps: 606041.89467
-  hps: 21620.17551
+  dps: 472636.16423
+  tps: 589936.30964
+  hps: 21703.01991
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-DefaultTalents-ExternalBleed-default-FullBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 631024.72141
-  tps: 571495.63793
-  hps: 25801.1502
+  dps: 640456.86652
+  tps: 587025.37677
+  hps: 25972.12589
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-DefaultTalents-ExternalBleed-default-NoBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 747095.44706
-  tps: 956601.09269
-  hps: 18150.10212
+  dps: 745903.88299
+  tps: 940267.33512
+  hps: 18096.49829
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-DefaultTalents-ExternalBleed-default-NoBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 336015.05085
-  tps: 437828.04805
-  hps: 18862.96494
+  dps: 340941.81103
+  tps: 445515.20304
+  hps: 18937.10799
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-DefaultTalents-ExternalBleed-default-NoBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 408414.85705
-  tps: 396549.19716
-  hps: 21113.04657
+  dps: 412595.44184
+  tps: 412934.05207
+  hps: 20906.25044
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-WC-SotF-HotW-ExternalBleed-aoe-FullBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 2.32208296934e+06
-  tps: 3.20801607176e+06
-  hps: 5086.27515
+  dps: 2.34998762574e+06
+  tps: 3.28384522156e+06
+  hps: 5072.23906
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-WC-SotF-HotW-ExternalBleed-aoe-FullBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 355679.23297
-  tps: 591300.54826
-  hps: 4949.93994
+  dps: 359101.07771
+  tps: 593543.12494
+  hps: 4915.39673
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-WC-SotF-HotW-ExternalBleed-aoe-FullBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 467606.95129
-  tps: 490215.24856
-  hps: 5079.9114
+  dps: 469231.74397
+  tps: 493400.32017
+  hps: 5114.08993
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-WC-SotF-HotW-ExternalBleed-aoe-NoBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.66549455112e+06
-  tps: 2.18383727452e+06
-  hps: 4725.13774
+  dps: 1.69731203794e+06
+  tps: 2.17587535693e+06
+  hps: 4703.38776
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-WC-SotF-HotW-ExternalBleed-aoe-NoBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 264529.16908
-  tps: 472033.38797
-  hps: 4453.97701
+  dps: 264743.34787
+  tps: 459660.37026
+  hps: 4524.72491
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-WC-SotF-HotW-ExternalBleed-aoe-NoBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 310428.92114
-  tps: 463758.4166
-  hps: 4552.61086
+  dps: 316285.79999
+  tps: 467210.50329
+  hps: 4633.27788
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-WC-SotF-HotW-ExternalBleed-default-FullBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.09502150959e+06
-  tps: 1.56203474475e+06
-  hps: 4867.66268
+  dps: 1.11101647963e+06
+  tps: 1.52916898403e+06
+  hps: 4902.07565
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-WC-SotF-HotW-ExternalBleed-default-FullBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 431769.80107
-  tps: 559600.00691
-  hps: 4829.92985
+  dps: 430045.86826
+  tps: 536894.79173
+  hps: 4848.8496
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-WC-SotF-HotW-ExternalBleed-default-FullBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 587079.60278
-  tps: 490539.671
-  hps: 4895.1867
+  dps: 585313.20788
+  tps: 488708.10199
+  hps: 4973.88074
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-WC-SotF-HotW-ExternalBleed-default-NoBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 740896.04119
-  tps: 942947.64502
-  hps: 4453.77199
+  dps: 748525.47361
+  tps: 953314.05685
+  hps: 4478.27094
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-WC-SotF-HotW-ExternalBleed-default-NoBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 315776.13801
-  tps: 398042.06479
-  hps: 4378.9828
+  dps: 309964.70693
+  tps: 390633.3461
+  hps: 4407.73272
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p5-WC-SotF-HotW-ExternalBleed-default-NoBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 386036.58945
-  tps: 325671.14707
-  hps: 4469.66042
+  dps: 382732.39608
+  tps: 322339.48003
+  hps: 4493.87556
  }
 }
 dps_results: {
@@ -4017,8 +4017,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 441548.49289
-  tps: 549959.41264
-  hps: 21023.77032
+  dps: 440066.6412
+  tps: 539333.74592
+  hps: 20982.83393
  }
 }

--- a/sim/druid/guardian/TestGuardian.results
+++ b/sim/druid/guardian/TestGuardian.results
@@ -888,10 +888,10 @@ dps_results: {
 dps_results: {
  key: "TestGuardian-AllItems-Fen-Yu,FuryofXuen-102248"
  value: {
-  dps: 346648.39274
-  tps: 2.12772112933e+06
-  dtps: 42538.50453
-  hps: 27103.98541
+  dps: 346253.30679
+  tps: 2.12389249968e+06
+  dtps: 43229.7178
+  hps: 28255.98318
  }
 }
 dps_results: {
@@ -987,10 +987,10 @@ dps_results: {
 dps_results: {
  key: "TestGuardian-AllItems-Gong-Lu,StrengthofXuen-102249"
  value: {
-  dps: 351910.19286
-  tps: 2.16545970528e+06
-  dtps: 44049.37726
-  hps: 27722.15863
+  dps: 351154.22295
+  tps: 2.15958121397e+06
+  dtps: 44241.92244
+  hps: 28492.36912
  }
 }
 dps_results: {

--- a/sim/hunter/beast_mastery/TestBeastMastery.results
+++ b/sim/hunter/beast_mastery/TestBeastMastery.results
@@ -33,1544 +33,1544 @@ character_stats_results: {
 dps_results: {
  key: "TestBeastMastery-AllItems-AgilePrimalDiamond"
  value: {
-  dps: 433482.92114
-  tps: 170396.61613
+  dps: 435948.79755
+  tps: 171683.54422
   hps: 17.83024
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-AlacrityofXuen-103989"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-ArcaneBadgeoftheShieldwall-93347"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-ArrowflightMedallion-93258"
  value: {
-  dps: 422028.00839
-  tps: 193587.52519
+  dps: 422406.01129
+  tps: 192939.21977
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-AssuranceofConsequence-105472"
  value: {
-  dps: 476300.42836
-  tps: 216483.91411
+  dps: 477164.98149
+  tps: 217065.14653
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-AusterePrimalDiamond"
  value: {
-  dps: 427991.20295
-  tps: 166433.66616
+  dps: 430260.84469
+  tps: 167452.50169
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-BadJuju-96781"
  value: {
-  dps: 445547.71204
-  tps: 198482.91284
+  dps: 447157.23298
+  tps: 198414.22636
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-BadgeofKypariZar-84079"
  value: {
-  dps: 415887.772
-  tps: 190179.01909
+  dps: 415808.25804
+  tps: 189643.37308
   hps: 18.07442
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-BattlegearoftheSaurokStalker"
  value: {
-  dps: 338314.1839
-  tps: 133961.07118
+  dps: 335707.45394
+  tps: 132827.5141
   hps: 17.51959
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-BattlegearoftheUnblinkingVigil"
  value: {
-  dps: 324985.28163
-  tps: 133699.79094
+  dps: 327692.56643
+  tps: 135025.26923
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-BlackBloodofY'Shaarj-105648"
  value: {
-  dps: 419038.45961
-  tps: 192587.33545
+  dps: 420073.66781
+  tps: 192946.96091
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-BlossomofPureSnow-89081"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-BottleofInfiniteStars-87057"
  value: {
-  dps: 433580.76456
-  tps: 194671.55658
+  dps: 433112.43561
+  tps: 194107.20331
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-BraidofTenSongs-84072"
  value: {
-  dps: 415182.375
-  tps: 189247.50434
+  dps: 415670.04272
+  tps: 189876.15821
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Brawler'sStatue-257885"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-BreathoftheHydra-96827"
  value: {
-  dps: 413447.70834
-  tps: 190585.82198
+  dps: 417303.26234
+  tps: 191649.03454
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-BroochofMunificentDeeds-87500"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-BrutalTalismanoftheShado-PanAssault-94508"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-BurningPrimalDiamond"
  value: {
-  dps: 431292.79433
-  tps: 169684.29146
+  dps: 433618.2056
+  tps: 170758.04615
   hps: 17.83024
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-CapacitivePrimalDiamond"
  value: {
-  dps: 466167.65475
-  tps: 206175.6732
+  dps: 466544.68529
+  tps: 205427.62387
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-CarbonicCarbuncle-81138"
  value: {
-  dps: 416480.22506
-  tps: 191438.59732
+  dps: 416340.97633
+  tps: 190925.80826
   hps: 18.14931
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Cha-Ye'sEssenceofBrilliance-96888"
  value: {
-  dps: 418089.47501
-  tps: 192408.03458
+  dps: 417228.19254
+  tps: 191495.51975
   hps: 17.84779
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-CharmofTenSongs-84071"
  value: {
-  dps: 413142.64167
-  tps: 189107.49105
+  dps: 416355.84959
+  tps: 191018.04011
   hps: 17.84779
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-CommunalIdolofDestruction-101168"
  value: {
-  dps: 414209.45743
-  tps: 189135.49344
+  dps: 414042.62535
+  tps: 187973.55637
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-CommunalStoneofDestruction-101171"
  value: {
-  dps: 417294.92478
-  tps: 188349.99471
+  dps: 418087.46035
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-CommunalStoneofWisdom-101183"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-ContemplationofChi-Ji-103988"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Coren'sColdChromiumCoaster-257880"
  value: {
-  dps: 425337.78832
-  tps: 194689.06887
+  dps: 425562.76993
+  tps: 193883.303
   hps: 17.84779
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-CoreofDecency-87497"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-CourageousPrimalDiamond"
  value: {
-  dps: 427991.20295
-  tps: 166433.66616
+  dps: 430260.84469
+  tps: 167452.50169
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-CraftedDreadfulGladiator'sBadgeofConquest-93419"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-CraftedDreadfulGladiator'sBadgeofDominance-93600"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-CraftedDreadfulGladiator'sBadgeofVictory-93606"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-CraftedDreadfulGladiator'sEmblemofCruelty-93485"
  value: {
-  dps: 412725.29446
-  tps: 190466.02269
+  dps: 413582.3738
+  tps: 189794.59949
   hps: 17.84779
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-CraftedDreadfulGladiator'sEmblemofMeditation-93487"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-CraftedDreadfulGladiator'sEmblemofTenacity-93486"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-CraftedDreadfulGladiator'sInsigniaofConquest-93424"
  value: {
-  dps: 423621.90853
-  tps: 194004.47969
+  dps: 423812.95779
+  tps: 193199.90156
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-CraftedDreadfulGladiator'sInsigniaofDominance-93601"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-CraftedDreadfulGladiator'sInsigniaofVictory-93611"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-CraftedMalevolentGladiator'sBadgeofConquest-98755"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-CraftedMalevolentGladiator'sBadgeofDominance-98910"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-CraftedMalevolentGladiator'sBadgeofVictory-98912"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-CraftedMalevolentGladiator'sEmblemofCruelty-98811"
  value: {
-  dps: 413674.64201
-  tps: 190812.65525
+  dps: 414037.54675
+  tps: 189945.83965
   hps: 17.84779
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-CraftedMalevolentGladiator'sEmblemofMeditation-98813"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-CraftedMalevolentGladiator'sEmblemofTenacity-98812"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-CraftedMalevolentGladiator'sInsigniaofConquest-98760"
  value: {
-  dps: 427136.72618
-  tps: 195112.92992
+  dps: 426171.59888
+  tps: 193496.27094
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-CraftedMalevolentGladiator'sInsigniaofDominance-98911"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-CraftedMalevolentGladiator'sInsigniaofVictory-98917"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-CurseofHubris-105645"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-CutstitcherMedallion-93255"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Daelo'sFinalWords-87496"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-DarkglowEmbroidery(Rank3)-4893"
  value: {
-  dps: 464178.6539
-  tps: 205057.22171
+  dps: 466013.81389
+  tps: 205363.01349
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-DarkmistVortex-87172"
  value: {
-  dps: 414980.58443
-  tps: 191403.75179
+  dps: 415423.29422
+  tps: 191230.78266
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-DeadeyeBadgeoftheShieldwall-93346"
  value: {
-  dps: 418221.90421
-  tps: 192252.17318
+  dps: 418614.95386
+  tps: 191965.93115
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-DelicateVialoftheSanguinaire-96895"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-DestructivePrimalDiamond"
  value: {
-  dps: 430076.44191
-  tps: 167323.147
+  dps: 432349.92028
+  tps: 168443.14302
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-DisciplineofXuen-103986"
  value: {
-  dps: 448281.14507
-  tps: 196386.22905
+  dps: 449293.99155
+  tps: 195339.47926
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Dominator'sArcaneBadge-93342"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Dominator'sDeadeyeBadge-93341"
  value: {
-  dps: 418221.90421
-  tps: 192252.17318
+  dps: 418614.95386
+  tps: 191965.93115
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Dominator'sDurableBadge-93345"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Dominator'sKnightlyBadge-93344"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Dominator'sMendingBadge-93343"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-DreadfulGladiator'sBadgeofConquest-84344"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-DreadfulGladiator'sBadgeofDominance-84488"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-DreadfulGladiator'sBadgeofVictory-84490"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-DreadfulGladiator'sEmblemofCruelty-84399"
  value: {
-  dps: 412725.29446
-  tps: 190466.02269
+  dps: 413582.3738
+  tps: 189794.59949
   hps: 17.84779
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-DreadfulGladiator'sEmblemofMeditation-84401"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-DreadfulGladiator'sEmblemofTenacity-84400"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-DreadfulGladiator'sInsigniaofConquest-84349"
  value: {
-  dps: 423645.04918
-  tps: 193658.17317
+  dps: 423668.95836
+  tps: 193104.22882
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-DreadfulGladiator'sInsigniaofDominance-84489"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-DreadfulGladiator'sInsigniaofVictory-84495"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-DurableBadgeoftheShieldwall-93350"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-DysmorphicSamophlangeofDiscontinuity-105615"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-EffulgentPrimalDiamond"
  value: {
-  dps: 427991.20295
-  tps: 166433.66616
+  dps: 430260.84469
+  tps: 167452.50169
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-EmberPrimalDiamond"
  value: {
-  dps: 427991.20295
-  tps: 166433.66616
+  dps: 430260.84469
+  tps: 167452.50169
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-EmblemofKypariZar-84077"
  value: {
-  dps: 415250.32661
-  tps: 190407.83385
+  dps: 416562.63871
+  tps: 192706.83238
   hps: 17.84779
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-EmblemoftheCatacombs-83733"
  value: {
-  dps: 415463.90738
-  tps: 190390.63667
+  dps: 413041.45346
+  tps: 188182.10199
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-EmptyFruitBarrel-81133"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-EnchantWeapon-BloodyDancingSteel-5125"
  value: {
-  dps: 463257.65985
-  tps: 205124.56175
+  dps: 464414.57431
+  tps: 204962.08731
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-EnchantWeapon-Colossus-4445"
  value: {
-  dps: 453465.02392
-  tps: 201676.41729
+  dps: 455412.09023
+  tps: 201640.5469
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-EnchantWeapon-DancingSteel-4444"
  value: {
-  dps: 463314.18771
-  tps: 205051.74064
+  dps: 464098.40294
+  tps: 204868.24228
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-EnchantWeapon-ElementalForce-4443"
  value: {
-  dps: 452337.32633
-  tps: 201321.79332
+  dps: 456082.5551
+  tps: 202370.99885
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-EnchantWeapon-JadeSpirit-4442"
  value: {
-  dps: 453465.02392
-  tps: 201676.41729
+  dps: 455412.09023
+  tps: 201640.5469
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-EnchantWeapon-River'sSong-4446"
  value: {
-  dps: 453465.02392
-  tps: 201676.41729
+  dps: 455412.09023
+  tps: 201640.5469
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-EnchantWeapon-SpiritofConquest-5124"
  value: {
-  dps: 453465.02392
-  tps: 201676.41729
+  dps: 455412.09023
+  tps: 201640.5469
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-EnchantWeapon-Windsong-4441"
  value: {
-  dps: 461240.11128
-  tps: 203477.70335
+  dps: 461929.48187
+  tps: 202874.99088
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-EnigmaticPrimalDiamond"
  value: {
-  dps: 430076.44191
-  tps: 167323.147
+  dps: 432349.92028
+  tps: 168443.14302
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-EssenceofTerror-87175"
  value: {
-  dps: 412037.17106
-  tps: 190400.91758
+  dps: 412930.50263
+  tps: 189518.43204
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-EternalPrimalDiamond"
  value: {
-  dps: 427991.20295
-  tps: 166433.66616
+  dps: 430260.84469
+  tps: 167452.50169
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-EvilEyeofGalakras-105491"
  value: {
-  dps: 408657.61162
-  tps: 188349.99471
+  dps: 409357.96879
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-FabledFeatherofJi-Kun-96842"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409357.96879
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-FearwurmBadge-84074"
  value: {
-  dps: 415636.72852
-  tps: 191059.66258
+  dps: 414624.4911
+  tps: 190713.24933
   hps: 17.84779
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-FearwurmRelic-84070"
  value: {
-  dps: 416583.59262
-  tps: 191517.7618
+  dps: 415741.03868
+  tps: 191116.30409
   hps: 17.84779
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-FelsoulIdolofDestruction-101263"
  value: {
-  dps: 415714.66222
-  tps: 189635.33269
+  dps: 415048.61588
+  tps: 188343.0565
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-FelsoulStoneofDestruction-101266"
  value: {
-  dps: 417452.41596
-  tps: 188349.99471
+  dps: 418130.5657
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-FlashfrozenResinGlobule-100951"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-FlashingSteelTalisman-81265"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-FleetPrimalDiamond"
  value: {
-  dps: 430300.59526
-  tps: 166433.66616
+  dps: 432580.98057
+  tps: 167452.50169
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-ForlornPrimalDiamond"
  value: {
-  dps: 427991.20295
-  tps: 166433.66616
+  dps: 430260.84469
+  tps: 167452.50169
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-FortitudeoftheZandalari-96793"
  value: {
-  dps: 416831.49935
-  tps: 188349.99471
+  dps: 417569.38895
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-FrenziedCrystalofRage-105572"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Fusion-FireCore-105459"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-GazeoftheTwins-96915"
  value: {
-  dps: 419066.47226
-  tps: 192736.7187
-  hps: 17.66285
+  dps: 419505.717
+  tps: 192741.17541
+  hps: 18.191
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Gerp'sPerfectArrow-87495"
  value: {
-  dps: 412265.72159
-  tps: 190043.41664
+  dps: 412689.67064
+  tps: 189404.39052
   hps: 17.84779
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 342765.30593
-  tps: 135750.39793
+  dps: 344825.64077
+  tps: 136526.48553
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Gong-Lu,StrengthofXuen-102249"
  value: {
-  dps: 440939.6942
-  tps: 196159.69892
+  dps: 441081.60553
+  tps: 196837.83355
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-GrievousGladiator'sBadgeofConquest-103145"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-GrievousGladiator'sBadgeofDominance-103308"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-GrievousGladiator'sBadgeofVictory-103314"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-GrievousGladiator'sEmblemofCruelty-103210"
  value: {
-  dps: 416511.38598
-  tps: 191809.9279
+  dps: 416295.71107
+  tps: 191120.57368
   hps: 17.84779
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-GrievousGladiator'sEmblemofMeditation-103212"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-GrievousGladiator'sEmblemofTenacity-103211"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-GrievousGladiator'sInsigniaofConquest-103150"
  value: {
-  dps: 435532.91656
-  tps: 198161.86344
+  dps: 434498.02827
+  tps: 196787.67873
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-GrievousGladiator'sInsigniaofDominance-103309"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-GrievousGladiator'sInsigniaofVictory-103319"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Haromm'sTalisman-105527"
  value: {
-  dps: 457285.29205
-  tps: 212710.96309
+  dps: 458456.92383
+  tps: 213313.76172
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Hawkmaster'sTalon-89082"
  value: {
-  dps: 421303.76136
-  tps: 193289.10168
+  dps: 421503.32923
+  tps: 192689.84296
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Heart-LesionDefenderIdol-100999"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Heart-LesionDefenderStone-101002"
  value: {
-  dps: 417244.68866
-  tps: 188349.99471
+  dps: 418063.15925
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Heart-LesionIdolofBattle-100991"
  value: {
-  dps: 414174.9529
-  tps: 190987.07088
+  dps: 414301.94747
+  tps: 190059.23007
   hps: 17.84779
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Heart-LesionStoneofBattle-100990"
  value: {
-  dps: 417442.73395
-  tps: 188349.99471
+  dps: 418024.89149
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-HeartofFire-81181"
  value: {
-  dps: 412612.35637
-  tps: 188349.99471
+  dps: 413332.23317
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-HeartwarmerMedallion-93260"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-HelmbreakerMedallion-93261"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Horridon'sLastGasp-96757"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-ImpassivePrimalDiamond"
  value: {
-  dps: 430076.44191
-  tps: 167323.147
+  dps: 432349.92028
+  tps: 168443.14302
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-IndomitablePrimalDiamond"
  value: {
-  dps: 427991.20295
-  tps: 166433.66616
+  dps: 430260.84469
+  tps: 167452.50169
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-InscribedBagofHydra-Spawn-96828"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-InsigniaofKypariZar-84078"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-IronBellyWok-89083"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-IronProtectorTalisman-85181"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-JadeBanditFigurine-86772"
  value: {
-  dps: 419785.10822
-  tps: 192696.22751
+  dps: 420297.62744
+  tps: 192377.7051
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-JadeCharioteerFigurine-86771"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-JadeCourtesanFigurine-86774"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-JadeMagistrateFigurine-86773"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-JadeWarlordFigurine-86775"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Ji-Kun'sRisingWinds-96843"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Juggernaut'sFocusingCrystal-105514"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
-  hps: 6095.03207
+  dps: 409366.62992
+  tps: 188070.24446
+  hps: 6087.78468
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Kardris'ToxicTotem-105540"
  value: {
-  dps: 418172.11418
-  tps: 198049.30396
+  dps: 419963.66531
+  tps: 198657.70846
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-KnightlyBadgeoftheShieldwall-93349"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-KnotofTenSongs-84073"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Kor'kronBookofHurting-92785"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Lao-Chin'sLiquidCourage-89079"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-LeiShen'sFinalOrders-87072"
  value: {
-  dps: 414310.33582
-  tps: 190178.05586
+  dps: 414007.13098
+  tps: 189481.21318
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-LessonsoftheDarkmaster-81268"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-LightdrinkerIdolofRage-101200"
  value: {
-  dps: 429388.91156
-  tps: 194058.79508
+  dps: 428998.99024
+  tps: 193290.95379
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-LightdrinkerStoneofRage-101203"
  value: {
-  dps: 429788.31028
-  tps: 193002.11393
+  dps: 430047.61693
+  tps: 192461.76018
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-LightoftheCosmos-87065"
  value: {
-  dps: 414310.33582
-  tps: 190178.05586
+  dps: 414007.13098
+  tps: 189481.21318
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-LightweaveEmbroidery(Rank3)-4892"
  value: {
-  dps: 464178.6539
-  tps: 205057.22171
+  dps: 466013.81389
+  tps: 205363.01349
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-MalevolentGladiator'sBadgeofConquest-91452"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-MalevolentGladiator'sBadgeofDominance-91753"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-MalevolentGladiator'sBadgeofVictory-91763"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-MalevolentGladiator'sEmblemofCruelty-91562"
  value: {
-  dps: 413674.64201
-  tps: 190812.65525
+  dps: 414037.54675
+  tps: 189945.83965
   hps: 17.84779
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-MalevolentGladiator'sEmblemofMeditation-91564"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-MalevolentGladiator'sEmblemofTenacity-91563"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-MalevolentGladiator'sInsigniaofConquest-91457"
  value: {
-  dps: 426702.01686
-  tps: 195068.96416
+  dps: 425942.05553
+  tps: 193734.67953
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-MalevolentGladiator'sInsigniaofDominance-91754"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-MalevolentGladiator'sInsigniaofVictory-91768"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-MarkoftheCatacombs-83731"
  value: {
-  dps: 415010.56921
-  tps: 189835.60184
+  dps: 415462.53934
+  tps: 189201.04124
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-MarkoftheHardenedGrunt-92783"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-MedallionofMystifyingVapors-93257"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-MedallionoftheCatacombs-83734"
  value: {
-  dps: 411540.08799
-  tps: 188349.99471
+  dps: 412255.38695
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-MendingBadgeoftheShieldwall-93348"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-MirrorScope-4700"
  value: {
-  dps: 456009.55941
-  tps: 201999.61148
+  dps: 456611.1421
+  tps: 202216.68447
   hps: 17.84779
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-MistdancerDefenderIdol-101089"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-MistdancerDefenderStone-101087"
  value: {
-  dps: 417538.85853
-  tps: 188349.99471
+  dps: 418306.57049
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-MistdancerIdolofRage-101113"
  value: {
-  dps: 429470.71205
-  tps: 193885.76628
+  dps: 429640.1823
+  tps: 193482.57467
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-MistdancerStoneofRage-101117"
  value: {
-  dps: 429359.89096
-  tps: 193002.11393
+  dps: 429745.14865
+  tps: 192461.76018
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-MistdancerStoneofWisdom-101107"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-MithrilWristwatch-257884"
  value: {
-  dps: 414505.80028
-  tps: 191174.18963
+  dps: 414653.68855
+  tps: 190234.17493
   hps: 17.84779
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-MountainsageIdolofDestruction-101069"
  value: {
-  dps: 414259.92644
-  tps: 190042.76532
+  dps: 417451.65653
+  tps: 190178.90501
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-MountainsageStoneofDestruction-101072"
  value: {
-  dps: 417218.62793
-  tps: 188349.99471
+  dps: 418086.32363
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-NitroBoosts-4223"
  value: {
-  dps: 466167.65475
-  tps: 206175.6732
+  dps: 466544.68529
+  tps: 205427.62387
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-OathswornDefenderIdol-101303"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-OathswornDefenderStone-101306"
  value: {
-  dps: 417443.90405
-  tps: 188349.99471
+  dps: 418401.52266
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-OathswornIdolofBattle-101295"
  value: {
-  dps: 414174.9529
-  tps: 190987.07088
+  dps: 414301.94747
+  tps: 190059.23007
   hps: 17.84779
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-OathswornStoneofBattle-101294"
  value: {
-  dps: 417190.75579
-  tps: 188349.99471
+  dps: 418083.1219
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-PhaseFingers-4697"
  value: {
-  dps: 466487.74511
-  tps: 207193.52863
+  dps: 465986.20182
+  tps: 205765.92345
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-PouchofWhiteAsh-103639"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-PowerfulPrimalDiamond"
  value: {
-  dps: 427991.20295
-  tps: 166433.66616
+  dps: 430260.84469
+  tps: 167452.50169
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-PriceofProgress-81266"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-PridefulGladiator'sBadgeofConquest-103342"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-PridefulGladiator'sBadgeofDominance-103505"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-PridefulGladiator'sBadgeofVictory-103511"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-PridefulGladiator'sEmblemofCruelty-103407"
  value: {
-  dps: 418484.31076
-  tps: 192865.12417
+  dps: 417764.51891
+  tps: 191971.9981
   hps: 18.07442
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-PridefulGladiator'sEmblemofMeditation-103409"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-PridefulGladiator'sEmblemofTenacity-103408"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-PridefulGladiator'sInsigniaofConquest-103347"
  value: {
-  dps: 444249.39531
-  tps: 200874.29341
+  dps: 442964.02139
+  tps: 199613.54143
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-PridefulGladiator'sInsigniaofDominance-103506"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-PridefulGladiator'sInsigniaofVictory-103516"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Primordius'TalismanofRage-96873"
  value: {
-  dps: 418065.41404
-  tps: 192408.03458
+  dps: 417219.53141
+  tps: 191495.51975
   hps: 17.84779
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-PrismaticPrisonofPride-105474"
  value: {
-  dps: 423283.99448
-  tps: 194770.95448
+  dps: 423058.70871
+  tps: 195252.94659
   hps: 17.89603
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-PurifiedBindingsofImmerseus-105422"
  value: {
-  dps: 423283.99448
-  tps: 194770.95448
+  dps: 423058.70871
+  tps: 195252.94659
   hps: 17.89603
  }
 }
@@ -1593,672 +1593,672 @@ dps_results: {
 dps_results: {
  key: "TestBeastMastery-AllItems-Qin-xi'sPolarizingSeal-87075"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-RelicofChi-Ji-79330"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-RelicofKypariZar-84075"
  value: {
-  dps: 415351.60648
-  tps: 191239.38337
+  dps: 414002.04867
+  tps: 190241.42631
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-RelicofNiuzao-79329"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-RelicofXuen-79327"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-RelicofXuen-79328"
  value: {
-  dps: 432152.64028
-  tps: 197274.50179
+  dps: 430772.17513
+  tps: 195611.1982
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-RelicofYu'lon-79331"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Renataki'sSoulCharm-96741"
  value: {
-  dps: 437314.18657
-  tps: 198938.97219
+  dps: 435664.82686
+  tps: 197967.09694
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-ResolveofNiuzao-103990"
  value: {
-  dps: 416388.60589
-  tps: 188349.99471
+  dps: 417124.60464
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-ReverberatingPrimalDiamond"
  value: {
-  dps: 431292.79433
-  tps: 169684.29146
+  dps: 433618.2056
+  tps: 170758.04615
   hps: 17.83024
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-RevitalizingPrimalDiamond"
  value: {
-  dps: 431292.79433
-  tps: 169684.29146
+  dps: 433618.2056
+  tps: 170758.04615
   hps: 17.83024
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-RuneofRe-Origination-96918"
  value: {
-  dps: 441554.85979
-  tps: 207228.02096
-  hps: 16.3387
+  dps: 443009.38843
+  tps: 206924.16967
+  hps: 16.15976
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-SI:7Operative'sManual-92784"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-ScrollofReveredAncestors-89080"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-SearingWords-81267"
  value: {
-  dps: 428356.46396
-  tps: 195928.72466
+  dps: 427519.82942
+  tps: 195179.49166
   hps: 17.84779
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Shock-ChargerMedallion-93259"
  value: {
-  dps: 413487.54856
-  tps: 189280.71947
+  dps: 413675.67584
+  tps: 189524.23488
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-SigilofCompassion-83736"
  value: {
-  dps: 411534.00833
-  tps: 188349.99471
+  dps: 412246.61066
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-SigilofDevotion-83740"
  value: {
-  dps: 415662.0804
-  tps: 189835.60184
+  dps: 416056.50349
+  tps: 189201.04124
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-SigilofFidelity-83737"
  value: {
-  dps: 415722.04704
-  tps: 191764.61768
+  dps: 413864.06574
+  tps: 189748.34468
   hps: 18.07442
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-SigilofGrace-83738"
  value: {
-  dps: 412669.35876
-  tps: 189355.26187
+  dps: 415639.52898
+  tps: 189204.81172
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-SigilofKypariZar-84076"
  value: {
-  dps: 415781.32342
-  tps: 189889.72936
+  dps: 416301.17444
+  tps: 189331.30986
   hps: 17.84779
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-SigilofPatience-83739"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-SigilofRampage-105580"
  value: {
-  dps: 449276.73023
-  tps: 202430.42563
+  dps: 450153.54124
+  tps: 203502.55671
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-SigiloftheCatacombs-83732"
  value: {
-  dps: 413596.21056
-  tps: 190762.63163
+  dps: 415386.18808
+  tps: 191551.16407
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-SinisterPrimalDiamond"
  value: {
-  dps: 429320.91815
-  tps: 166972.53406
+  dps: 431772.9967
+  tps: 168195.5326
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Skeer'sBloodsoakedTalisman-105632"
  value: {
-  dps: 420198.15475
-  tps: 194861.47132
+  dps: 420542.20005
+  tps: 194219.75895
   hps: 17.95939
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-SkullrenderMedallion-93256"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-SoothingTalismanoftheShado-PanAssault-94509"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-SoulBarrier-96927"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-SparkofZandalar-96770"
  value: {
-  dps: 413447.70834
-  tps: 190585.82198
+  dps: 417303.26234
+  tps: 191649.03454
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-SpiritsoftheSun-87163"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-SpringrainIdolofDestruction-101023"
  value: {
-  dps: 415161.32089
-  tps: 188969.77408
+  dps: 416861.16359
+  tps: 190771.29394
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-SpringrainIdolofRage-101009"
  value: {
-  dps: 429952.93075
-  tps: 193902.49709
+  dps: 429109.67304
+  tps: 193084.283
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-SpringrainStoneofDestruction-101026"
  value: {
-  dps: 417363.45568
-  tps: 188349.99471
+  dps: 418177.45088
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-SpringrainStoneofRage-101012"
  value: {
-  dps: 429390.45374
-  tps: 193002.11393
+  dps: 429843.92284
+  tps: 192461.76018
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-SpringrainStoneofWisdom-101041"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Static-Caster'sMedallion-93254"
  value: {
-  dps: 413487.54856
-  tps: 189280.71947
+  dps: 413675.67584
+  tps: 189524.23488
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-SteadfastFootman'sMedallion-92782"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-SteadfastTalismanoftheShado-PanAssault-94507"
  value: {
-  dps: 415502.81896
-  tps: 188349.99471
+  dps: 416235.03602
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-StreamtalkerIdolofDestruction-101222"
  value: {
-  dps: 416557.42602
-  tps: 189955.66575
+  dps: 416184.25938
+  tps: 188848.64315
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-StreamtalkerIdolofRage-101217"
  value: {
-  dps: 429570.62516
-  tps: 194285.12818
+  dps: 429225.3862
+  tps: 193267.73306
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-StreamtalkerStoneofDestruction-101225"
  value: {
-  dps: 417370.13714
-  tps: 188349.99471
+  dps: 418132.54119
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-StreamtalkerStoneofRage-101220"
  value: {
-  dps: 429461.93835
-  tps: 193002.11393
+  dps: 429805.31683
+  tps: 192461.76018
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-StreamtalkerStoneofWisdom-101250"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-StuffofNightmares-87160"
  value: {
-  dps: 414724.25888
-  tps: 188349.99471
+  dps: 415453.15203
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-SunsoulDefenderIdol-101160"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-SunsoulDefenderStone-101163"
  value: {
-  dps: 417616.76363
-  tps: 188349.99471
+  dps: 418247.1332
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-SunsoulIdolofBattle-101152"
  value: {
-  dps: 414174.9529
-  tps: 190987.07088
+  dps: 414301.94747
+  tps: 190059.23007
   hps: 17.84779
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-SunsoulStoneofBattle-101151"
  value: {
-  dps: 417305.00589
-  tps: 188349.99471
+  dps: 418013.61299
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-SunsoulStoneofWisdom-101138"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-SwordguardEmbroidery(Rank3)-4894"
  value: {
-  dps: 469514.28355
-  tps: 206706.06355
+  dps: 471400.29667
+  tps: 207008.21502
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-SymboloftheCatacombs-83735"
  value: {
-  dps: 416064.91046
-  tps: 190445.08221
+  dps: 415364.06472
+  tps: 189409.08235
   hps: 18.07442
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-SynapseSprings(MarkII)-4898"
  value: {
-  dps: 474883.65725
-  tps: 210053.9044
+  dps: 475773.31649
+  tps: 209084.69212
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-TalismanofBloodlust-96864"
  value: {
-  dps: 435560.95548
-  tps: 198618.00206
+  dps: 437635.35456
+  tps: 200556.80743
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-TerrorintheMists-87167"
  value: {
-  dps: 435733.2866
-  tps: 199023.85115
-  hps: 19.3748
+  dps: 436640.52919
+  tps: 199355.45319
+  hps: 19.87759
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-TheGloamingBlade-88149"
  value: {
-  dps: 466167.65475
-  tps: 206175.6732
+  dps: 466544.68529
+  tps: 205427.62387
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Thok'sAcid-GroovedTooth-105607"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Thok'sTailTip-105609"
  value: {
-  dps: 423283.99448
-  tps: 194770.95448
+  dps: 423058.70871
+  tps: 195252.94659
   hps: 17.89603
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Thousand-YearPickledEgg-257881"
  value: {
-  dps: 408366.49114
-  tps: 188413.35963
+  dps: 409825.15539
+  tps: 188496.29547
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-TickingEbonDetonator-105612"
  value: {
-  dps: 461071.18119
-  tps: 202066.74204
+  dps: 463033.2774
+  tps: 202261.00305
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Time-LostArtifact-103678"
  value: {
-  dps: 422042.35036
-  tps: 191767.4497
+  dps: 424389.71339
+  tps: 193435.80546
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-TrailseekerIdolofRage-101054"
  value: {
-  dps: 429505.82197
-  tps: 193926.53247
+  dps: 429422.25445
+  tps: 193118.95286
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-TrailseekerStoneofRage-101057"
  value: {
-  dps: 429331.19737
-  tps: 193002.11393
+  dps: 429831.85912
+  tps: 192461.76018
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-TyrannicalGladiator'sBadgeofConquest-100043"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-TyrannicalGladiator'sBadgeofDominance-100016"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-TyrannicalGladiator'sBadgeofVictory-100019"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-TyrannicalGladiator'sEmblemofCruelty-100066"
  value: {
-  dps: 414721.25356
-  tps: 191318.70318
+  dps: 415001.41446
+  tps: 190661.9392
   hps: 17.84779
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-TyrannicalGladiator'sEmblemofMeditation-99990"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-TyrannicalGladiator'sEmblemofTenacity-100092"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-TyrannicalGladiator'sInsigniaofConquest-100026"
  value: {
-  dps: 430876.97561
-  tps: 196587.1078
+  dps: 429577.25902
+  tps: 195011.64775
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-TyrannicalGladiator'sInsigniaofDominance-100152"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-TyrannicalGladiator'sInsigniaofVictory-100085"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-TyrannicalPrimalDiamond"
  value: {
-  dps: 427991.20295
-  tps: 166433.66616
+  dps: 430260.84469
+  tps: 167452.50169
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-UnerringVisionofLeiShen-96930"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-VaporshieldMedallion-93262"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-VialofDragon'sBlood-87063"
  value: {
-  dps: 414341.97189
-  tps: 188349.99471
+  dps: 415069.23294
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-VialofIchorousBlood-100963"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-VialofLivingCorruption-105568"
  value: {
-  dps: 408663.6115
-  tps: 188349.99471
+  dps: 409366.62992
+  tps: 188070.24446
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-ViciousTalismanoftheShado-PanAssault-94511"
  value: {
-  dps: 441065.95367
-  tps: 198906.01292
+  dps: 442191.9361
+  tps: 198886.70132
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-VisionofthePredator-81192"
  value: {
-  dps: 413112.49901
-  tps: 190577.8583
+  dps: 413083.93959
+  tps: 189401.83293
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-VolatileTalismanoftheShado-PanAssault-94510"
  value: {
-  dps: 408230.63009
-  tps: 187400.61093
+  dps: 410431.26422
+  tps: 188850.31942
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-WindsweptPages-81125"
  value: {
-  dps: 424239.23381
-  tps: 194350.93583
+  dps: 426695.68423
+  tps: 196516.36669
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-WoundripperMedallion-93253"
  value: {
-  dps: 422028.00839
-  tps: 193587.52519
+  dps: 422406.01129
+  tps: 192939.21977
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Wushoolay'sFinalChoice-96785"
  value: {
-  dps: 408657.61162
-  tps: 188349.99471
+  dps: 409357.96879
+  tps: 188070.24446
   hps: 17.66285
  }
 }
@@ -2273,342 +2273,342 @@ dps_results: {
 dps_results: {
  key: "TestBeastMastery-AllItems-YaungolFireCarrier-86518"
  value: {
-  dps: 466167.65475
-  tps: 206175.6732
+  dps: 466544.68529
+  tps: 205427.62387
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-YaungolSlayerBattlegear"
  value: {
-  dps: 316260.55328
-  tps: 125497.81214
+  dps: 315058.77451
+  tps: 124296.52213
   hps: 17.51959
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-Yu'lon'sBite-103987"
  value: {
-  dps: 418315.97932
-  tps: 192939.05145
+  dps: 419328.12966
+  tps: 192722.26694
   hps: 18.21674
  }
 }
 dps_results: {
  key: "TestBeastMastery-AllItems-ZenAlchemistStone-75274"
  value: {
-  dps: 429515.64751
-  tps: 194151.37676
+  dps: 429598.34397
+  tps: 193800.24095
   hps: 17.66285
  }
 }
 dps_results: {
  key: "TestBeastMastery-Average-Default"
  value: {
-  dps: 476782.11806
-  tps: 210754.4277
-  hps: 17.42468
+  dps: 477088.98171
+  tps: 210808.78282
+  hps: 17.4181
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-DefaultTalents-Basic-bm-FullBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 2.5779676556e+06
-  tps: 710469.58878
+  dps: 2.58494659235e+06
+  tps: 708855.84998
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-DefaultTalents-Basic-bm-FullBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 465255.27005
-  tps: 207503.73663
+  dps: 466290.87939
+  tps: 206712.80924
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-DefaultTalents-Basic-bm-FullBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 723248.64109
-  tps: 273697.08559
+  dps: 728718.10462
+  tps: 272860.10157
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-DefaultTalents-Basic-bm-NoBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.77025557103e+06
-  tps: 554310.12468
+  dps: 1.77589427833e+06
+  tps: 556305.87929
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-DefaultTalents-Basic-bm-NoBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 331420.20887
-  tps: 161673.76035
+  dps: 330344.91391
+  tps: 160971.14762
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-DefaultTalents-Basic-bm-NoBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 425602.15392
-  tps: 185200.85916
+  dps: 428350.9035
+  tps: 185961.09438
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row4_Talent1-Basic-bm-FullBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 2.70420655041e+06
-  tps: 725680.20051
+  dps: 2.69707288452e+06
+  tps: 727625.74857
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row4_Talent1-Basic-bm-FullBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 453967.56528
-  tps: 213220.00878
+  dps: 456976.82199
+  tps: 214818.01509
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row4_Talent1-Basic-bm-FullBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 695825.67739
-  tps: 280513.65432
+  dps: 706990.5234
+  tps: 285833.43674
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row4_Talent1-Basic-bm-NoBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.89942901955e+06
-  tps: 567180.79832
+  dps: 1.90579913898e+06
+  tps: 563789.53968
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row4_Talent1-Basic-bm-NoBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 324756.33987
-  tps: 165157.38237
+  dps: 323866.17812
+  tps: 164487.60081
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row4_Talent1-Basic-bm-NoBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 415250.46371
-  tps: 188833.42392
+  dps: 420449.18573
+  tps: 190894.65329
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row4_Talent3-Basic-bm-FullBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 2.61671665409e+06
-  tps: 757501.35104
+  dps: 2.61938466714e+06
+  tps: 752416.84967
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row4_Talent3-Basic-bm-FullBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 451777.61325
-  tps: 218814.53639
+  dps: 453253.61929
+  tps: 217860.15543
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row4_Talent3-Basic-bm-FullBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 698426.87229
-  tps: 284248.22903
+  dps: 707148.95738
+  tps: 286474.01809
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row4_Talent3-Basic-bm-NoBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.84486378968e+06
-  tps: 588351.86507
+  dps: 1.8506514568e+06
+  tps: 596080.80033
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row4_Talent3-Basic-bm-NoBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 324982.82752
-  tps: 170677.16902
+  dps: 325024.18231
+  tps: 170849.09789
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row4_Talent3-Basic-bm-NoBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 417516.59126
-  tps: 194136.77294
+  dps: 421081.75224
+  tps: 196884.19392
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row5_Talent1-Basic-bm-FullBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 2.27738723555e+06
-  tps: 711128.03912
+  dps: 2.25754932739e+06
+  tps: 721081.61721
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row5_Talent1-Basic-bm-FullBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 461296.3299
-  tps: 228340.02324
+  dps: 461392.09028
+  tps: 227719.26422
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row5_Talent1-Basic-bm-FullBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 712421.916
-  tps: 307742.75654
+  dps: 710499.48086
+  tps: 309612.13467
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row5_Talent1-Basic-bm-NoBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.55388910443e+06
-  tps: 560252.65642
+  dps: 1.55170944287e+06
+  tps: 559953.43097
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row5_Talent1-Basic-bm-NoBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 331316.50545
-  tps: 177472.51692
+  dps: 330395.37322
+  tps: 177659.99321
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row5_Talent1-Basic-bm-NoBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 430139.46521
-  tps: 209791.80568
+  dps: 429528.59149
+  tps: 207388.69208
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row5_Talent3-Basic-bm-FullBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 2.22495314697e+06
-  tps: 695965.805
+  dps: 2.20711309599e+06
+  tps: 694521.46098
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row5_Talent3-Basic-bm-FullBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 447791.09891
-  tps: 204556.49636
+  dps: 449661.04983
+  tps: 204524.33962
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row5_Talent3-Basic-bm-FullBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 688152.39596
-  tps: 264108.23456
+  dps: 691265.43946
+  tps: 261367.95496
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row5_Talent3-Basic-bm-NoBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.56635369413e+06
-  tps: 556070.77267
+  dps: 1.55242245008e+06
+  tps: 551073.16693
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row5_Talent3-Basic-bm-NoBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 320319.19505
-  tps: 159368.75107
+  dps: 319335.46069
+  tps: 159718.16717
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row5_Talent3-Basic-bm-NoBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 406199.57994
-  tps: 175449.87479
+  dps: 411309.51534
+  tps: 178240.07322
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row6_Talent1-Basic-bm-FullBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 2.42924835818e+06
-  tps: 566788.00797
+  dps: 2.45338557703e+06
+  tps: 573656.96396
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row6_Talent1-Basic-bm-FullBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 463898.15975
-  tps: 209281.7942
+  dps: 464135.78033
+  tps: 208676.18039
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row6_Talent1-Basic-bm-FullBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 703929.93508
-  tps: 274168.21226
+  dps: 704913.29483
+  tps: 272038.9192
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row6_Talent1-Basic-bm-NoBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.69533639567e+06
-  tps: 445226.37238
+  dps: 1.68158962933e+06
+  tps: 446524.52405
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row6_Talent1-Basic-bm-NoBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 332535.68027
-  tps: 164006.40197
+  dps: 334992.49692
+  tps: 164019.55205
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row6_Talent1-Basic-bm-NoBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 424929.26688
-  tps: 184815.35603
+  dps: 425177.6642
+  tps: 182750.29685
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row6_Talent2-Basic-bm-FullBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 2.46932087163e+06
-  tps: 574970.12059
+  dps: 2.46552504161e+06
+  tps: 564680.97935
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row6_Talent2-Basic-bm-FullBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 461343.67802
-  tps: 203874.53594
+  dps: 462754.36312
+  tps: 204747.79276
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row6_Talent2-Basic-bm-FullBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 696232.63293
-  tps: 266573.52652
+  dps: 702045.96538
+  tps: 267560.34269
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row6_Talent2-Basic-bm-NoBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.71146121189e+06
-  tps: 448867.0267
+  dps: 1.71638884821e+06
+  tps: 450046.63117
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row6_Talent2-Basic-bm-NoBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 325132.62849
-  tps: 156572.34472
+  dps: 329727.99526
+  tps: 158607.03829
  }
 }
 dps_results: {
  key: "TestBeastMastery-Settings-Orc-p5-Row6_Talent2-Basic-bm-NoBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 416013.73059
-  tps: 177300.83708
+  dps: 425132.6455
+  tps: 181608.4618
  }
 }
 dps_results: {
  key: "TestBeastMastery-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 455417.25536
-  tps: 208332.89866
+  dps: 456563.41248
+  tps: 207194.23698
   hps: 17.66285
  }
 }

--- a/sim/hunter/marksmanship/TestMarksmanship.results
+++ b/sim/hunter/marksmanship/TestMarksmanship.results
@@ -33,1545 +33,1545 @@ character_stats_results: {
 dps_results: {
  key: "TestMarksmanship-AllItems-AgilePrimalDiamond"
  value: {
-  dps: 433624.45162
-  tps: 332617.04072
-  hps: 18.9305
+  dps: 434193.27417
+  tps: 332730.61042
+  hps: 18.99596
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-AlacrityofXuen-103989"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-ArcaneBadgeoftheShieldwall-93347"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-ArrowflightMedallion-93258"
  value: {
-  dps: 420882.03696
-  tps: 329443.52984
+  dps: 422087.27628
+  tps: 329839.38615
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-AssuranceofConsequence-105472"
  value: {
-  dps: 462041.70172
-  tps: 359070.63162
+  dps: 463140.12666
+  tps: 359105.55085
   hps: 18.70464
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-AusterePrimalDiamond"
  value: {
-  dps: 423936.98729
-  tps: 323545.56477
-  hps: 18.70464
+  dps: 424726.22878
+  tps: 323847.77785
+  hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-BadJuju-96781"
  value: {
-  dps: 439510.03497
-  tps: 343346.78033
+  dps: 441137.14064
+  tps: 344453.88193
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-BadgeofKypariZar-84079"
  value: {
-  dps: 415893.51372
-  tps: 326562.4832
-  hps: 19.62024
+  dps: 416516.41921
+  tps: 326612.17104
+  hps: 19.87759
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-BattlegearoftheSaurokStalker"
  value: {
-  dps: 336752.56014
-  tps: 256644.17555
-  hps: 17.78423
+  dps: 339677.48217
+  tps: 258597.22065
+  hps: 17.84779
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-BattlegearoftheUnblinkingVigil"
  value: {
-  dps: 341517.10568
-  tps: 262894.02928
-  hps: 18.01086
+  dps: 343698.62328
+  tps: 264521.42298
+  hps: 18.07442
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-BlackBloodofY'Shaarj-105648"
  value: {
-  dps: 424576.02068
-  tps: 332575.54002
-  hps: 18.70464
+  dps: 426069.92317
+  tps: 333701.31129
+  hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-BlossomofPureSnow-89081"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-BottleofInfiniteStars-87057"
  value: {
-  dps: 429660.43776
-  tps: 336636.52684
+  dps: 433075.24385
+  tps: 338993.4693
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-BraidofTenSongs-84072"
  value: {
-  dps: 418212.56257
-  tps: 328523.83302
-  hps: 18.70464
+  dps: 418302.42245
+  tps: 328023.07614
+  hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Brawler'sStatue-257885"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-BreathoftheHydra-96827"
  value: {
-  dps: 419373.25338
-  tps: 328537.88542
-  hps: 18.70464
+  dps: 422522.57357
+  tps: 330844.17128
+  hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-BroochofMunificentDeeds-87500"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-BrutalTalismanoftheShado-PanAssault-94508"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-BurningPrimalDiamond"
  value: {
-  dps: 431520.7507
-  tps: 331068.79401
-  hps: 18.9305
+  dps: 432297.43972
+  tps: 331357.88794
+  hps: 18.99596
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-CapacitivePrimalDiamond"
  value: {
-  dps: 461830.16996
-  tps: 362112.81218
+  dps: 464772.47603
+  tps: 364245.22627
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-CarbonicCarbuncle-81138"
  value: {
-  dps: 415339.35657
-  tps: 325847.09163
-  hps: 20.12958
+  dps: 417538.11072
+  tps: 327214.13351
+  hps: 20.47882
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Cha-Ye'sEssenceofBrilliance-96888"
  value: {
-  dps: 418447.92034
-  tps: 328736.38446
+  dps: 419015.81208
+  tps: 328519.15117
   hps: 19.87759
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-CharmofTenSongs-84071"
  value: {
-  dps: 418612.45968
-  tps: 328121.87929
+  dps: 422496.17201
+  tps: 331581.44131
   hps: 18.96199
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-CommunalIdolofDestruction-101168"
  value: {
-  dps: 413037.95886
-  tps: 324158.47076
+  dps: 415535.61058
+  tps: 326409.96478
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-CommunalStoneofDestruction-101171"
  value: {
-  dps: 416591.29082
-  tps: 328072.4914
+  dps: 415929.03511
+  tps: 326537.80631
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-CommunalStoneofWisdom-101183"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-ContemplationofChi-Ji-103988"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Coren'sColdChromiumCoaster-257880"
  value: {
-  dps: 424057.89325
-  tps: 331613.78798
+  dps: 425157.58001
+  tps: 331868.21492
   hps: 19.52835
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-CoreofDecency-87497"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-CourageousPrimalDiamond"
  value: {
-  dps: 423936.98729
-  tps: 323545.56477
-  hps: 18.70464
+  dps: 424726.22878
+  tps: 323847.77785
+  hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-CraftedDreadfulGladiator'sBadgeofConquest-93419"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-CraftedDreadfulGladiator'sBadgeofDominance-93600"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-CraftedDreadfulGladiator'sBadgeofVictory-93606"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-CraftedDreadfulGladiator'sEmblemofCruelty-93485"
  value: {
-  dps: 413848.02233
-  tps: 324755.78288
+  dps: 414985.52755
+  tps: 325067.68959
   hps: 19.02555
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-CraftedDreadfulGladiator'sEmblemofMeditation-93487"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-CraftedDreadfulGladiator'sEmblemofTenacity-93486"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-CraftedDreadfulGladiator'sInsigniaofConquest-93424"
  value: {
-  dps: 421909.87585
-  tps: 329733.24671
+  dps: 423573.07004
+  tps: 330437.23661
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-CraftedDreadfulGladiator'sInsigniaofDominance-93601"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-CraftedDreadfulGladiator'sInsigniaofVictory-93611"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-CraftedMalevolentGladiator'sBadgeofConquest-98755"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-CraftedMalevolentGladiator'sBadgeofDominance-98910"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-CraftedMalevolentGladiator'sBadgeofVictory-98912"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-CraftedMalevolentGladiator'sEmblemofCruelty-98811"
  value: {
-  dps: 414653.50368
-  tps: 325465.77284
+  dps: 415542.3856
+  tps: 325536.38655
   hps: 19.52835
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-CraftedMalevolentGladiator'sEmblemofMeditation-98813"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-CraftedMalevolentGladiator'sEmblemofTenacity-98812"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-CraftedMalevolentGladiator'sInsigniaofConquest-98760"
  value: {
-  dps: 424127.26583
-  tps: 331354.95816
+  dps: 425911.29505
+  tps: 332115.56192
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-CraftedMalevolentGladiator'sInsigniaofDominance-98911"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-CraftedMalevolentGladiator'sInsigniaofVictory-98917"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-CurseofHubris-105645"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-CutstitcherMedallion-93255"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Daelo'sFinalWords-87496"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-DarkglowEmbroidery(Rank3)-4893"
  value: {
-  dps: 462816.14839
-  tps: 363324.86305
+  dps: 461108.21937
+  tps: 361048.47945
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-DarkmistVortex-87172"
  value: {
-  dps: 412756.28695
-  tps: 323118.49731
+  dps: 412753.26449
+  tps: 322151.72144
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-DeadeyeBadgeoftheShieldwall-93346"
  value: {
-  dps: 417193.65877
-  tps: 326611.70191
+  dps: 418719.23706
+  tps: 327335.4797
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-DelicateVialoftheSanguinaire-96895"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-DestructivePrimalDiamond"
  value: {
-  dps: 425854.36055
-  tps: 325145.26351
-  hps: 18.70464
+  dps: 426464.50703
+  tps: 325348.02579
+  hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-DisciplineofXuen-103986"
  value: {
-  dps: 435122.35536
-  tps: 341961.5853
+  dps: 434373.93019
+  tps: 340697.15131
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Dominator'sArcaneBadge-93342"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Dominator'sDeadeyeBadge-93341"
  value: {
-  dps: 417193.65877
-  tps: 326611.70191
+  dps: 418719.23706
+  tps: 327335.4797
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Dominator'sDurableBadge-93345"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Dominator'sKnightlyBadge-93344"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Dominator'sMendingBadge-93343"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-DreadfulGladiator'sBadgeofConquest-84344"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-DreadfulGladiator'sBadgeofDominance-84488"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-DreadfulGladiator'sBadgeofVictory-84490"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-DreadfulGladiator'sEmblemofCruelty-84399"
  value: {
-  dps: 413848.02233
-  tps: 324755.78288
+  dps: 414985.52755
+  tps: 325067.68959
   hps: 19.02555
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-DreadfulGladiator'sEmblemofMeditation-84401"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-DreadfulGladiator'sEmblemofTenacity-84400"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-DreadfulGladiator'sInsigniaofConquest-84349"
  value: {
-  dps: 421810.34103
-  tps: 329671.0272
+  dps: 423397.57947
+  tps: 330394.59213
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-DreadfulGladiator'sInsigniaofDominance-84489"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-DreadfulGladiator'sInsigniaofVictory-84495"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-DurableBadgeoftheShieldwall-93350"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-DysmorphicSamophlangeofDiscontinuity-105615"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-EffulgentPrimalDiamond"
  value: {
-  dps: 423936.98729
-  tps: 323545.56477
-  hps: 18.70464
+  dps: 424726.22878
+  tps: 323847.77785
+  hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-EmberPrimalDiamond"
  value: {
-  dps: 423936.98729
-  tps: 323545.56477
-  hps: 18.70464
+  dps: 424726.22878
+  tps: 323847.77785
+  hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-EmblemofKypariZar-84077"
  value: {
-  dps: 424806.20288
-  tps: 333864.04336
-  hps: 18.96199
+  dps: 421814.71233
+  tps: 330645.18541
+  hps: 19.02555
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-EmblemoftheCatacombs-83733"
  value: {
-  dps: 417673.10762
-  tps: 328260.43687
-  hps: 18.70464
+  dps: 418335.81927
+  tps: 327471.41287
+  hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-EmptyFruitBarrel-81133"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-EnchantWeapon-BloodyDancingSteel-5125"
  value: {
-  dps: 460558.58971
-  tps: 360905.71057
+  dps: 463402.49137
+  tps: 362900.97187
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-EnchantWeapon-Colossus-4445"
  value: {
-  dps: 452298.37543
-  tps: 354877.93737
+  dps: 455336.78258
+  tps: 357126.45232
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-EnchantWeapon-DancingSteel-4444"
  value: {
-  dps: 460553.89936
-  tps: 360924.76495
+  dps: 463584.45992
+  tps: 363054.61716
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-EnchantWeapon-ElementalForce-4443"
  value: {
-  dps: 454547.029
-  tps: 357206.8304
+  dps: 457261.75332
+  tps: 358509.22514
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-EnchantWeapon-JadeSpirit-4442"
  value: {
-  dps: 452298.37543
-  tps: 354877.93737
+  dps: 455336.78258
+  tps: 357126.45232
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-EnchantWeapon-River'sSong-4446"
  value: {
-  dps: 452235.97148
-  tps: 354877.93737
+  dps: 455290.73565
+  tps: 357126.45232
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-EnchantWeapon-SpiritofConquest-5124"
  value: {
-  dps: 452298.37543
-  tps: 354877.93737
+  dps: 455336.78258
+  tps: 357126.45232
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-EnchantWeapon-Windsong-4441"
  value: {
-  dps: 455499.58089
-  tps: 357240.43116
+  dps: 462566.78522
+  tps: 362968.11803
   hps: 19.271
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-EnigmaticPrimalDiamond"
  value: {
-  dps: 425854.36055
-  tps: 325145.26351
-  hps: 18.70464
+  dps: 426464.50703
+  tps: 325348.02579
+  hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-EssenceofTerror-87175"
  value: {
-  dps: 411316.88202
-  tps: 322301.67607
+  dps: 411105.5317
+  tps: 321174.41828
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-EternalPrimalDiamond"
  value: {
-  dps: 423936.98729
-  tps: 323545.56477
-  hps: 18.70464
+  dps: 424726.22878
+  tps: 323847.77785
+  hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-EvilEyeofGalakras-105491"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-FabledFeatherofJi-Kun-96842"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-FearwurmBadge-84074"
  value: {
-  dps: 421381.76708
-  tps: 330987.55263
-  hps: 18.96199
+  dps: 421252.4959
+  tps: 330137.00904
+  hps: 19.02555
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-FearwurmRelic-84070"
  value: {
-  dps: 418806.3644
-  tps: 328659.68707
-  hps: 18.96199
+  dps: 417852.29392
+  tps: 327219.50955
+  hps: 19.02555
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-FelsoulIdolofDestruction-101263"
  value: {
-  dps: 413904.37073
-  tps: 324681.17936
+  dps: 415272.83628
+  tps: 325816.0855
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-FelsoulStoneofDestruction-101266"
  value: {
-  dps: 415943.24278
-  tps: 327268.11201
+  dps: 416388.7916
+  tps: 326912.25701
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-FlashfrozenResinGlobule-100951"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-FlashingSteelTalisman-81265"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-FleetPrimalDiamond"
  value: {
-  dps: 423306.65778
-  tps: 323249.02733
-  hps: 18.70464
+  dps: 425392.32833
+  tps: 324451.62654
+  hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-ForlornPrimalDiamond"
  value: {
-  dps: 423936.98729
-  tps: 323545.56477
-  hps: 18.70464
+  dps: 424726.22878
+  tps: 323847.77785
+  hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-FortitudeoftheZandalari-96793"
  value: {
-  dps: 417157.59203
-  tps: 328135.61206
+  dps: 418401.52314
+  tps: 328747.0755
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-FrenziedCrystalofRage-105572"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Fusion-FireCore-105459"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-GazeoftheTwins-96915"
  value: {
-  dps: 420202.51404
-  tps: 330330.5437
-  hps: 20.12958
+  dps: 421734.84052
+  tps: 330934.21573
+  hps: 20.53644
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Gerp'sPerfectArrow-87495"
  value: {
-  dps: 413320.56831
-  tps: 324280.22505
+  dps: 414366.0838
+  tps: 324509.58026
   hps: 19.02555
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 345823.68986
-  tps: 267023.09488
-  hps: 18.31238
+  dps: 349728.43855
+  tps: 269269.90677
+  hps: 18.37594
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Gong-Lu,StrengthofXuen-102249"
  value: {
-  dps: 440094.52503
-  tps: 347107.65519
+  dps: 440280.28786
+  tps: 345933.69384
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-GrievousGladiator'sBadgeofConquest-103145"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-GrievousGladiator'sBadgeofDominance-103308"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-GrievousGladiator'sBadgeofVictory-103314"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-GrievousGladiator'sEmblemofCruelty-103210"
  value: {
-  dps: 417083.36358
-  tps: 327561.38149
+  dps: 417750.94043
+  tps: 327420.82536
   hps: 19.52835
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-GrievousGladiator'sEmblemofMeditation-103212"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-GrievousGladiator'sEmblemofTenacity-103211"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-GrievousGladiator'sInsigniaofConquest-103150"
  value: {
-  dps: 431964.89758
-  tps: 336986.56649
+  dps: 433521.93494
+  tps: 337344.11326
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-GrievousGladiator'sInsigniaofDominance-103309"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-GrievousGladiator'sInsigniaofVictory-103319"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Haromm'sTalisman-105527"
  value: {
-  dps: 456480.64492
-  tps: 357496.45251
+  dps: 460339.97858
+  tps: 359900.71553
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Hawkmaster'sTalon-89082"
  value: {
-  dps: 420075.33352
-  tps: 328842.82379
+  dps: 421457.24009
+  tps: 329415.79333
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Heart-LesionDefenderIdol-100999"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Heart-LesionDefenderStone-101002"
  value: {
-  dps: 414804.79493
-  tps: 326267.82366
+  dps: 417131.34558
+  tps: 327963.12307
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Heart-LesionIdolofBattle-100991"
  value: {
-  dps: 414897.52345
-  tps: 325669.87022
+  dps: 415953.49235
+  tps: 325905.19199
   hps: 19.52835
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Heart-LesionStoneofBattle-100990"
  value: {
-  dps: 414567.26802
-  tps: 325843.69835
+  dps: 415822.12974
+  tps: 326457.90643
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-HeartofFire-81181"
  value: {
-  dps: 414496.30879
-  tps: 325563.14273
+  dps: 414843.51402
+  tps: 325627.38383
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-HeartwarmerMedallion-93260"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-HelmbreakerMedallion-93261"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Horridon'sLastGasp-96757"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-ImpassivePrimalDiamond"
  value: {
-  dps: 425854.36055
-  tps: 325145.26351
-  hps: 18.70464
+  dps: 426464.50703
+  tps: 325348.02579
+  hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-IndomitablePrimalDiamond"
  value: {
-  dps: 423936.98729
-  tps: 323545.56477
-  hps: 18.70464
+  dps: 424726.22878
+  tps: 323847.77785
+  hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-InscribedBagofHydra-Spawn-96828"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-InsigniaofKypariZar-84078"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-IronBellyWok-89083"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-IronProtectorTalisman-85181"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-JadeBanditFigurine-86772"
  value: {
-  dps: 418739.68947
-  tps: 327804.10662
+  dps: 420254.41599
+  tps: 328520.02057
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-JadeCharioteerFigurine-86771"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-JadeCourtesanFigurine-86774"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-JadeMagistrateFigurine-86773"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-JadeWarlordFigurine-86775"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Ji-Kun'sRisingWinds-96843"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Juggernaut'sFocusingCrystal-105514"
  value: {
-  dps: 409622.67042
-  tps: 321061.59575
-  hps: 10283.7103
+  dps: 411120.04125
+  tps: 321777.8832
+  hps: 10306.60316
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Kardris'ToxicTotem-105540"
  value: {
-  dps: 424533.70028
-  tps: 335323.47992
+  dps: 426617.36576
+  tps: 337346.98765
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-KnightlyBadgeoftheShieldwall-93349"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-KnotofTenSongs-84073"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Kor'kronBookofHurting-92785"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Lao-Chin'sLiquidCourage-89079"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-LeiShen'sFinalOrders-87072"
  value: {
-  dps: 415353.45139
-  tps: 325009.11811
-  hps: 18.70464
+  dps: 417684.12678
+  tps: 326786.13942
+  hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-LessonsoftheDarkmaster-81268"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-LightdrinkerIdolofRage-101200"
  value: {
-  dps: 425845.62417
-  tps: 333158.35622
+  dps: 428829.50605
+  tps: 335648.27346
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-LightdrinkerStoneofRage-101203"
  value: {
-  dps: 424959.20692
-  tps: 333666.27803
+  dps: 425470.50097
+  tps: 333243.27967
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-LightoftheCosmos-87065"
  value: {
-  dps: 415354.67119
-  tps: 325009.11811
-  hps: 18.70464
+  dps: 417684.12678
+  tps: 326786.13942
+  hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-LightweaveEmbroidery(Rank3)-4892"
  value: {
-  dps: 462816.14839
-  tps: 363324.86305
+  dps: 461108.21937
+  tps: 361048.47945
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-MalevolentGladiator'sBadgeofConquest-91452"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-MalevolentGladiator'sBadgeofDominance-91753"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-MalevolentGladiator'sBadgeofVictory-91763"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-MalevolentGladiator'sEmblemofCruelty-91562"
  value: {
-  dps: 414653.50368
-  tps: 325465.77284
+  dps: 415542.3856
+  tps: 325536.38655
   hps: 19.52835
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-MalevolentGladiator'sEmblemofMeditation-91564"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-MalevolentGladiator'sEmblemofTenacity-91563"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-MalevolentGladiator'sInsigniaofConquest-91457"
  value: {
-  dps: 424102.41054
-  tps: 331346.27786
+  dps: 425646.5913
+  tps: 332031.57362
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-MalevolentGladiator'sInsigniaofDominance-91754"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-MalevolentGladiator'sInsigniaofVictory-91768"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-MarkoftheCatacombs-83731"
  value: {
-  dps: 415404.57258
-  tps: 326271.44733
+  dps: 418891.57247
+  tps: 328801.71181
   hps: 19.02555
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-MarkoftheHardenedGrunt-92783"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-MedallionofMystifyingVapors-93257"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-MedallionoftheCatacombs-83734"
  value: {
-  dps: 412460.08035
-  tps: 323531.43239
+  dps: 414971.0807
+  tps: 325473.58417
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-MendingBadgeoftheShieldwall-93348"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-MirrorScope-4700"
  value: {
-  dps: 454817.09535
-  tps: 357065.23069
+  dps: 457664.06254
+  tps: 359114.5916
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-MistdancerDefenderIdol-101089"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-MistdancerDefenderStone-101087"
  value: {
-  dps: 415356.1031
-  tps: 327012.79595
+  dps: 416883.05772
+  tps: 327426.76442
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-MistdancerIdolofRage-101113"
  value: {
-  dps: 425391.7767
-  tps: 332851.71849
+  dps: 428483.38494
+  tps: 335455.12652
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-MistdancerStoneofRage-101117"
  value: {
-  dps: 424070.92853
-  tps: 332948.98489
+  dps: 425703.52645
+  tps: 333616.64519
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-MistdancerStoneofWisdom-101107"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-MithrilWristwatch-257884"
  value: {
-  dps: 415096.31641
-  tps: 325832.3073
+  dps: 416053.94384
+  tps: 325975.9802
   hps: 19.52835
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-MountainsageIdolofDestruction-101069"
  value: {
-  dps: 414373.74115
-  tps: 325209.6999
+  dps: 416142.49847
+  tps: 326614.44603
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-MountainsageStoneofDestruction-101072"
  value: {
-  dps: 417524.61168
-  tps: 329187.64198
+  dps: 416539.39128
+  tps: 327167.94545
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-NitroBoosts-4223"
  value: {
-  dps: 461830.16996
-  tps: 362112.81218
+  dps: 464772.47603
+  tps: 364245.22627
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-OathswornDefenderIdol-101303"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-OathswornDefenderStone-101306"
  value: {
-  dps: 416576.78014
-  tps: 327983.11924
+  dps: 417740.82408
+  tps: 328121.13827
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-OathswornIdolofBattle-101295"
  value: {
-  dps: 414897.52345
-  tps: 325669.87022
+  dps: 415953.49235
+  tps: 325905.19199
   hps: 19.52835
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-OathswornStoneofBattle-101294"
  value: {
-  dps: 413181.3982
-  tps: 324489.71118
+  dps: 416753.07542
+  tps: 327222.07447
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-PhaseFingers-4697"
  value: {
-  dps: 467870.38323
-  tps: 367607.9772
+  dps: 467996.31352
+  tps: 367256.37153
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-PouchofWhiteAsh-103639"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-PowerfulPrimalDiamond"
  value: {
-  dps: 423936.98729
-  tps: 323545.56477
-  hps: 18.70464
+  dps: 424726.22878
+  tps: 323847.77785
+  hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-PriceofProgress-81266"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-PridefulGladiator'sBadgeofConquest-103342"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-PridefulGladiator'sBadgeofDominance-103505"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-PridefulGladiator'sBadgeofVictory-103511"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-PridefulGladiator'sEmblemofCruelty-103407"
  value: {
-  dps: 419103.43984
-  tps: 329308.78345
+  dps: 419685.93799
+  tps: 329088.9454
   hps: 19.87759
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-PridefulGladiator'sEmblemofMeditation-103409"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-PridefulGladiator'sEmblemofTenacity-103408"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-PridefulGladiator'sInsigniaofConquest-103347"
  value: {
-  dps: 438711.35527
-  tps: 341521.89189
+  dps: 441152.07059
+  tps: 342779.19513
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-PridefulGladiator'sInsigniaofDominance-103506"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-PridefulGladiator'sInsigniaofVictory-103516"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Primordius'TalismanofRage-96873"
  value: {
-  dps: 418447.92034
-  tps: 328736.38446
+  dps: 419015.81208
+  tps: 328519.15117
   hps: 19.87759
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-PrismaticPrisonofPride-105474"
  value: {
-  dps: 430283.30608
-  tps: 339852.84691
-  hps: 19.01926
+  dps: 429366.75126
+  tps: 338137.33072
+  hps: 19.08547
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-PurifiedBindingsofImmerseus-105422"
  value: {
-  dps: 430283.30608
-  tps: 339852.84691
-  hps: 19.01926
+  dps: 429366.75126
+  tps: 338137.33072
+  hps: 19.08547
  }
 }
 dps_results: {
@@ -1593,672 +1593,672 @@ dps_results: {
 dps_results: {
  key: "TestMarksmanship-AllItems-Qin-xi'sPolarizingSeal-87075"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-RelicofChi-Ji-79330"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-RelicofKypariZar-84075"
  value: {
-  dps: 417295.25826
-  tps: 327810.89917
+  dps: 416149.33108
+  tps: 325177.79098
   hps: 19.46479
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-RelicofNiuzao-79329"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-RelicofXuen-79327"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-RelicofXuen-79328"
  value: {
-  dps: 428412.50061
-  tps: 334680.40121
+  dps: 429950.14254
+  tps: 335078.89925
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-RelicofYu'lon-79331"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Renataki'sSoulCharm-96741"
  value: {
-  dps: 432553.54415
-  tps: 337107.59155
+  dps: 434253.5534
+  tps: 337967.17243
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-ResolveofNiuzao-103990"
  value: {
-  dps: 417464.40496
-  tps: 328485.96755
+  dps: 417469.22642
+  tps: 328012.90101
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-ReverberatingPrimalDiamond"
  value: {
-  dps: 431520.7507
-  tps: 331068.79401
-  hps: 18.9305
+  dps: 432297.43972
+  tps: 331357.88794
+  hps: 18.99596
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-RevitalizingPrimalDiamond"
  value: {
-  dps: 431520.7507
-  tps: 331068.79401
-  hps: 18.9305
+  dps: 432297.43972
+  tps: 331357.88794
+  hps: 18.99596
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-RuneofRe-Origination-96918"
  value: {
-  dps: 442045.30427
-  tps: 341441.23665
-  hps: 17.18862
+  dps: 442178.41821
+  tps: 339968.31124
+  hps: 17.1438
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-SI:7Operative'sManual-92784"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-ScrollofReveredAncestors-89080"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-SearingWords-81267"
  value: {
-  dps: 426297.82467
-  tps: 333627.40131
+  dps: 427347.52464
+  tps: 333609.55292
   hps: 19.02555
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Shock-ChargerMedallion-93259"
  value: {
-  dps: 417623.81523
-  tps: 327316.4378
-  hps: 18.70464
+  dps: 418523.48009
+  tps: 327552.61312
+  hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-SigilofCompassion-83736"
  value: {
-  dps: 412460.08035
-  tps: 323531.43239
+  dps: 414971.0807
+  tps: 325473.58417
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-SigilofDevotion-83740"
  value: {
-  dps: 417694.8073
-  tps: 328489.38281
+  dps: 419187.06983
+  tps: 329392.398
   hps: 19.02555
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-SigilofFidelity-83737"
  value: {
-  dps: 418698.06996
-  tps: 328515.64354
-  hps: 19.31124
+  dps: 419024.33539
+  tps: 328070.48545
+  hps: 19.87759
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-SigilofGrace-83738"
  value: {
-  dps: 416966.25625
-  tps: 327408.01107
-  hps: 18.70464
+  dps: 417021.12204
+  tps: 326529.27159
+  hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-SigilofKypariZar-84076"
  value: {
-  dps: 416218.37901
-  tps: 327384.97825
+  dps: 419127.30047
+  tps: 329252.68456
   hps: 19.02555
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-SigilofPatience-83739"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-SigilofRampage-105580"
  value: {
-  dps: 442988.7474
-  tps: 343301.28651
+  dps: 445441.34245
+  tps: 344609.27923
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-SigiloftheCatacombs-83732"
  value: {
-  dps: 418899.16408
-  tps: 328829.74633
-  hps: 18.96199
+  dps: 419503.96783
+  tps: 328922.51562
+  hps: 19.02555
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-SinisterPrimalDiamond"
  value: {
-  dps: 425333.58008
-  tps: 324700.38361
-  hps: 18.70464
+  dps: 425923.16818
+  tps: 324888.4782
+  hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Skeer'sBloodsoakedTalisman-105632"
  value: {
-  dps: 414479.38194
-  tps: 325040.19199
+  dps: 416837.67683
+  tps: 326558.12803
   hps: 19.46596
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-SkullrenderMedallion-93256"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-SoothingTalismanoftheShado-PanAssault-94509"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-SoulBarrier-96927"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-SparkofZandalar-96770"
  value: {
-  dps: 419373.25338
-  tps: 328537.88542
-  hps: 18.70464
+  dps: 422522.57357
+  tps: 330844.17128
+  hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-SpiritsoftheSun-87163"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-SpringrainIdolofDestruction-101023"
  value: {
-  dps: 415011.1812
-  tps: 325694.38876
+  dps: 416590.99634
+  tps: 326684.05032
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-SpringrainIdolofRage-101009"
  value: {
-  dps: 425527.26823
-  tps: 332995.48107
+  dps: 428981.93741
+  tps: 335965.40895
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-SpringrainStoneofDestruction-101026"
  value: {
-  dps: 412919.80423
-  tps: 324353.86088
+  dps: 417674.01806
+  tps: 328202.12922
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-SpringrainStoneofRage-101012"
  value: {
-  dps: 423747.92227
-  tps: 332330.43731
+  dps: 426462.21008
+  tps: 334607.1826
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-SpringrainStoneofWisdom-101041"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Static-Caster'sMedallion-93254"
  value: {
-  dps: 417623.81523
-  tps: 327316.4378
-  hps: 18.70464
+  dps: 418523.48009
+  tps: 327552.61312
+  hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-SteadfastFootman'sMedallion-92782"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-SteadfastTalismanoftheShado-PanAssault-94507"
  value: {
-  dps: 413549.91627
-  tps: 324966.40914
+  dps: 417051.99513
+  tps: 327552.46955
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-StreamtalkerIdolofDestruction-101222"
  value: {
-  dps: 413892.00727
-  tps: 324772.07011
+  dps: 415791.80536
+  tps: 326622.09409
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-StreamtalkerIdolofRage-101217"
  value: {
-  dps: 425482.69248
-  tps: 333088.45589
+  dps: 429021.21865
+  tps: 336062.02853
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-StreamtalkerStoneofDestruction-101225"
  value: {
-  dps: 414692.55553
-  tps: 325871.02067
+  dps: 416302.11417
+  tps: 326917.75315
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-StreamtalkerStoneofRage-101220"
  value: {
-  dps: 424789.47515
-  tps: 333380.21211
+  dps: 427769.2384
+  tps: 335912.22369
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-StreamtalkerStoneofWisdom-101250"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-StuffofNightmares-87160"
  value: {
-  dps: 415623.33543
-  tps: 327077.79563
+  dps: 416237.3289
+  tps: 327034.73114
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-SunsoulDefenderIdol-101160"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-SunsoulDefenderStone-101163"
  value: {
-  dps: 414995.52216
-  tps: 326020.35916
+  dps: 418363.49592
+  tps: 329148.37549
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-SunsoulIdolofBattle-101152"
  value: {
-  dps: 414897.52345
-  tps: 325669.87022
+  dps: 415953.49235
+  tps: 325905.19199
   hps: 19.52835
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-SunsoulStoneofBattle-101151"
  value: {
-  dps: 413771.77292
-  tps: 325304.76056
+  dps: 416931.78336
+  tps: 327608.59059
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-SunsoulStoneofWisdom-101138"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-SwordguardEmbroidery(Rank3)-4894"
  value: {
-  dps: 467080.68204
-  tps: 366103.49432
+  dps: 465310.18623
+  tps: 363806.97502
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-SymboloftheCatacombs-83735"
  value: {
-  dps: 416649.71558
-  tps: 327152.20403
+  dps: 418328.90353
+  tps: 328282.90489
   hps: 19.87759
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-SynapseSprings(MarkII)-4898"
  value: {
-  dps: 469866.0065
-  tps: 368339.19336
+  dps: 473210.56449
+  tps: 370857.08879
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-TalismanofBloodlust-96864"
  value: {
-  dps: 437550.92717
-  tps: 341981.99249
-  hps: 18.70464
+  dps: 437166.41216
+  tps: 340919.45547
+  hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-TerrorintheMists-87167"
  value: {
-  dps: 432014.85469
-  tps: 338826.91442
-  hps: 20.59321
+  dps: 433654.59625
+  tps: 339549.47379
+  hps: 22.20193
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-TheGloamingBlade-88149"
  value: {
-  dps: 461830.16996
-  tps: 362112.81218
+  dps: 464772.47603
+  tps: 364245.22627
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Thok'sAcid-GroovedTooth-105607"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Thok'sTailTip-105609"
  value: {
-  dps: 430283.30608
-  tps: 339852.84691
-  hps: 19.01926
+  dps: 429366.75126
+  tps: 338137.33072
+  hps: 19.08547
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Thousand-YearPickledEgg-257881"
  value: {
-  dps: 411959.20991
-  tps: 323101.01809
+  dps: 411379.33851
+  tps: 321730.21093
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-TickingEbonDetonator-105612"
  value: {
-  dps: 446552.05676
-  tps: 348365.96207
+  dps: 446685.14434
+  tps: 347778.05157
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Time-LostArtifact-103678"
  value: {
-  dps: 423149.82624
-  tps: 331914.76328
-  hps: 18.70464
+  dps: 425070.33322
+  tps: 333315.59724
+  hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-TrailseekerIdolofRage-101054"
  value: {
-  dps: 425478.62476
-  tps: 332807.45617
+  dps: 429106.04567
+  tps: 335942.24845
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-TrailseekerStoneofRage-101057"
  value: {
-  dps: 425362.95362
-  tps: 334166.41687
+  dps: 427030.8837
+  tps: 335257.97074
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-TyrannicalGladiator'sBadgeofConquest-100043"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-TyrannicalGladiator'sBadgeofDominance-100016"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-TyrannicalGladiator'sBadgeofVictory-100019"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-TyrannicalGladiator'sEmblemofCruelty-100066"
  value: {
-  dps: 415517.63644
-  tps: 326234.97539
+  dps: 416412.44453
+  tps: 326287.94873
   hps: 19.52835
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-TyrannicalGladiator'sEmblemofMeditation-99990"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-TyrannicalGladiator'sEmblemofTenacity-100092"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-TyrannicalGladiator'sInsigniaofConquest-100026"
  value: {
-  dps: 426275.2594
-  tps: 332703.76448
+  dps: 428912.61931
+  tps: 334100.00513
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-TyrannicalGladiator'sInsigniaofDominance-100152"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-TyrannicalGladiator'sInsigniaofVictory-100085"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-TyrannicalPrimalDiamond"
  value: {
-  dps: 423936.98729
-  tps: 323545.56477
-  hps: 18.70464
+  dps: 424726.22878
+  tps: 323847.77785
+  hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-UnerringVisionofLeiShen-96930"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-VaporshieldMedallion-93262"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-VialofDragon'sBlood-87063"
  value: {
-  dps: 415356.40952
-  tps: 326555.85534
+  dps: 417033.74119
+  tps: 327691.95493
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-VialofIchorousBlood-100963"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-VialofLivingCorruption-105568"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-ViciousTalismanoftheShado-PanAssault-94511"
  value: {
-  dps: 435524.79468
-  tps: 338509.08289
+  dps: 438484.54094
+  tps: 339917.0992
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-VisionofthePredator-81192"
  value: {
-  dps: 411282.69958
-  tps: 322446.78027
+  dps: 412888.16957
+  tps: 323212.10687
   hps: 19.31803
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-VolatileTalismanoftheShado-PanAssault-94510"
  value: {
-  dps: 409728.37259
-  tps: 320934.57143
+  dps: 411869.87877
+  tps: 322330.52538
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-WindsweptPages-81125"
  value: {
-  dps: 426099.33351
-  tps: 333169.09174
-  hps: 18.70464
+  dps: 424087.54245
+  tps: 331269.17358
+  hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-WoundripperMedallion-93253"
  value: {
-  dps: 420882.03696
-  tps: 329443.52984
+  dps: 422087.27628
+  tps: 329839.38615
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Wushoolay'sFinalChoice-96785"
  value: {
-  dps: 409624.50261
-  tps: 321063.42794
+  dps: 411120.04125
+  tps: 321777.8832
   hps: 18.7682
  }
 }
@@ -2273,342 +2273,342 @@ dps_results: {
 dps_results: {
  key: "TestMarksmanship-AllItems-YaungolFireCarrier-86518"
  value: {
-  dps: 461830.16996
-  tps: 362112.81218
+  dps: 464772.47603
+  tps: 364245.22627
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-YaungolSlayerBattlegear"
  value: {
-  dps: 322802.68383
-  tps: 252266.73422
-  hps: 17.78423
+  dps: 323137.28338
+  tps: 252324.50328
+  hps: 17.84779
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-Yu'lon'sBite-103987"
  value: {
-  dps: 413170.15555
-  tps: 323742.16131
+  dps: 414779.40429
+  tps: 324573.82621
   hps: 19.77513
  }
 }
 dps_results: {
  key: "TestMarksmanship-AllItems-ZenAlchemistStone-75274"
  value: {
-  dps: 428699.42133
-  tps: 335556.61576
+  dps: 429152.01673
+  tps: 335509.60349
   hps: 18.7682
  }
 }
 dps_results: {
  key: "TestMarksmanship-Average-Default"
  value: {
-  dps: 467549.29955
-  tps: 366355.6611
-  hps: 19.09122
+  dps: 470837.45315
+  tps: 368480.83363
+  hps: 19.11878
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-DefaultTalents-Basic-mm-FullBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.34927914483e+06
-  tps: 1.24341975054e+06
+  dps: 1.35400383612e+06
+  tps: 1.24765119109e+06
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-DefaultTalents-Basic-mm-FullBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 466765.2203
-  tps: 367785.25772
+  dps: 463797.27211
+  tps: 363971.96587
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-DefaultTalents-Basic-mm-FullBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 659290.14421
-  tps: 456259.09897
+  dps: 664203.88396
+  tps: 455527.00298
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-DefaultTalents-Basic-mm-NoBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 977224.79022
-  tps: 911187.14182
+  dps: 993944.30822
+  tps: 926993.41849
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-DefaultTalents-Basic-mm-NoBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 345222.56929
-  tps: 279994.08463
+  dps: 345431.4053
+  tps: 281149.86036
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-DefaultTalents-Basic-mm-NoBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 407047.18019
-  tps: 304622.47953
+  dps: 407540.63333
+  tps: 303101.37074
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row4_Talent1-Basic-mm-FullBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.41716680267e+06
-  tps: 1.32425915189e+06
+  dps: 1.42677932026e+06
+  tps: 1.33332332609e+06
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row4_Talent1-Basic-mm-FullBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 465090.68041
-  tps: 378319.56242
+  dps: 467066.31271
+  tps: 380101.84364
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row4_Talent1-Basic-mm-FullBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 666750.61727
-  tps: 479382.59935
+  dps: 663338.12683
+  tps: 475501.52599
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row4_Talent1-Basic-mm-NoBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.06219951237e+06
-  tps: 1.0044639223e+06
+  dps: 1.06645387097e+06
+  tps: 1.00872356459e+06
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row4_Talent1-Basic-mm-NoBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 345204.32162
-  tps: 288523.35432
+  dps: 345205.97003
+  tps: 289415.63325
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row4_Talent1-Basic-mm-NoBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 419441.80014
-  tps: 327119.57505
+  dps: 416943.85129
+  tps: 323257.32909
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row4_Talent3-Basic-mm-FullBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.61475888554e+06
-  tps: 1.52691888801e+06
+  dps: 1.62256928494e+06
+  tps: 1.53390717719e+06
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row4_Talent3-Basic-mm-FullBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 447786.90482
-  tps: 366964.07514
+  dps: 447106.4741
+  tps: 365886.33218
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row4_Talent3-Basic-mm-FullBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 633677.50518
-  tps: 452451.3208
+  dps: 638060.0701
+  tps: 457238.90294
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row4_Talent3-Basic-mm-NoBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.20153270073e+06
-  tps: 1.14885824191e+06
+  dps: 1.20902514811e+06
+  tps: 1.15563402834e+06
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row4_Talent3-Basic-mm-NoBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 329249.88483
-  tps: 277460.22006
+  dps: 329740.57573
+  tps: 277890.84858
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row4_Talent3-Basic-mm-NoBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 390923.61386
-  tps: 300644.23075
+  dps: 393354.12413
+  tps: 302434.97308
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row5_Talent2-Basic-mm-FullBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.37210947169e+06
-  tps: 1.25760782974e+06
+  dps: 1.39065368797e+06
+  tps: 1.27540262009e+06
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row5_Talent2-Basic-mm-FullBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 458659.22861
-  tps: 352267.64273
+  dps: 459026.74793
+  tps: 351899.87607
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row5_Talent2-Basic-mm-FullBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 650562.84481
-  tps: 432787.91923
+  dps: 650760.52744
+  tps: 432028.45509
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row5_Talent2-Basic-mm-NoBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 997607.79734
-  tps: 925917.31639
+  dps: 1.00519929623e+06
+  tps: 933109.07185
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row5_Talent2-Basic-mm-NoBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 338676.02257
-  tps: 268868.94797
+  dps: 340784.35563
+  tps: 271261.47121
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row5_Talent2-Basic-mm-NoBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 388363.06424
-  tps: 279824.75545
+  dps: 394546.60919
+  tps: 284186.3879
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row5_Talent3-Basic-mm-FullBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.3366794237e+06
-  tps: 1.2281186061e+06
+  dps: 1.33817300435e+06
+  tps: 1.23009869689e+06
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row5_Talent3-Basic-mm-FullBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 450610.90646
-  tps: 348317.79166
+  dps: 450617.04463
+  tps: 348501.46977
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row5_Talent3-Basic-mm-FullBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 625864.48916
-  tps: 417497.93122
+  dps: 632686.89759
+  tps: 423779.97975
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row5_Talent3-Basic-mm-NoBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 986323.4774
-  tps: 916959.78953
+  dps: 978365.7109
+  tps: 909190.53405
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row5_Talent3-Basic-mm-NoBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 332647.04827
-  tps: 265476.03161
+  dps: 332316.19723
+  tps: 264997.71272
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row5_Talent3-Basic-mm-NoBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 385497.56353
-  tps: 277696.77893
+  dps: 382463.91646
+  tps: 273555.23053
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row6_Talent1-Basic-mm-FullBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.1652273118e+06
-  tps: 1.06493592205e+06
+  dps: 1.17081431153e+06
+  tps: 1.07133837081e+06
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row6_Talent1-Basic-mm-FullBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 461083.46428
-  tps: 364829.20609
+  dps: 465554.09443
+  tps: 368842.92518
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row6_Talent1-Basic-mm-FullBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 643863.19962
-  tps: 454234.80252
+  dps: 649106.75561
+  tps: 456530.52208
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row6_Talent1-Basic-mm-NoBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 845175.06495
-  tps: 778725.69067
+  dps: 842866.82802
+  tps: 776799.3188
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row6_Talent1-Basic-mm-NoBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 344508.26176
-  tps: 280719.22847
+  dps: 343961.69335
+  tps: 279553.50177
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row6_Talent1-Basic-mm-NoBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 408443.48435
-  tps: 308930.30341
+  dps: 411972.12888
+  tps: 307833.62254
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row6_Talent2-Basic-mm-FullBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.21551599485e+06
-  tps: 1.11407993084e+06
+  dps: 1.21403110823e+06
+  tps: 1.11373842836e+06
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row6_Talent2-Basic-mm-FullBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 457771.58873
-  tps: 361791.69375
+  dps: 457617.31336
+  tps: 361564.04462
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row6_Talent2-Basic-mm-FullBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 644069.59679
-  tps: 455419.78634
+  dps: 651284.2872
+  tps: 457076.14813
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row6_Talent2-Basic-mm-NoBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 887757.07962
-  tps: 820992.54994
+  dps: 891940.12641
+  tps: 825054.81688
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row6_Talent2-Basic-mm-NoBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 344777.76253
-  tps: 280152.65011
+  dps: 344626.6213
+  tps: 280215.68515
  }
 }
 dps_results: {
  key: "TestMarksmanship-Settings-Orc-p5-Row6_Talent2-Basic-mm-NoBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 412148.97019
-  tps: 312606.88357
+  dps: 414847.82107
+  tps: 310356.39666
  }
 }
 dps_results: {
  key: "TestMarksmanship-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 458021.69465
-  tps: 365234.85865
-  hps: 18.70464
+  dps: 460822.48702
+  tps: 367970.45579
+  hps: 18.7682
  }
 }

--- a/sim/hunter/survival/TestSurvival.results
+++ b/sim/hunter/survival/TestSurvival.results
@@ -33,1353 +33,1353 @@ character_stats_results: {
 dps_results: {
  key: "TestSurvival-AllItems-AgilePrimalDiamond"
  value: {
-  dps: 430880.46173
-  tps: 337343.8281
+  dps: 430871.18923
+  tps: 336861.45248
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-AlacrityofXuen-103989"
  value: {
-  dps: 403263.40264
-  tps: 319691.44641
+  dps: 403340.81379
+  tps: 319651.39222
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-ArcaneBadgeoftheShieldwall-93347"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-ArrowflightMedallion-93258"
  value: {
-  dps: 415871.91029
-  tps: 330560.00512
+  dps: 414542.83127
+  tps: 328884.01623
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-AssuranceofConsequence-105472"
  value: {
-  dps: 452343.55138
-  tps: 355613.7657
+  dps: 450334.54526
+  tps: 353515.2935
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-AusterePrimalDiamond"
  value: {
-  dps: 420984.90219
-  tps: 327999.55105
+  dps: 421012.61177
+  tps: 327577.67733
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-BadJuju-96781"
  value: {
-  dps: 435643.33693
-  tps: 346230.35735
+  dps: 434387.61996
+  tps: 344679.40592
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-BadgeofKypariZar-84079"
  value: {
-  dps: 408240.85228
-  tps: 324976.70902
+  dps: 407140.49174
+  tps: 323477.47049
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-BattlegearoftheSaurokStalker"
  value: {
-  dps: 326660.5796
-  tps: 249483.36637
+  dps: 325941.92678
+  tps: 248387.60549
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-BattlegearoftheUnblinkingVigil"
  value: {
-  dps: 329970.30739
-  tps: 255186.90298
+  dps: 331858.10524
+  tps: 256612.91795
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-BlackBloodofY'Shaarj-105648"
  value: {
-  dps: 412530.43732
-  tps: 325626.89113
+  dps: 412739.1878
+  tps: 325760.89067
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-BlossomofPureSnow-89081"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-BottleofInfiniteStars-87057"
  value: {
-  dps: 423044.52318
-  tps: 336511.88599
+  dps: 422702.77973
+  tps: 335478.25533
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-BraidofTenSongs-84072"
  value: {
-  dps: 407134.72456
-  tps: 322760.08561
+  dps: 408133.08289
+  tps: 323236.38394
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Brawler'sStatue-257885"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-BreathoftheHydra-96827"
  value: {
-  dps: 408811.22244
-  tps: 322976.06296
+  dps: 409282.36094
+  tps: 323228.08431
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-BroochofMunificentDeeds-87500"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-BrutalTalismanoftheShado-PanAssault-94508"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-BurningPrimalDiamond"
  value: {
-  dps: 428537.09718
-  tps: 335476.48367
+  dps: 428521.20264
+  tps: 335009.88652
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-CapacitivePrimalDiamond"
  value: {
-  dps: 463455.7699
-  tps: 370440.44372
+  dps: 467368.85183
+  tps: 373545.94981
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-CarbonicCarbuncle-81138"
  value: {
-  dps: 408031.83885
-  tps: 324596.0387
+  dps: 407221.83352
+  tps: 323467.35623
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Cha-Ye'sEssenceofBrilliance-96888"
  value: {
-  dps: 410018.41694
-  tps: 326229.84277
+  dps: 409049.35905
+  tps: 324966.52311
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-CharmofTenSongs-84071"
  value: {
-  dps: 408257.79819
-  tps: 323373.89604
+  dps: 407419.2456
+  tps: 322359.91805
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-CommunalIdolofDestruction-101168"
  value: {
-  dps: 408995.01523
-  tps: 325722.45693
+  dps: 407017.18038
+  tps: 323385.78005
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-CommunalStoneofDestruction-101171"
  value: {
-  dps: 407788.8122
-  tps: 324778.00593
+  dps: 406670.01047
+  tps: 323231.58598
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-CommunalStoneofWisdom-101183"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-ContemplationofChi-Ji-103988"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Coren'sColdChromiumCoaster-257880"
  value: {
-  dps: 417618.3433
-  tps: 331444.61674
+  dps: 416168.2044
+  tps: 329645.14409
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-CoreofDecency-87497"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-CourageousPrimalDiamond"
  value: {
-  dps: 420984.90219
-  tps: 327999.55105
+  dps: 421012.61177
+  tps: 327577.67733
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-CraftedDreadfulGladiator'sBadgeofConquest-93419"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-CraftedDreadfulGladiator'sBadgeofDominance-93600"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-CraftedDreadfulGladiator'sBadgeofVictory-93606"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-CraftedDreadfulGladiator'sEmblemofCruelty-93485"
  value: {
-  dps: 406138.61049
-  tps: 322908.96945
+  dps: 404890.59939
+  tps: 321324.05276
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-CraftedDreadfulGladiator'sEmblemofMeditation-93487"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-CraftedDreadfulGladiator'sEmblemofTenacity-93486"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-CraftedDreadfulGladiator'sInsigniaofConquest-93424"
  value: {
-  dps: 416187.03352
-  tps: 330294.46931
+  dps: 415408.48766
+  tps: 329111.42973
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-CraftedDreadfulGladiator'sInsigniaofDominance-93601"
  value: {
-  dps: 402783.55158
-  tps: 320075.47612
+  dps: 401585.21778
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-CraftedDreadfulGladiator'sInsigniaofVictory-93611"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-CraftedMalevolentGladiator'sBadgeofConquest-98755"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-CraftedMalevolentGladiator'sBadgeofDominance-98910"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-CraftedMalevolentGladiator'sBadgeofVictory-98912"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-CraftedMalevolentGladiator'sEmblemofCruelty-98811"
  value: {
-  dps: 406754.68477
-  tps: 323411.56312
+  dps: 405407.91443
+  tps: 321757.61791
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-CraftedMalevolentGladiator'sEmblemofMeditation-98813"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-CraftedMalevolentGladiator'sEmblemofTenacity-98812"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-CraftedMalevolentGladiator'sInsigniaofConquest-98760"
  value: {
-  dps: 418585.17135
-  tps: 332209.78884
+  dps: 417890.19018
+  tps: 330933.49022
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-CraftedMalevolentGladiator'sInsigniaofDominance-98911"
  value: {
-  dps: 402783.55158
-  tps: 320075.47612
+  dps: 401585.21778
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-CraftedMalevolentGladiator'sInsigniaofVictory-98917"
  value: {
-  dps: 402783.55158
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-CurseofHubris-105645"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-CutstitcherMedallion-93255"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Daelo'sFinalWords-87496"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-DarkglowEmbroidery(Rank3)-4893"
  value: {
-  dps: 458505.06227
-  tps: 366814.85584
+  dps: 462474.57307
+  tps: 369964.23637
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-DarkmistVortex-87172"
  value: {
-  dps: 407116.45384
-  tps: 321935.44672
+  dps: 405954.26848
+  tps: 320314.90482
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-DeadeyeBadgeoftheShieldwall-93346"
  value: {
-  dps: 412019.38387
-  tps: 327460.11743
+  dps: 410714.76162
+  tps: 325802.67006
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-DelicateVialoftheSanguinaire-96895"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-DestructivePrimalDiamond"
  value: {
-  dps: 422753.87814
-  tps: 329554.77095
+  dps: 422858.89016
+  tps: 329179.75159
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-DisciplineofXuen-103986"
  value: {
-  dps: 431074.44408
-  tps: 343959.86572
+  dps: 429975.80621
+  tps: 342507.95678
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Dominator'sArcaneBadge-93342"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Dominator'sDeadeyeBadge-93341"
  value: {
-  dps: 412019.38387
-  tps: 327460.11743
+  dps: 410714.76162
+  tps: 325802.67006
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Dominator'sDurableBadge-93345"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Dominator'sKnightlyBadge-93344"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Dominator'sMendingBadge-93343"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-DreadfulGladiator'sBadgeofConquest-84344"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-DreadfulGladiator'sBadgeofDominance-84488"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-DreadfulGladiator'sBadgeofVictory-84490"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-DreadfulGladiator'sEmblemofCruelty-84399"
  value: {
-  dps: 406138.61049
-  tps: 322908.96945
+  dps: 404890.59939
+  tps: 321324.05276
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-DreadfulGladiator'sEmblemofMeditation-84401"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-DreadfulGladiator'sEmblemofTenacity-84400"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-DreadfulGladiator'sInsigniaofConquest-84349"
  value: {
-  dps: 416479.6931
-  tps: 330575.80455
+  dps: 415419.6424
+  tps: 329144.53674
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-DreadfulGladiator'sInsigniaofDominance-84489"
  value: {
-  dps: 402783.55158
-  tps: 320075.47612
+  dps: 401585.21778
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-DreadfulGladiator'sInsigniaofVictory-84495"
  value: {
-  dps: 402783.55158
-  tps: 320075.47612
+  dps: 401585.21778
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-DurableBadgeoftheShieldwall-93350"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-DysmorphicSamophlangeofDiscontinuity-105615"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-EffulgentPrimalDiamond"
  value: {
-  dps: 420984.90219
-  tps: 327999.55105
+  dps: 421012.61177
+  tps: 327577.67733
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-EmberPrimalDiamond"
  value: {
-  dps: 420984.90219
-  tps: 327999.55105
+  dps: 421012.61177
+  tps: 327577.67733
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-EmblemofKypariZar-84077"
  value: {
-  dps: 407760.34745
-  tps: 323404.39744
+  dps: 409834.8608
+  tps: 324492.84913
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-EmblemoftheCatacombs-83733"
  value: {
-  dps: 406341.80608
-  tps: 322724.14612
+  dps: 407119.31734
+  tps: 323241.91848
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-EmptyFruitBarrel-81133"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-EnchantWeapon-BloodyDancingSteel-5125"
  value: {
-  dps: 461200.88688
-  tps: 368323.10327
+  dps: 464921.81312
+  tps: 371247.0054
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-EnchantWeapon-Colossus-4445"
  value: {
-  dps: 451943.46144
-  tps: 360992.79143
+  dps: 455597.72661
+  tps: 363883.47795
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-EnchantWeapon-DancingSteel-4444"
  value: {
-  dps: 461452.11292
-  tps: 368518.7818
+  dps: 465122.04918
+  tps: 371369.20989
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-EnchantWeapon-ElementalForce-4443"
  value: {
-  dps: 453150.34936
-  tps: 362089.41636
+  dps: 455745.71422
+  tps: 364255.27728
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-EnchantWeapon-JadeSpirit-4442"
  value: {
-  dps: 451943.46144
-  tps: 360992.79143
+  dps: 455597.72661
+  tps: 363883.47795
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-EnchantWeapon-River'sSong-4446"
  value: {
-  dps: 451943.46144
-  tps: 360992.79143
+  dps: 455597.72661
+  tps: 363883.47795
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-EnchantWeapon-SpiritofConquest-5124"
  value: {
-  dps: 451943.46144
-  tps: 360992.79143
+  dps: 455595.17823
+  tps: 363883.47795
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-EnchantWeapon-Windsong-4441"
  value: {
-  dps: 453246.65649
-  tps: 361979.39455
+  dps: 453470.04436
+  tps: 361363.77967
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-EnigmaticPrimalDiamond"
  value: {
-  dps: 422753.87814
-  tps: 329554.77095
+  dps: 422858.89016
+  tps: 329179.75159
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-EssenceofTerror-87175"
  value: {
-  dps: 406809.8948
-  tps: 321661.59958
+  dps: 405408.68362
+  tps: 320272.89295
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-EternalPrimalDiamond"
  value: {
-  dps: 420984.90219
-  tps: 327999.55105
+  dps: 421012.61177
+  tps: 327577.67733
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-EvilEyeofGalakras-105491"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401585.21778
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-FabledFeatherofJi-Kun-96842"
  value: {
-  dps: 402786.48537
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-FearwurmBadge-84074"
  value: {
-  dps: 407578.15331
-  tps: 322944.33738
+  dps: 407883.20207
+  tps: 322366.72497
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-FearwurmRelic-84070"
  value: {
-  dps: 407382.08497
-  tps: 322941.67124
+  dps: 407804.73316
+  tps: 322521.12904
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-FelsoulIdolofDestruction-101263"
  value: {
-  dps: 407513.42786
-  tps: 323696.48443
+  dps: 406520.11886
+  tps: 322241.00875
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-FelsoulStoneofDestruction-101266"
  value: {
-  dps: 407901.21844
-  tps: 324837.81628
+  dps: 406650.93207
+  tps: 323198.32617
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-FlashfrozenResinGlobule-100951"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-FlashingSteelTalisman-81265"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-FleetPrimalDiamond"
  value: {
-  dps: 422396.43911
-  tps: 329376.01105
+  dps: 422417.24694
+  tps: 328946.79586
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-ForlornPrimalDiamond"
  value: {
-  dps: 420984.90219
-  tps: 327999.55105
+  dps: 421012.61177
+  tps: 327577.67733
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-FortitudeoftheZandalari-96793"
  value: {
-  dps: 408535.02397
-  tps: 325713.91904
+  dps: 407343.57963
+  tps: 324167.72924
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-FrenziedCrystalofRage-105572"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Fusion-FireCore-105459"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-GazeoftheTwins-96915"
  value: {
-  dps: 412242.18855
-  tps: 328271.72388
+  dps: 411193.31716
+  tps: 326908.67027
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Gerp'sPerfectArrow-87495"
  value: {
-  dps: 405718.55237
-  tps: 322533.45563
+  dps: 404427.21432
+  tps: 320910.32072
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 335532.87453
-  tps: 258403.15497
+  dps: 336948.62827
+  tps: 259469.53697
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Gong-Lu,StrengthofXuen-102249"
  value: {
-  dps: 428757.00963
-  tps: 342975.98513
+  dps: 430980.4348
+  tps: 344384.36395
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-GrievousGladiator'sBadgeofConquest-103145"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-GrievousGladiator'sBadgeofDominance-103308"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-GrievousGladiator'sBadgeofVictory-103314"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-GrievousGladiator'sEmblemofCruelty-103210"
  value: {
-  dps: 408689.937
-  tps: 325079.1914
+  dps: 407662.18933
+  tps: 323748.45003
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-GrievousGladiator'sEmblemofMeditation-103212"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-GrievousGladiator'sEmblemofTenacity-103211"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-GrievousGladiator'sInsigniaofConquest-103150"
  value: {
-  dps: 427747.72842
-  tps: 339246.44687
+  dps: 427243.20597
+  tps: 338199.03977
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-GrievousGladiator'sInsigniaofDominance-103309"
  value: {
-  dps: 402783.55158
-  tps: 320075.47612
+  dps: 401585.21778
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-GrievousGladiator'sInsigniaofVictory-103319"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Haromm'sTalisman-105527"
  value: {
-  dps: 456312.04619
-  tps: 364605.26495
+  dps: 457007.88614
+  tps: 364777.48699
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Hawkmaster'sTalon-89082"
  value: {
-  dps: 415050.09473
-  tps: 329889.34475
+  dps: 413731.84085
+  tps: 328228.16236
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Heart-LesionDefenderIdol-100999"
  value: {
-  dps: 402783.55158
-  tps: 320075.47612
+  dps: 401585.21778
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Heart-LesionDefenderStone-101002"
  value: {
-  dps: 407859.37125
-  tps: 324835.38841
+  dps: 406718.07641
+  tps: 323288.9821
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Heart-LesionIdolofBattle-100991"
  value: {
-  dps: 407017.34284
-  tps: 323621.88742
+  dps: 405672.14726
+  tps: 321959.80601
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Heart-LesionStoneofBattle-100990"
  value: {
-  dps: 407840.18984
-  tps: 324809.11177
+  dps: 406620.47839
+  tps: 323202.50383
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-HeartofFire-81181"
  value: {
-  dps: 405564.72338
-  tps: 322801.36719
+  dps: 404369.8182
+  tps: 321252.64679
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-HeartwarmerMedallion-93260"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-HelmbreakerMedallion-93261"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Horridon'sLastGasp-96757"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-ImpassivePrimalDiamond"
  value: {
-  dps: 422753.87814
-  tps: 329554.77095
+  dps: 422858.89016
+  tps: 329179.75159
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-IndomitablePrimalDiamond"
  value: {
-  dps: 420984.90219
-  tps: 327999.55105
+  dps: 421012.61177
+  tps: 327577.67733
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-InscribedBagofHydra-Spawn-96828"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-InsigniaofKypariZar-84078"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-IronBellyWok-89083"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-IronProtectorTalisman-85181"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-JadeBanditFigurine-86772"
  value: {
-  dps: 413734.9585
-  tps: 328848.96831
+  dps: 412333.85924
+  tps: 327106.09543
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-JadeCharioteerFigurine-86771"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-JadeCourtesanFigurine-86774"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-JadeMagistrateFigurine-86773"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-JadeWarlordFigurine-86775"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Ji-Kun'sRisingWinds-96843"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Juggernaut'sFocusingCrystal-105514"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
-  hps: 10259.90057
+  dps: 401586.64037
+  tps: 318524.38729
+  hps: 10213.69879
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Kardris'ToxicTotem-105540"
  value: {
-  dps: 420067.75151
-  tps: 337016.53607
+  dps: 419639.45987
+  tps: 336560.22437
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-KnightlyBadgeoftheShieldwall-93349"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-KnotofTenSongs-84073"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Kor'kronBookofHurting-92785"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Lao-Chin'sLiquidCourage-89079"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-LeiShen'sFinalOrders-87072"
  value: {
-  dps: 405073.24777
-  tps: 320179.20018
+  dps: 405026.15731
+  tps: 319810.42382
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-LessonsoftheDarkmaster-81268"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-LightdrinkerIdolofRage-101200"
  value: {
-  dps: 419878.69396
-  tps: 333719.88642
+  dps: 419321.28664
+  tps: 332693.13455
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-LightdrinkerStoneofRage-101203"
  value: {
-  dps: 419596.46871
-  tps: 334213.24682
+  dps: 418231.51698
+  tps: 332473.67441
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-LightoftheCosmos-87065"
  value: {
-  dps: 405073.24777
-  tps: 320179.20018
+  dps: 405026.15731
+  tps: 319810.42382
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-LightweaveEmbroidery(Rank3)-4892"
  value: {
-  dps: 458506.66781
-  tps: 366814.85584
+  dps: 462476.17861
+  tps: 369964.23637
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-MalevolentGladiator'sBadgeofConquest-91452"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-MalevolentGladiator'sBadgeofDominance-91753"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-MalevolentGladiator'sBadgeofVictory-91763"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-MalevolentGladiator'sEmblemofCruelty-91562"
  value: {
-  dps: 406754.68477
-  tps: 323411.56312
+  dps: 405407.91443
+  tps: 321757.61791
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-MalevolentGladiator'sEmblemofMeditation-91564"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-MalevolentGladiator'sEmblemofTenacity-91563"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-MalevolentGladiator'sInsigniaofConquest-91457"
  value: {
-  dps: 418853.64574
-  tps: 332435.21856
+  dps: 417843.11515
+  tps: 330938.93169
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-MalevolentGladiator'sInsigniaofDominance-91754"
  value: {
-  dps: 402783.55158
-  tps: 320075.47612
+  dps: 401585.21778
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-MalevolentGladiator'sInsigniaofVictory-91768"
  value: {
-  dps: 402783.55158
-  tps: 320075.47612
+  dps: 401585.21778
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-MarkoftheCatacombs-83731"
  value: {
-  dps: 407661.0867
-  tps: 324478.74727
+  dps: 406377.9936
+  tps: 322850.69304
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-MarkoftheHardenedGrunt-92783"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-MedallionofMystifyingVapors-93257"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-MedallionoftheCatacombs-83734"
  value: {
-  dps: 404809.84036
-  tps: 322061.16064
+  dps: 403614.05562
+  tps: 320511.7971
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-MendingBadgeoftheShieldwall-93348"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-MirrorScope-4700"
  value: {
-  dps: 454412.05237
-  tps: 363155.54486
+  dps: 457895.88136
+  tps: 365884.93082
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-MistdancerDefenderIdol-101089"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-MistdancerDefenderStone-101087"
  value: {
-  dps: 407902.75437
-  tps: 324877.93565
+  dps: 406715.46547
+  tps: 323275.17741
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-MistdancerIdolofRage-101113"
  value: {
-  dps: 419423.19313
-  tps: 333446.30179
+  dps: 418885.8685
+  tps: 332370.7436
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-MistdancerStoneofRage-101117"
  value: {
-  dps: 419624.24342
-  tps: 334295.57262
+  dps: 418237.37906
+  tps: 332504.9457
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-MistdancerStoneofWisdom-101107"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-MithrilWristwatch-257884"
  value: {
-  dps: 407152.20364
-  tps: 323724.09178
+  dps: 405803.73514
+  tps: 322050.10759
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-MountainsageIdolofDestruction-101069"
  value: {
-  dps: 408492.27738
-  tps: 324349.48004
+  dps: 408597.42465
+  tps: 324194.59051
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-MountainsageStoneofDestruction-101072"
  value: {
-  dps: 407871.26797
-  tps: 324829.50603
+  dps: 406595.77177
+  tps: 323161.18061
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-NitroBoosts-4223"
  value: {
-  dps: 463455.7699
-  tps: 370440.44372
+  dps: 467368.85183
+  tps: 373545.94981
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-OathswornDefenderIdol-101303"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-OathswornDefenderStone-101306"
  value: {
-  dps: 407743.95859
-  tps: 324752.23905
+  dps: 406605.90103
+  tps: 323204.58962
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-OathswornIdolofBattle-101295"
  value: {
-  dps: 407015.73731
-  tps: 323621.88742
+  dps: 405672.14726
+  tps: 321959.80601
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-OathswornStoneofBattle-101294"
  value: {
-  dps: 407718.07894
-  tps: 324693.38984
+  dps: 406659.20115
+  tps: 323244.13766
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-PhaseFingers-4697"
  value: {
-  dps: 460702.78168
-  tps: 367684.91188
+  dps: 462591.50039
+  tps: 369284.07223
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-PouchofWhiteAsh-103639"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-PowerfulPrimalDiamond"
  value: {
-  dps: 420984.90219
-  tps: 327999.55105
+  dps: 421012.61177
+  tps: 327577.67733
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-PriceofProgress-81266"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-PridefulGladiator'sBadgeofConquest-103342"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-PridefulGladiator'sBadgeofDominance-103505"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-PridefulGladiator'sBadgeofVictory-103511"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-PridefulGladiator'sEmblemofCruelty-103407"
  value: {
-  dps: 410717.85848
-  tps: 326862.37564
+  dps: 409630.20113
+  tps: 325446.93786
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-PridefulGladiator'sEmblemofMeditation-103409"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-PridefulGladiator'sEmblemofTenacity-103408"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-PridefulGladiator'sInsigniaofConquest-103347"
  value: {
-  dps: 435432.07037
-  tps: 344977.61562
+  dps: 435319.85024
+  tps: 344352.91837
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-PridefulGladiator'sInsigniaofDominance-103506"
  value: {
-  dps: 402783.55158
-  tps: 320075.47612
+  dps: 401585.21778
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-PridefulGladiator'sInsigniaofVictory-103516"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Primordius'TalismanofRage-96873"
  value: {
-  dps: 410017.18391
-  tps: 326229.84277
+  dps: 409047.93646
+  tps: 324966.52311
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-PrismaticPrisonofPride-105474"
  value: {
-  dps: 419149.7724
-  tps: 334710.84661
+  dps: 418143.013
+  tps: 333506.02626
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-PurifiedBindingsofImmerseus-105422"
  value: {
-  dps: 419149.7724
-  tps: 334710.84661
+  dps: 418143.013
+  tps: 333506.02626
  }
 }
 dps_results: {
@@ -1399,582 +1399,582 @@ dps_results: {
 dps_results: {
  key: "TestSurvival-AllItems-Qin-xi'sPolarizingSeal-87075"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-RelicofChi-Ji-79330"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-RelicofKypariZar-84075"
  value: {
-  dps: 407632.87159
-  tps: 323287.29387
+  dps: 407582.19008
+  tps: 323109.17353
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-RelicofNiuzao-79329"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-RelicofXuen-79327"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-RelicofXuen-79328"
  value: {
-  dps: 423829.73339
-  tps: 336470.45128
+  dps: 423211.94297
+  tps: 335216.62981
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-RelicofYu'lon-79331"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Renataki'sSoulCharm-96741"
  value: {
-  dps: 430903.21405
-  tps: 341683.67154
+  dps: 428050.12841
+  tps: 338676.04161
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-ResolveofNiuzao-103990"
  value: {
-  dps: 408223.22446
-  tps: 325408.18155
+  dps: 407031.41683
+  tps: 323861.72611
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-ReverberatingPrimalDiamond"
  value: {
-  dps: 428537.09718
-  tps: 335476.48367
+  dps: 428521.20264
+  tps: 335009.88652
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-RevitalizingPrimalDiamond"
  value: {
-  dps: 428537.09718
-  tps: 335476.48367
+  dps: 428521.20264
+  tps: 335009.88652
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-RuneofRe-Origination-96918"
  value: {
-  dps: 427300.23469
-  tps: 342559.11011
+  dps: 426407.00188
+  tps: 341291.5529
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-SI:7Operative'sManual-92784"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-ScrollofReveredAncestors-89080"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-SearingWords-81267"
  value: {
-  dps: 420825.93932
-  tps: 334134.51597
+  dps: 419378.87267
+  tps: 332267.56833
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Shock-ChargerMedallion-93259"
  value: {
-  dps: 404498.82671
-  tps: 320051.50062
+  dps: 405136.50014
+  tps: 320319.64892
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-SigilofCompassion-83736"
  value: {
-  dps: 404809.84036
-  tps: 322061.16064
+  dps: 403614.05562
+  tps: 320511.7971
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-SigilofDevotion-83740"
  value: {
-  dps: 407994.39091
-  tps: 324773.93267
+  dps: 406712.87905
+  tps: 323137.36159
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-SigilofFidelity-83737"
  value: {
-  dps: 407042.08772
-  tps: 322900.10738
+  dps: 407948.96624
+  tps: 323566.41286
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-SigilofGrace-83738"
  value: {
-  dps: 406947.27961
-  tps: 322781.08271
+  dps: 407594.57097
+  tps: 322902.32049
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-SigilofKypariZar-84076"
  value: {
-  dps: 408268.26675
-  tps: 324989.30347
+  dps: 406992.27537
+  tps: 323363.10478
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-SigilofPatience-83739"
  value: {
-  dps: 402845.04637
-  tps: 320131.14067
+  dps: 401652.51033
+  tps: 318585.66003
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-SigilofRampage-105580"
  value: {
-  dps: 441145.71968
-  tps: 348420.01649
+  dps: 440618.51672
+  tps: 347274.39112
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-SigiloftheCatacombs-83732"
  value: {
-  dps: 406240.17905
-  tps: 321497.01992
+  dps: 408710.29259
+  tps: 323840.92578
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-SinisterPrimalDiamond"
  value: {
-  dps: 422297.19709
-  tps: 329171.21112
+  dps: 422343.48623
+  tps: 328756.63723
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Skeer'sBloodsoakedTalisman-105632"
  value: {
-  dps: 408416.69996
-  tps: 324620.5931
+  dps: 407268.87452
+  tps: 323138.34869
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-SkullrenderMedallion-93256"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-SoothingTalismanoftheShado-PanAssault-94509"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-SoulBarrier-96927"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-SparkofZandalar-96770"
  value: {
-  dps: 408770.20425
-  tps: 322929.16668
+  dps: 409282.36094
+  tps: 323228.08431
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-SpiritsoftheSun-87163"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-SpringrainIdolofDestruction-101023"
  value: {
-  dps: 409347.30926
-  tps: 325211.01824
+  dps: 408175.2644
+  tps: 323745.33493
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-SpringrainIdolofRage-101009"
  value: {
-  dps: 419957.7921
-  tps: 333901.57264
+  dps: 419184.59336
+  tps: 332645.98165
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-SpringrainStoneofDestruction-101026"
  value: {
-  dps: 407907.36349
-  tps: 324863.00189
+  dps: 406654.54493
+  tps: 323217.05709
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-SpringrainStoneofRage-101012"
  value: {
-  dps: 419619.61096
-  tps: 334239.74848
+  dps: 418211.61286
+  tps: 332454.99107
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-SpringrainStoneofWisdom-101041"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Static-Caster'sMedallion-93254"
  value: {
-  dps: 404498.82671
-  tps: 320051.50062
+  dps: 405136.50014
+  tps: 320319.64892
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-SteadfastFootman'sMedallion-92782"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-SteadfastTalismanoftheShado-PanAssault-94507"
  value: {
-  dps: 407599.62544
-  tps: 324796.70658
+  dps: 406407.09122
+  tps: 323249.71985
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-StreamtalkerIdolofDestruction-101222"
  value: {
-  dps: 407497.79188
-  tps: 323871.34871
+  dps: 406456.9113
+  tps: 322471.7714
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-StreamtalkerIdolofRage-101217"
  value: {
-  dps: 419970.27657
-  tps: 334013.85656
+  dps: 419016.94076
+  tps: 332505.50484
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-StreamtalkerStoneofDestruction-101225"
  value: {
-  dps: 407734.66481
-  tps: 324720.50178
+  dps: 406656.39541
+  tps: 323241.9081
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-StreamtalkerStoneofRage-101220"
  value: {
-  dps: 419439.65924
-  tps: 334099.21526
+  dps: 418269.2732
+  tps: 332517.7241
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-StreamtalkerStoneofWisdom-101250"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-StuffofNightmares-87160"
  value: {
-  dps: 407051.51472
-  tps: 324259.25226
+  dps: 405858.34188
+  tps: 322711.79856
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-SunsoulDefenderIdol-101160"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-SunsoulDefenderStone-101163"
  value: {
-  dps: 407920.52642
-  tps: 324868.32027
+  dps: 406705.72183
+  tps: 323264.32507
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-SunsoulIdolofBattle-101152"
  value: {
-  dps: 407015.73731
-  tps: 323621.88742
+  dps: 405672.14726
+  tps: 321959.80601
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-SunsoulStoneofBattle-101151"
  value: {
-  dps: 407807.51384
-  tps: 324768.71498
+  dps: 406692.24517
+  tps: 323259.10853
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-SunsoulStoneofWisdom-101138"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-SymboloftheCatacombs-83735"
  value: {
-  dps: 408191.71893
-  tps: 324885.45248
+  dps: 406974.6914
+  tps: 323316.37444
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-SynapseSprings(MarkII)-4898"
  value: {
-  dps: 463785.19533
-  tps: 370016.40154
+  dps: 465204.08514
+  tps: 371016.65645
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-TalismanofBloodlust-96864"
  value: {
-  dps: 428565.76849
-  tps: 338516.62135
+  dps: 428406.35581
+  tps: 338290.01257
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-TerrorintheMists-87167"
  value: {
-  dps: 425626.47173
-  tps: 338598.88112
+  dps: 424730.93871
+  tps: 337401.91884
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-TheGloamingBlade-88149"
  value: {
-  dps: 463455.7699
-  tps: 370440.44372
+  dps: 467368.85183
+  tps: 373545.94981
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Thok'sAcid-GroovedTooth-105607"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Thok'sTailTip-105609"
  value: {
-  dps: 419149.7724
-  tps: 334710.84661
+  dps: 418143.013
+  tps: 333506.02626
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Thousand-YearPickledEgg-257881"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-TickingEbonDetonator-105612"
  value: {
-  dps: 446691.89645
-  tps: 354332.24673
+  dps: 445276.71876
+  tps: 352765.01258
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Time-LostArtifact-103678"
  value: {
-  dps: 413091.3445
-  tps: 327533.01011
+  dps: 412404.42292
+  tps: 326207.55358
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-TrailseekerIdolofRage-101054"
  value: {
-  dps: 420189.53774
-  tps: 334012.92968
+  dps: 419413.32725
+  tps: 332843.78483
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-TrailseekerStoneofRage-101057"
  value: {
-  dps: 419589.77218
-  tps: 334231.08299
+  dps: 418278.27307
+  tps: 332535.37633
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-TyrannicalGladiator'sBadgeofConquest-100043"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-TyrannicalGladiator'sBadgeofDominance-100016"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-TyrannicalGladiator'sBadgeofVictory-100019"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-TyrannicalGladiator'sEmblemofCruelty-100066"
  value: {
-  dps: 407505.99671
-  tps: 324039.67812
+  dps: 406124.97308
+  tps: 322328.78473
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-TyrannicalGladiator'sEmblemofMeditation-99990"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-TyrannicalGladiator'sEmblemofTenacity-100092"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-TyrannicalGladiator'sInsigniaofConquest-100026"
  value: {
-  dps: 422314.40149
-  tps: 335083.27348
+  dps: 421327.01869
+  tps: 333613.44515
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-TyrannicalGladiator'sInsigniaofDominance-100152"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-TyrannicalGladiator'sInsigniaofVictory-100085"
  value: {
-  dps: 402783.55158
-  tps: 320075.47612
+  dps: 401585.21778
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-TyrannicalPrimalDiamond"
  value: {
-  dps: 420984.90219
-  tps: 327999.55105
+  dps: 421012.61177
+  tps: 327577.67733
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-UnerringVisionofLeiShen-96930"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-VaporshieldMedallion-93262"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-VialofDragon'sBlood-87063"
  value: {
-  dps: 406780.77698
-  tps: 323995.35254
+  dps: 405587.4422
+  tps: 322447.66954
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-VialofIchorousBlood-100963"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-VialofLivingCorruption-105568"
  value: {
-  dps: 402784.78461
-  tps: 320075.47612
+  dps: 401586.64037
+  tps: 318524.38729
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-ViciousTalismanoftheShado-PanAssault-94511"
  value: {
-  dps: 429976.86119
-  tps: 339857.95414
+  dps: 429243.59044
+  tps: 338374.47893
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-VisionofthePredator-81192"
  value: {
-  dps: 406976.79774
-  tps: 323615.88137
+  dps: 405864.28747
+  tps: 322192.93837
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-VolatileTalismanoftheShado-PanAssault-94510"
  value: {
-  dps: 404816.00053
-  tps: 320782.76753
+  dps: 405409.78543
+  tps: 320635.80741
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-WindsweptPages-81125"
  value: {
-  dps: 415816.55775
-  tps: 328701.74528
+  dps: 417867.26869
+  tps: 330660.86596
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-WoundripperMedallion-93253"
  value: {
-  dps: 415871.91029
-  tps: 330560.00512
+  dps: 414542.83127
+  tps: 328884.01623
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Wushoolay'sFinalChoice-96785"
  value: {
-  dps: 402785.58998
-  tps: 320085.56815
+  dps: 401582.5965
+  tps: 318519.5088
  }
 }
 dps_results: {
@@ -1987,336 +1987,336 @@ dps_results: {
 dps_results: {
  key: "TestSurvival-AllItems-YaungolFireCarrier-86518"
  value: {
-  dps: 463337.59813
-  tps: 370322.27195
+  dps: 467434.72753
+  tps: 373611.8255
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-YaungolSlayerBattlegear"
  value: {
-  dps: 314317.7109
-  tps: 245883.60724
+  dps: 314281.69898
+  tps: 245804.14214
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-Yu'lon'sBite-103987"
  value: {
-  dps: 411530.65744
-  tps: 327366.56644
+  dps: 410158.56526
+  tps: 325705.14355
  }
 }
 dps_results: {
  key: "TestSurvival-AllItems-ZenAlchemistStone-75274"
  value: {
-  dps: 421531.84465
-  tps: 334899.59747
+  dps: 420581.96757
+  tps: 333578.50402
  }
 }
 dps_results: {
  key: "TestSurvival-Average-Default"
  value: {
-  dps: 469007.00788
-  tps: 374592.24562
+  dps: 470917.52202
+  tps: 375681.5949
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-DefaultTalents-Basic-sv-FullBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.66564733313e+06
-  tps: 1.31025422002e+06
+  dps: 1.67819147274e+06
+  tps: 1.32184589594e+06
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-DefaultTalents-Basic-sv-FullBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 468842.87734
-  tps: 374488.81822
+  dps: 471492.25471
+  tps: 376272.49763
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-DefaultTalents-Basic-sv-FullBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 674276.86415
-  tps: 474146.04125
+  dps: 675750.41126
+  tps: 470898.34137
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-DefaultTalents-Basic-sv-NoBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.26305208733e+06
-  tps: 1.01957894674e+06
+  dps: 1.25956738174e+06
+  tps: 1.0180170521e+06
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-DefaultTalents-Basic-sv-NoBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 346423.6982
-  tps: 285405.09716
+  dps: 348981.90242
+  tps: 287699.12559
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-DefaultTalents-Basic-sv-NoBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 418535.6199
-  tps: 319510.23071
+  dps: 424371.64486
+  tps: 323843.62787
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row4_Talent1-Basic-sv-FullBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.77935449889e+06
-  tps: 1.38355254705e+06
+  dps: 1.78802304443e+06
+  tps: 1.39092135181e+06
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row4_Talent1-Basic-sv-FullBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 471045.83609
-  tps: 385196.22823
+  dps: 471125.52375
+  tps: 384871.47854
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row4_Talent1-Basic-sv-FullBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 693608.61136
-  tps: 501113.20023
+  dps: 688092.9702
+  tps: 494561.16872
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row4_Talent1-Basic-sv-NoBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.3496873678e+06
-  tps: 1.07147716886e+06
+  dps: 1.36526372632e+06
+  tps: 1.0845642117e+06
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row4_Talent1-Basic-sv-NoBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 341143.50497
-  tps: 287287.39135
+  dps: 346594.75008
+  tps: 292397.17122
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row4_Talent1-Basic-sv-NoBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 416460.03793
-  tps: 326685.47422
+  dps: 420641.74422
+  tps: 331365.45222
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row4_Talent3-Basic-sv-FullBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.81533930255e+06
-  tps: 1.40373127519e+06
+  dps: 1.81993368561e+06
+  tps: 1.40939241591e+06
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row4_Talent3-Basic-sv-FullBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 460815.03337
-  tps: 382663.45594
+  dps: 463858.20985
+  tps: 385259.65686
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row4_Talent3-Basic-sv-FullBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 662760.57484
-  tps: 485594.61661
+  dps: 666146.89966
+  tps: 485919.19057
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row4_Talent3-Basic-sv-NoBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.36346667948e+06
-  tps: 1.07814333818e+06
+  dps: 1.36574432377e+06
+  tps: 1.08164027899e+06
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row4_Talent3-Basic-sv-NoBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 337198.81603
-  tps: 288293.67305
+  dps: 338921.37789
+  tps: 289580.07641
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row4_Talent3-Basic-sv-NoBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 412194.26549
-  tps: 327618.85069
+  dps: 416018.79023
+  tps: 329211.55139
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row5_Talent2-Basic-sv-FullBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.74308217364e+06
-  tps: 1.35136785542e+06
+  dps: 1.73445580192e+06
+  tps: 1.34477126296e+06
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row5_Talent2-Basic-sv-FullBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 460813.46821
-  tps: 358431.22803
+  dps: 462783.00716
+  tps: 359937.72158
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row5_Talent2-Basic-sv-FullBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 663862.5956
-  tps: 447457.00369
+  dps: 668435.71819
+  tps: 448139.07671
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row5_Talent2-Basic-sv-NoBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.31050267558e+06
-  tps: 1.04495629944e+06
+  dps: 1.30427102845e+06
+  tps: 1.03985427028e+06
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row5_Talent2-Basic-sv-NoBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 339508.45014
-  tps: 273136.36258
+  dps: 338933.736
+  tps: 273219.48454
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row5_Talent2-Basic-sv-NoBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 402521.94325
-  tps: 296346.65699
+  dps: 401013.41095
+  tps: 294165.65828
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row5_Talent3-Basic-sv-FullBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.72520451014e+06
-  tps: 1.34218963304e+06
+  dps: 1.72106499885e+06
+  tps: 1.33980640803e+06
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row5_Talent3-Basic-sv-FullBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 456264.58884
-  tps: 358288.29476
+  dps: 456775.7741
+  tps: 358056.85053
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row5_Talent3-Basic-sv-FullBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 648886.67068
-  tps: 440712.51822
+  dps: 658656.90813
+  tps: 448594.21823
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row5_Talent3-Basic-sv-NoBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.29591761118e+06
-  tps: 1.03771550412e+06
+  dps: 1.28596894257e+06
+  tps: 1.0310095624e+06
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row5_Talent3-Basic-sv-NoBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 333158.96604
-  tps: 269896.18327
+  dps: 337248.76387
+  tps: 273362.44109
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row5_Talent3-Basic-sv-NoBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 391165.18552
-  tps: 287020.63053
+  dps: 399661.31506
+  tps: 294168.60814
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row6_Talent1-Basic-sv-FullBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.53083623774e+06
-  tps: 1.18023936075e+06
+  dps: 1.54463978019e+06
+  tps: 1.19253513474e+06
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row6_Talent1-Basic-sv-FullBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 468885.89919
-  tps: 378079.19955
+  dps: 471199.06463
+  tps: 380099.67589
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row6_Talent1-Basic-sv-FullBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 654408.03906
-  tps: 471090.19748
+  dps: 666617.28131
+  tps: 479305.09191
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row6_Talent1-Basic-sv-NoBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.1612316824e+06
-  tps: 912565.53498
+  dps: 1.15727796456e+06
+  tps: 910729.5395
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row6_Talent1-Basic-sv-NoBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 348804.04344
-  tps: 287612.51416
+  dps: 347020.97685
+  tps: 286341.94546
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row6_Talent1-Basic-sv-NoBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 416537.46147
-  tps: 318612.35223
+  dps: 421080.62636
+  tps: 320229.87694
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row6_Talent2-Basic-sv-FullBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.58057058549e+06
-  tps: 1.20336806249e+06
+  dps: 1.58421890257e+06
+  tps: 1.20763881036e+06
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row6_Talent2-Basic-sv-FullBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 464353.10204
-  tps: 373486.86548
+  dps: 465260.11873
+  tps: 373782.58718
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row6_Talent2-Basic-sv-FullBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 652572.37173
-  tps: 468915.74468
+  dps: 659542.54598
+  tps: 472053.75382
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row6_Talent2-Basic-sv-NoBuffs-24.0yards-LongMultiTarget"
  value: {
-  dps: 1.17591910254e+06
-  tps: 913425.51704
+  dps: 1.18882429829e+06
+  tps: 923585.02228
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row6_Talent2-Basic-sv-NoBuffs-24.0yards-LongSingleTarget"
  value: {
-  dps: 342037.38392
-  tps: 281222.71085
+  dps: 343075.02093
+  tps: 282430.61698
  }
 }
 dps_results: {
  key: "TestSurvival-Settings-Orc-p5-Row6_Talent2-Basic-sv-NoBuffs-24.0yards-ShortSingleTarget"
  value: {
-  dps: 411746.10878
-  tps: 314632.56941
+  dps: 415245.67489
+  tps: 315730.65033
  }
 }
 dps_results: {
  key: "TestSurvival-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 458881.02252
-  tps: 372928.71932
+  dps: 462968.63728
+  tps: 375607.4172
  }
 }

--- a/sim/monk/brewmaster/TestBrewmaster.results
+++ b/sim/monk/brewmaster/TestBrewmaster.results
@@ -897,10 +897,10 @@ dps_results: {
 dps_results: {
  key: "TestBrewmaster-AllItems-Fen-Yu,FuryofXuen-102248"
  value: {
-  dps: 592850.01168
-  tps: 3.23627100002e+06
-  dtps: 41847.61817
-  hps: 83393.18906
+  dps: 597711.41313
+  tps: 3.2701776799e+06
+  dtps: 41700.33861
+  hps: 83272.35999
  }
 }
 dps_results: {
@@ -1005,10 +1005,10 @@ dps_results: {
 dps_results: {
  key: "TestBrewmaster-AllItems-Gong-Lu,StrengthofXuen-102249"
  value: {
-  dps: 590572.39887
-  tps: 3.23960468907e+06
-  dtps: 45674.71951
-  hps: 84587.44462
+  dps: 591878.97825
+  tps: 3.24836101777e+06
+  dtps: 46020.89138
+  hps: 84757.30906
  }
 }
 dps_results: {
@@ -2697,109 +2697,109 @@ dps_results: {
 dps_results: {
  key: "TestBrewmaster-Settings-Orc-p5_bis_offensive_dw-DefaultTalents-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 4.37357057139e+06
-  tps: 2.720285778593e+07
-  dtps: 503756.59451
-  hps: 414334.69389
+  dps: 4.42063047566e+06
+  tps: 2.752124337041e+07
+  dtps: 498466.92732
+  hps: 411644.16642
  }
 }
 dps_results: {
  key: "TestBrewmaster-Settings-Orc-p5_bis_offensive_dw-DefaultTalents-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 319242.41603
-  tps: 1.96822497135e+06
-  dtps: 8729.69962
-  hps: 52311.51862
+  dps: 320169.62505
+  tps: 1.97522490899e+06
+  dtps: 9124.57273
+  hps: 51987.50836
  }
 }
 dps_results: {
  key: "TestBrewmaster-Settings-Orc-p5_bis_offensive_dw-DefaultTalents-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 415771.35187
-  tps: 2.18983884063e+06
-  dtps: 8889.48891
-  hps: 55331.73152
+  dps: 416386.08021
+  tps: 2.19541914862e+06
+  dtps: 9215.024
+  hps: 55714.2037
  }
 }
 dps_results: {
  key: "TestBrewmaster-Settings-Orc-p5_bis_offensive_dw-DefaultTalents-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3.24780696259e+06
-  tps: 2.021628717231e+07
-  dtps: 652844.8381
-  hps: 354562.70157
+  dps: 3.26089476899e+06
+  tps: 2.03005551041e+07
+  dtps: 655227.60099
+  hps: 354384.70478
  }
 }
 dps_results: {
  key: "TestBrewmaster-Settings-Orc-p5_bis_offensive_dw-DefaultTalents-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 250193.5831
-  tps: 1.5598590471e+06
-  dtps: 13342.74658
-  hps: 46757.0446
+  dps: 250448.24875
+  tps: 1.5597039827e+06
+  dtps: 13784.58465
+  hps: 46339.7375
  }
 }
 dps_results: {
  key: "TestBrewmaster-Settings-Orc-p5_bis_offensive_dw-DefaultTalents-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 293954.99947
-  tps: 1.58329152953e+06
-  dtps: 15122.30751
-  hps: 47331.20826
+  dps: 297546.86619
+  tps: 1.60604690669e+06
+  dtps: 14594.147
+  hps: 47393.86371
  }
 }
 dps_results: {
  key: "TestBrewmaster-Settings-Orc-p5_bis_offensive_dw-Dungeon-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 7.65047463491e+06
-  tps: 5.326509767925e+07
-  dtps: 491661.74278
-  hps: 551787.27108
+  dps: 7.66568104652e+06
+  tps: 5.337154256058e+07
+  dtps: 491123.36747
+  hps: 552787.47378
  }
 }
 dps_results: {
  key: "TestBrewmaster-Settings-Orc-p5_bis_offensive_dw-Dungeon-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 334021.06729
-  tps: 2.29414205387e+06
-  dtps: 17678.30754
-  hps: 51589.32772
+  dps: 336757.18791
+  tps: 2.31316716394e+06
+  dtps: 17142.66698
+  hps: 51262.36782
  }
 }
 dps_results: {
  key: "TestBrewmaster-Settings-Orc-p5_bis_offensive_dw-Dungeon-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 406454.89601
-  tps: 2.62908941504e+06
-  dtps: 12420.67493
-  hps: 52012.38304
+  dps: 406823.37909
+  tps: 2.63097038582e+06
+  dtps: 11852.5345
+  hps: 51853.00757
  }
 }
 dps_results: {
  key: "TestBrewmaster-Settings-Orc-p5_bis_offensive_dw-Dungeon-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 5.55712618051e+06
-  tps: 3.889988326355e+07
-  dtps: 627185.06699
-  hps: 555683.65537
+  dps: 5.58246296958e+06
+  tps: 3.907724078705e+07
+  dtps: 633386.27723
+  hps: 559166.14753
  }
 }
 dps_results: {
  key: "TestBrewmaster-Settings-Orc-p5_bis_offensive_dw-Dungeon-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 258079.58615
-  tps: 1.80655710302e+06
-  dtps: 24095.44131
-  hps: 50027.57658
+  dps: 259187.15831
+  tps: 1.81431010814e+06
+  dtps: 23400.47105
+  hps: 49187.12508
  }
 }
 dps_results: {
  key: "TestBrewmaster-Settings-Orc-p5_bis_offensive_dw-Dungeon-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 265403.14199
-  tps: 1.85782199393e+06
-  dtps: 20454.05464
-  hps: 45889.78078
+  dps: 266432.8466
+  tps: 1.86502992623e+06
+  dtps: 20142.00833
+  hps: 45339.81261
  }
 }
 dps_results: {
@@ -3021,109 +3021,109 @@ dps_results: {
 dps_results: {
  key: "TestBrewmaster-Settings-Troll-p5_bis_offensive_dw-DefaultTalents-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 4.36505981765e+06
-  tps: 2.719869126743e+07
-  dtps: 508564.57579
-  hps: 410696.33156
+  dps: 4.41083518065e+06
+  tps: 2.749267263733e+07
+  dtps: 507640.00055
+  hps: 409727.38633
  }
 }
 dps_results: {
  key: "TestBrewmaster-Settings-Troll-p5_bis_offensive_dw-DefaultTalents-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 318234.7485
-  tps: 1.96606854642e+06
-  dtps: 9171.63302
-  hps: 51320.35736
+  dps: 320426.77692
+  tps: 1.97963827699e+06
+  dtps: 8975.18807
+  hps: 51262.63692
  }
 }
 dps_results: {
  key: "TestBrewmaster-Settings-Troll-p5_bis_offensive_dw-DefaultTalents-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 417782.60638
-  tps: 2.20907069699e+06
-  dtps: 9709.45817
-  hps: 52730.03191
+  dps: 419042.48004
+  tps: 2.21703662561e+06
+  dtps: 9829.66282
+  hps: 52291.6331
  }
 }
 dps_results: {
  key: "TestBrewmaster-Settings-Troll-p5_bis_offensive_dw-DefaultTalents-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3.22681282485e+06
-  tps: 2.011140618279e+07
-  dtps: 681540.30672
-  hps: 355495.6635
+  dps: 3.28694876919e+06
+  tps: 2.052654319898e+07
+  dtps: 661198.96879
+  hps: 357929.9765
  }
 }
 dps_results: {
  key: "TestBrewmaster-Settings-Troll-p5_bis_offensive_dw-DefaultTalents-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 248953.48645
-  tps: 1.55206383671e+06
-  dtps: 14072.53497
-  hps: 46753.32537
+  dps: 248121.16419
+  tps: 1.54663582479e+06
+  dtps: 14194.29722
+  hps: 47465.42127
  }
 }
 dps_results: {
  key: "TestBrewmaster-Settings-Troll-p5_bis_offensive_dw-DefaultTalents-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 292895.80237
-  tps: 1.58354634848e+06
-  dtps: 15550.87525
-  hps: 48577.13591
+  dps: 293914.40243
+  tps: 1.58793319122e+06
+  dtps: 15916.12696
+  hps: 48894.60158
  }
 }
 dps_results: {
  key: "TestBrewmaster-Settings-Troll-p5_bis_offensive_dw-Dungeon-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 8.02427886306e+06
-  tps: 5.581862013011e+07
-  dtps: 476754.82215
-  hps: 544611.82074
+  dps: 8.03657561368e+06
+  tps: 5.590469738446e+07
+  dtps: 477457.09695
+  hps: 543347.0496
  }
 }
 dps_results: {
  key: "TestBrewmaster-Settings-Troll-p5_bis_offensive_dw-Dungeon-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 336192.7724
-  tps: 2.30658595039e+06
-  dtps: 17098.17954
-  hps: 51153.62558
+  dps: 336421.88711
+  tps: 2.30793393127e+06
+  dtps: 16411.23211
+  hps: 50478.20476
  }
 }
 dps_results: {
  key: "TestBrewmaster-Settings-Troll-p5_bis_offensive_dw-Dungeon-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 407390.27025
-  tps: 2.62141841926e+06
-  dtps: 10278.51362
-  hps: 50619.31012
+  dps: 406740.61064
+  tps: 2.6159413975e+06
+  dtps: 10960.78167
+  hps: 50087.37683
  }
 }
 dps_results: {
  key: "TestBrewmaster-Settings-Troll-p5_bis_offensive_dw-Dungeon-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 5.61219213024e+06
-  tps: 3.928534491168e+07
-  dtps: 660614.17051
-  hps: 543534.19498
+  dps: 5.61217106429e+06
+  tps: 3.928519745e+07
+  dtps: 658457.85397
+  hps: 541754.88897
  }
 }
 dps_results: {
  key: "TestBrewmaster-Settings-Troll-p5_bis_offensive_dw-Dungeon-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 258235.64904
-  tps: 1.80764954326e+06
-  dtps: 24162.18083
-  hps: 49730.62978
+  dps: 259925.86526
+  tps: 1.81948105681e+06
+  dtps: 24299.07177
+  hps: 50191.8199
  }
 }
 dps_results: {
  key: "TestBrewmaster-Settings-Troll-p5_bis_offensive_dw-Dungeon-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 267395.35247
-  tps: 1.87176746729e+06
-  dtps: 22169.40432
-  hps: 50588.66128
+  dps: 270816.51986
+  tps: 1.89571563904e+06
+  dtps: 22311.35003
+  hps: 50977.29741
  }
 }
 dps_results: {

--- a/sim/monk/windwalker/TestWindwalker.results
+++ b/sim/monk/windwalker/TestWindwalker.results
@@ -33,1561 +33,1561 @@ character_stats_results: {
 dps_results: {
  key: "TestWindwalker-AllItems-AgilePrimalDiamond"
  value: {
-  dps: 501340.32031
-  tps: 485185.83437
-  hps: 12254.50024
+  dps: 505980.07321
+  tps: 489797.91603
+  hps: 12171.91553
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-AlacrityofXuen-103989"
  value: {
-  dps: 476759.82947
-  tps: 461790.15856
-  hps: 11075.52235
+  dps: 484357.25064
+  tps: 469419.29371
+  hps: 10933.17152
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-ArcaneBadgeoftheShieldwall-93347"
  value: {
-  dps: 456877.34038
-  tps: 441808.20929
-  hps: 10605.39624
+  dps: 458734.39587
+  tps: 443728.46244
+  hps: 10501.00754
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-ArmorofSevenSacredSeals"
  value: {
-  dps: 341438.22387
-  tps: 326711.11785
-  hps: 9326.15563
+  dps: 342018.1632
+  tps: 327253.8311
+  hps: 9365.48179
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-ArmoroftheRedCrane"
  value: {
-  dps: 315450.16543
-  tps: 302011.74373
-  hps: 8805.77963
+  dps: 320806.71421
+  tps: 307095.44688
+  hps: 8832.69073
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-ArrowflightMedallion-93258"
  value: {
-  dps: 460160.3394
-  tps: 443016.03552
-  hps: 12666.55188
+  dps: 463741.575
+  tps: 446663.94056
+  hps: 13116.3866
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-AssuranceofConsequence-105472"
  value: {
-  dps: 502715.47365
-  tps: 486705.4801
-  hps: 11968.39584
+  dps: 497494.48949
+  tps: 481522.58036
+  hps: 12068.99977
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-AusterePrimalDiamond"
  value: {
-  dps: 489281.87704
-  tps: 473226.36279
-  hps: 12066.05135
+  dps: 493938.64986
+  tps: 477868.82137
+  hps: 11988.31377
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-BadJuju-96781"
  value: {
-  dps: 490763.31081
-  tps: 475358.12917
-  hps: 11706.08437
+  dps: 488419.99286
+  tps: 473069.53284
+  hps: 11739.03349
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-BadgeofKypariZar-84079"
  value: {
-  dps: 456190.07845
-  tps: 441537.40148
-  hps: 11673.28156
+  dps: 450693.4344
+  tps: 436273.32618
+  hps: 11957.14898
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-BattlegearofSevenSacredSeals"
  value: {
-  dps: 341804.7805
-  tps: 327498.74919
-  hps: 8977.09739
+  dps: 342307.32558
+  tps: 327932.49264
+  hps: 8852.2567
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-BattlegearoftheRedCrane"
  value: {
-  dps: 322843.58993
-  tps: 309144.73618
-  hps: 8640.3488
+  dps: 324566.56087
+  tps: 310707.61711
+  hps: 8827.507
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-BlackBloodofY'Shaarj-105648"
  value: {
-  dps: 405075.62982
-  tps: 389603.38896
-  hps: 9910.47204
+  dps: 401575.20173
+  tps: 386137.7593
+  hps: 9669.8803
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-BlossomofPureSnow-89081"
  value: {
-  dps: 449387.0226
-  tps: 432868.17296
-  hps: 12227.53267
+  dps: 452120.2674
+  tps: 435692.64139
+  hps: 12662.64929
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-BottleofInfiniteStars-87057"
  value: {
-  dps: 483187.45666
-  tps: 468443.75985
-  hps: 11426.21632
+  dps: 482048.31338
+  tps: 467308.92327
+  hps: 11505.76251
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-BraidofTenSongs-84072"
  value: {
-  dps: 461036.88638
-  tps: 446495.50935
-  hps: 10787.02497
+  dps: 462196.69794
+  tps: 447524.87095
+  hps: 10831.71701
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Brawler'sStatue-257885"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-BreathoftheHydra-96827"
  value: {
-  dps: 404774.73684
-  tps: 389387.85591
-  hps: 9981.45378
+  dps: 405181.22958
+  tps: 389785.39707
+  hps: 9997.55624
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-BroochofMunificentDeeds-87500"
  value: {
-  dps: 463775.39642
-  tps: 449758.74474
-  hps: 10998.39425
+  dps: 463908.24514
+  tps: 449895.73541
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-BrutalTalismanoftheShado-PanAssault-94508"
  value: {
-  dps: 470048.04895
-  tps: 455465.03031
-  hps: 11267.79107
+  dps: 470075.68651
+  tps: 455519.18446
+  hps: 11311.24635
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-BurningPrimalDiamond"
  value: {
-  dps: 499243.54725
-  tps: 483185.73715
-  hps: 12179.76241
+  dps: 503825.47106
+  tps: 487753.34672
+  hps: 12097.27986
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-CapacitivePrimalDiamond"
  value: {
-  dps: 517141.00444
-  tps: 501176.13904
-  hps: 11925.01344
+  dps: 520150.06864
+  tps: 503901.76797
+  hps: 12094.1058
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-CarbonicCarbuncle-81138"
  value: {
-  dps: 461179.2219
-  tps: 446507.29927
-  hps: 11697.22018
+  dps: 455674.14698
+  tps: 440987.61269
+  hps: 11668.09045
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Cha-Ye'sEssenceofBrilliance-96888"
  value: {
-  dps: 393722.88019
-  tps: 376790.13575
-  hps: 13894.16474
+  dps: 390277.71665
+  tps: 373240.23517
+  hps: 14062.09391
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-CharmofTenSongs-84071"
  value: {
-  dps: 400989.62643
-  tps: 384063.18666
-  hps: 12636.69249
+  dps: 401543.03538
+  tps: 384491.54698
+  hps: 12838.15389
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-CommunalIdolofDestruction-101168"
  value: {
-  dps: 466662.12353
-  tps: 452019.14479
-  hps: 10850.65213
+  dps: 480481.01438
+  tps: 466039.12949
+  hps: 10807.31606
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-CommunalStoneofDestruction-101171"
  value: {
-  dps: 468134.50755
-  tps: 454123.31511
-  hps: 10998.39425
+  dps: 468287.77089
+  tps: 454275.26115
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-CommunalStoneofWisdom-101183"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-ContemplationofChi-Ji-103988"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Coren'sColdChromiumCoaster-257880"
  value: {
-  dps: 398806.84104
-  tps: 381238.22807
-  hps: 14332.64995
+  dps: 394934.93593
+  tps: 377272.98574
+  hps: 14502.02793
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-CoreofDecency-87497"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-CourageousPrimalDiamond"
  value: {
-  dps: 489277.62067
-  tps: 473222.10641
-  hps: 12066.05135
+  dps: 493935.15571
+  tps: 477865.32722
+  hps: 11988.31377
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-CraftedDreadfulGladiator'sBadgeofConquest-93419"
  value: {
-  dps: 471232.34004
-  tps: 456732.87627
-  hps: 11206.70199
+  dps: 470555.88774
+  tps: 456090.77097
+  hps: 11238.15616
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-CraftedDreadfulGladiator'sBadgeofDominance-93600"
  value: {
-  dps: 463761.90372
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463893.7257
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-CraftedDreadfulGladiator'sBadgeofVictory-93606"
  value: {
-  dps: 466136.8673
-  tps: 451932.00354
-  hps: 11097.58841
+  dps: 466276.53808
+  tps: 452076.62327
+  hps: 11129.65882
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-CraftedDreadfulGladiator'sEmblemofCruelty-93485"
  value: {
-  dps: 391273.4553
-  tps: 374417.16838
-  hps: 13795.92401
+  dps: 387872.53195
+  tps: 370946.45318
+  hps: 13983.10377
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-CraftedDreadfulGladiator'sEmblemofMeditation-93487"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-CraftedDreadfulGladiator'sEmblemofTenacity-93486"
  value: {
-  dps: 463776.64801
-  tps: 449759.99633
-  hps: 10998.39425
+  dps: 463909.71336
+  tps: 449897.20362
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-CraftedDreadfulGladiator'sInsigniaofConquest-93424"
  value: {
-  dps: 475222.5125
-  tps: 460624.70821
-  hps: 11347.7826
+  dps: 474578.74224
+  tps: 460011.42946
+  hps: 11403.04146
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-CraftedDreadfulGladiator'sInsigniaofDominance-93601"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-CraftedDreadfulGladiator'sInsigniaofVictory-93611"
  value: {
-  dps: 467475.05486
-  tps: 453227.14063
-  hps: 11168.32848
+  dps: 467525.54115
+  tps: 453290.39501
+  hps: 11199.42683
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-CraftedMalevolentGladiator'sBadgeofConquest-98755"
  value: {
-  dps: 472362.87884
-  tps: 457773.6402
-  hps: 11244.73542
+  dps: 471639.45731
+  tps: 457081.97874
+  hps: 11275.97478
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-CraftedMalevolentGladiator'sBadgeofDominance-98910"
  value: {
-  dps: 463761.90372
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463893.7257
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-CraftedMalevolentGladiator'sBadgeofVictory-98912"
  value: {
-  dps: 466570.49499
-  tps: 452330.27017
-  hps: 11115.69957
+  dps: 466711.59883
+  tps: 452476.5367
+  hps: 11147.66769
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-CraftedMalevolentGladiator'sEmblemofCruelty-98811"
  value: {
-  dps: 391650.69887
-  tps: 374775.27384
-  hps: 13816.3152
+  dps: 388170.26143
+  tps: 371225.68616
+  hps: 13995.29763
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-CraftedMalevolentGladiator'sEmblemofMeditation-98813"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-CraftedMalevolentGladiator'sEmblemofTenacity-98812"
  value: {
-  dps: 463778.33621
-  tps: 449761.68452
-  hps: 10998.39425
+  dps: 463911.69373
+  tps: 449899.184
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-CraftedMalevolentGladiator'sInsigniaofConquest-98760"
  value: {
-  dps: 477729.66442
-  tps: 463035.47263
-  hps: 11407.04416
+  dps: 476720.48603
+  tps: 462050.23276
+  hps: 11461.27959
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-CraftedMalevolentGladiator'sInsigniaofDominance-98911"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-CraftedMalevolentGladiator'sInsigniaofVictory-98917"
  value: {
-  dps: 468234.33991
-  tps: 453950.87396
-  hps: 11194.27544
+  dps: 468359.16617
+  tps: 454083.09082
+  hps: 11234.27134
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-CurseofHubris-105645"
  value: {
-  dps: 453941.93799
-  tps: 437143.86748
-  hps: 12499.2185
+  dps: 462347.7918
+  tps: 445687.98239
+  hps: 12819.0004
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-CutstitcherMedallion-93255"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Daelo'sFinalWords-87496"
  value: {
-  dps: 462146.83057
-  tps: 447620.11122
-  hps: 11232.40912
+  dps: 465285.38679
+  tps: 450767.13641
+  hps: 11151.13024
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-DarkglowEmbroidery(Rank3)-4893"
  value: {
-  dps: 515531.6294
-  tps: 499583.5376
-  hps: 11902.98151
+  dps: 518372.69899
+  tps: 502144.40986
+  hps: 12077.20666
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-DarkmistVortex-87172"
  value: {
-  dps: 478604.40792
-  tps: 463807.32635
-  hps: 10905.41442
+  dps: 480605.24066
+  tps: 465681.43315
+  hps: 10882.05324
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-DeadeyeBadgeoftheShieldwall-93346"
  value: {
-  dps: 474167.3162
-  tps: 459775.13139
-  hps: 11275.59841
+  dps: 474115.24488
+  tps: 459737.68419
+  hps: 11308.93544
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-DelicateVialoftheSanguinaire-96895"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-DestructivePrimalDiamond"
  value: {
-  dps: 410618.90482
-  tps: 391107.80974
-  hps: 15209.47811
+  dps: 417010.57221
+  tps: 397467.10073
+  hps: 15098.35412
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-DisciplineofXuen-103986"
  value: {
-  dps: 487768.71824
-  tps: 472984.90904
-  hps: 11566.16593
+  dps: 487169.45332
+  tps: 472391.19531
+  hps: 11600.24342
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Dominator'sArcaneBadge-93342"
  value: {
-  dps: 456877.34038
-  tps: 441808.20929
-  hps: 10605.39624
+  dps: 458734.39587
+  tps: 443728.46244
+  hps: 10501.00754
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Dominator'sDeadeyeBadge-93341"
  value: {
-  dps: 474167.3162
-  tps: 459775.13139
-  hps: 11275.59841
+  dps: 474115.24488
+  tps: 459737.68419
+  hps: 11308.93544
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Dominator'sDurableBadge-93345"
  value: {
-  dps: 466008.13809
-  tps: 451991.4864
-  hps: 10998.39425
+  dps: 466251.69639
+  tps: 452239.18666
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Dominator'sKnightlyBadge-93344"
  value: {
-  dps: 468769.93937
-  tps: 454604.59919
-  hps: 11130.39623
+  dps: 469003.41423
+  tps: 454841.6707
+  hps: 11163.36324
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Dominator'sMendingBadge-93343"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-DreadfulGladiator'sBadgeofConquest-84344"
  value: {
-  dps: 471232.34004
-  tps: 456732.87627
-  hps: 11206.70199
+  dps: 470555.88774
+  tps: 456090.77097
+  hps: 11238.15616
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-DreadfulGladiator'sBadgeofDominance-84488"
  value: {
-  dps: 463761.90372
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463893.7257
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-DreadfulGladiator'sBadgeofVictory-84490"
  value: {
-  dps: 466136.8673
-  tps: 451932.00354
-  hps: 11097.58841
+  dps: 466276.53808
+  tps: 452076.62327
+  hps: 11129.65882
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-DreadfulGladiator'sEmblemofCruelty-84399"
  value: {
-  dps: 391273.4553
-  tps: 374417.16838
-  hps: 13795.92401
+  dps: 387872.53195
+  tps: 370946.45318
+  hps: 13983.10377
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-DreadfulGladiator'sEmblemofMeditation-84401"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-DreadfulGladiator'sEmblemofTenacity-84400"
  value: {
-  dps: 463776.64801
-  tps: 449759.99633
-  hps: 10998.39425
+  dps: 463909.71336
+  tps: 449897.20362
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-DreadfulGladiator'sInsigniaofConquest-84349"
  value: {
-  dps: 475760.6288
-  tps: 461158.28929
-  hps: 11346.7446
+  dps: 474787.19877
+  tps: 460234.14306
+  hps: 11401.38068
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-DreadfulGladiator'sInsigniaofDominance-84489"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-DreadfulGladiator'sInsigniaofVictory-84495"
  value: {
-  dps: 467536.22407
-  tps: 453281.9581
-  hps: 11159.57969
+  dps: 467524.35969
+  tps: 453286.09663
+  hps: 11200.16826
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-DurableBadgeoftheShieldwall-93350"
  value: {
-  dps: 466008.13809
-  tps: 451991.4864
-  hps: 10998.39425
+  dps: 466251.69639
+  tps: 452239.18666
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-DysmorphicSamophlangeofDiscontinuity-105615"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463893.7257
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-EffulgentPrimalDiamond"
  value: {
-  dps: 489281.87704
-  tps: 473226.36279
-  hps: 12066.05135
+  dps: 493938.64986
+  tps: 477868.82137
+  hps: 11988.31377
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-EmberPrimalDiamond"
  value: {
-  dps: 489277.62067
-  tps: 473222.10641
-  hps: 12066.05135
+  dps: 493935.15571
+  tps: 477865.32722
+  hps: 11988.31377
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-EmblemofKypariZar-84077"
  value: {
-  dps: 399335.33724
-  tps: 382422.56269
-  hps: 12657.88354
+  dps: 400635.28679
+  tps: 383672.37223
+  hps: 12791.95093
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-EmblemoftheCatacombs-83733"
  value: {
-  dps: 440422.63023
-  tps: 425275.35939
-  hps: 10413.90324
+  dps: 443859.81872
+  tps: 428709.7176
+  hps: 10471.70633
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-EmptyFruitBarrel-81133"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463893.7257
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-EnchantWeapon-BloodyDancingSteel-5125"
  value: {
-  dps: 517971.42086
-  tps: 501972.39745
-  hps: 11947.52512
+  dps: 519918.26115
+  tps: 503613.11687
+  hps: 12111.69492
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-EnchantWeapon-Colossus-4445"
  value: {
-  dps: 510040.07404
-  tps: 494441.61641
-  hps: 11669.28085
+  dps: 511822.31054
+  tps: 495918.89043
+  hps: 11839.27368
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-EnchantWeapon-ElementalForce-4443"
  value: {
-  dps: 511905.75605
-  tps: 496228.72151
-  hps: 11669.28085
+  dps: 513391.9955
+  tps: 497350.14215
+  hps: 11839.27368
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-EnchantWeapon-JadeSpirit-4442"
  value: {
-  dps: 510040.07404
-  tps: 494441.61641
-  hps: 11669.28085
+  dps: 511801.44338
+  tps: 495918.89043
+  hps: 11839.27368
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-EnchantWeapon-River'sSong-4446"
  value: {
-  dps: 510040.07404
-  tps: 494441.61641
-  hps: 11669.28085
+  dps: 511796.34781
+  tps: 495918.89043
+  hps: 11839.27368
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-EnchantWeapon-SpiritofConquest-5124"
  value: {
-  dps: 510040.07404
-  tps: 494441.61641
-  hps: 11669.28085
+  dps: 511801.44338
+  tps: 495918.89043
+  hps: 11839.27368
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-EnchantWeapon-Windsong-4441"
  value: {
-  dps: 495379.80685
-  tps: 479405.97747
-  hps: 12192.02373
+  dps: 502435.92734
+  tps: 486417.14754
+  hps: 11976.09837
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-EnigmaticPrimalDiamond"
  value: {
-  dps: 410618.90482
-  tps: 391107.80974
-  hps: 15209.47811
+  dps: 417010.57221
+  tps: 397467.10073
+  hps: 15098.35412
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-EssenceofTerror-87175"
  value: {
-  dps: 463580.86078
-  tps: 448976.07051
-  hps: 10786.84103
+  dps: 476062.70429
+  tps: 461489.53769
+  hps: 10826.78937
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-EternalPrimalDiamond"
  value: {
-  dps: 489277.62067
-  tps: 473222.10641
-  hps: 12066.05135
+  dps: 493935.15571
+  tps: 477865.32722
+  hps: 11988.31377
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-EvilEyeofGalakras-105491"
  value: {
-  dps: 473327.95956
-  tps: 458756.36203
-  hps: 11408.47273
+  dps: 473449.59465
+  tps: 458890.85174
+  hps: 11498.01817
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-FabledFeatherofJi-Kun-96842"
  value: {
-  dps: 470769.39619
-  tps: 456072.31692
-  hps: 11220.24916
+  dps: 466477.39408
+  tps: 451687.02132
+  hps: 11272.11912
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-FearwurmBadge-84074"
  value: {
-  dps: 402834.51995
-  tps: 385902.43559
-  hps: 12821.05792
+  dps: 403049.9274
+  tps: 385974.75555
+  hps: 13095.85586
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-FearwurmRelic-84070"
  value: {
-  dps: 402978.12261
-  tps: 385905.50933
-  hps: 12948.47912
+  dps: 408614.49085
+  tps: 391587.92306
+  hps: 12875.03326
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-FelsoulIdolofDestruction-101263"
  value: {
-  dps: 465131.8949
-  tps: 450538.37954
-  hps: 10910.44109
+  dps: 472086.02543
+  tps: 457440.18528
+  hps: 10869.80855
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-FelsoulStoneofDestruction-101266"
  value: {
-  dps: 468979.23475
-  tps: 454962.58307
-  hps: 10998.39425
+  dps: 468872.9523
+  tps: 454865.53814
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Fire-CharmArmor"
  value: {
-  dps: 338175.45368
-  tps: 323712.23628
-  hps: 9453.32808
+  dps: 343230.00754
+  tps: 328585.71616
+  hps: 9304.68466
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Fire-CharmBattlegear"
  value: {
-  dps: 351172.05768
-  tps: 336665.36955
-  hps: 9212.15332
+  dps: 352456.17568
+  tps: 337931.61643
+  hps: 9032.21832
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-FlashfrozenResinGlobule-100951"
  value: {
-  dps: 459436.94121
-  tps: 445235.19551
-  hps: 11100.95307
+  dps: 462650.06517
+  tps: 448455.5126
+  hps: 11016.55125
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-FlashingSteelTalisman-81265"
  value: {
-  dps: 471255.58971
-  tps: 456284.58626
-  hps: 11324.80639
+  dps: 473090.37183
+  tps: 458051.62621
+  hps: 11319.13543
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-FleetPrimalDiamond"
  value: {
-  dps: 490955.30167
-  tps: 474899.75103
-  hps: 12066.05135
+  dps: 495606.63207
+  tps: 479536.76719
+  hps: 11988.31377
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-ForlornPrimalDiamond"
  value: {
-  dps: 489277.62067
-  tps: 473222.10641
-  hps: 12066.05135
+  dps: 493935.15571
+  tps: 477865.32722
+  hps: 11988.31377
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-FortitudeoftheZandalari-96793"
  value: {
-  dps: 470217.10378
-  tps: 456200.4521
-  hps: 10998.39425
+  dps: 470251.69404
+  tps: 456239.18431
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-FrenziedCrystalofRage-105572"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Fusion-FireCore-105459"
  value: {
-  dps: 473800.25166
-  tps: 458903.4257
-  hps: 11423.06627
+  dps: 473938.45207
+  tps: 459060.98341
+  hps: 11454.48077
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-GazeoftheTwins-96915"
  value: {
-  dps: 449415.55177
-  tps: 434007.20128
-  hps: 12514.91854
+  dps: 462041.8598
+  tps: 446664.34011
+  hps: 12280.96456
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Gerp'sPerfectArrow-87495"
  value: {
-  dps: 396636.11505
-  tps: 379112.75815
-  hps: 14130.57337
+  dps: 393130.70336
+  tps: 375539.00558
+  hps: 14313.72585
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Gong-Lu,StrengthofXuen-102249"
  value: {
-  dps: 497222.8267
-  tps: 481707.37105
-  hps: 11762.66153
+  dps: 501967.52558
+  tps: 486621.10606
+  hps: 11391.39693
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-GrievousGladiator'sBadgeofConquest-103145"
  value: {
-  dps: 477018.21918
-  tps: 462104.91228
-  hps: 11376.6671
+  dps: 476022.02269
+  tps: 461145.97885
+  hps: 11407.16135
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-GrievousGladiator'sBadgeofDominance-103308"
  value: {
-  dps: 463761.90372
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463893.7257
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-GrievousGladiator'sBadgeofVictory-103314"
  value: {
-  dps: 468074.67777
-  tps: 453711.79125
-  hps: 11178.52418
+  dps: 468220.75264
+  tps: 453863.77026
+  hps: 11210.13748
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-GrievousGladiator'sEmblemofCruelty-103210"
  value: {
-  dps: 393000.36678
-  tps: 376082.12671
-  hps: 13871.83265
+  dps: 389503.22889
+  tps: 372504.6694
+  hps: 14056.3608
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-GrievousGladiator'sEmblemofMeditation-103212"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-GrievousGladiator'sEmblemofTenacity-103211"
  value: {
-  dps: 463784.20607
-  tps: 449767.55438
-  hps: 10998.39425
+  dps: 463918.57954
+  tps: 449906.0698
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-GrievousGladiator'sInsigniaofConquest-103150"
  value: {
-  dps: 484752.16616
-  tps: 469677.50674
-  hps: 11644.50346
+  dps: 483961.14932
+  tps: 468933.30119
+  hps: 11675.62669
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-GrievousGladiator'sInsigniaofDominance-103309"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-GrievousGladiator'sInsigniaofVictory-103319"
  value: {
-  dps: 470633.62373
-  tps: 456220.20304
-  hps: 11308.30845
+  dps: 470682.78982
+  tps: 456275.50703
+  hps: 11340.93908
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Hawkmaster'sTalon-89082"
  value: {
-  dps: 474805.26551
-  tps: 459319.91335
-  hps: 10976.40436
+  dps: 474533.34413
+  tps: 459022.78981
+  hps: 11006.73549
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Heart-LesionDefenderIdol-100999"
  value: {
-  dps: 463782.21711
-  tps: 449765.56542
-  hps: 10998.39425
+  dps: 463916.24633
+  tps: 449903.73659
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Heart-LesionDefenderStone-101002"
  value: {
-  dps: 467827.2035
-  tps: 453810.55182
-  hps: 10998.39425
+  dps: 468410.9724
+  tps: 454398.46266
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Heart-LesionIdolofBattle-100991"
  value: {
-  dps: 394987.91893
-  tps: 377812.22441
-  hps: 14056.17252
+  dps: 391566.30935
+  tps: 374302.00964
+  hps: 14261.55808
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Heart-LesionStoneofBattle-100990"
  value: {
-  dps: 471783.52461
-  tps: 457584.69361
-  hps: 11164.9876
+  dps: 471567.38743
+  tps: 457366.5369
+  hps: 11198.04276
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-HeartofFire-81181"
  value: {
-  dps: 466885.47396
-  tps: 452868.82228
-  hps: 10998.39425
+  dps: 466970.10166
+  tps: 452957.59192
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-HeartwarmerMedallion-93260"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-HelmbreakerMedallion-93261"
  value: {
-  dps: 453545.89006
-  tps: 436777.72065
-  hps: 12439.43527
+  dps: 456187.98434
+  tps: 439497.15348
+  hps: 12881.71773
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Horridon'sLastGasp-96757"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463862.11732
+  tps: 449849.60758
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-ImpassivePrimalDiamond"
  value: {
-  dps: 410618.90482
-  tps: 391107.80974
-  hps: 15209.47811
+  dps: 417010.57221
+  tps: 397467.10073
+  hps: 15098.35412
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-IndomitablePrimalDiamond"
  value: {
-  dps: 489281.87704
-  tps: 473226.36279
-  hps: 12066.05135
+  dps: 493938.64986
+  tps: 477868.82137
+  hps: 11988.31377
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-InscribedBagofHydra-Spawn-96828"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-InsigniaofKypariZar-84078"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-IronBellyWok-89083"
  value: {
-  dps: 468721.40675
-  tps: 453549.93961
-  hps: 10789.03392
+  dps: 468001.18898
+  tps: 452807.59466
+  hps: 10819.26223
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-IronProtectorTalisman-85181"
  value: {
-  dps: 463778.28769
-  tps: 449761.63601
-  hps: 10998.39425
+  dps: 463911.63683
+  tps: 449899.12709
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-JadeBanditFigurine-86772"
  value: {
-  dps: 466534.10277
-  tps: 450845.09095
-  hps: 10903.79798
+  dps: 467558.57965
+  tps: 451968.06305
+  hps: 10848.38158
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-JadeCharioteerFigurine-86771"
  value: {
-  dps: 460380.83364
-  tps: 444981.59098
-  hps: 10738.26042
+  dps: 461634.07459
+  tps: 446323.11984
+  hps: 10684.02825
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-JadeCourtesanFigurine-86774"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-JadeMagistrateFigurine-86773"
  value: {
-  dps: 448948.13324
-  tps: 432436.18899
-  hps: 12216.06647
+  dps: 451794.72038
+  tps: 435376.1672
+  hps: 12651.18309
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-JadeWarlordFigurine-86775"
  value: {
-  dps: 466430.59942
-  tps: 452413.94773
-  hps: 10998.39425
+  dps: 466697.00433
+  tps: 452684.4946
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Ji-Kun'sRisingWinds-96843"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Juggernaut'sFocusingCrystal-105514"
  value: {
-  dps: 464448.9948
-  tps: 450433.45184
-  hps: 25278.91392
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 25278.26254
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Kardris'ToxicTotem-105540"
  value: {
-  dps: 487153.3386
-  tps: 473136.68692
-  hps: 10998.39425
+  dps: 489822.42252
+  tps: 475809.91279
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-KnightlyBadgeoftheShieldwall-93349"
  value: {
-  dps: 468769.93937
-  tps: 454604.59919
-  hps: 11130.39623
+  dps: 469003.41423
+  tps: 454841.6707
+  hps: 11163.36324
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-KnotofTenSongs-84073"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Kor'kronBookofHurting-92785"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Lao-Chin'sLiquidCourage-89079"
  value: {
-  dps: 466774.37672
-  tps: 452757.72504
-  hps: 10998.39425
+  dps: 467058.20076
+  tps: 453045.69103
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-LeiShen'sFinalOrders-87072"
  value: {
-  dps: 410073.38366
-  tps: 394378.25158
-  hps: 10353.57854
+  dps: 408401.05165
+  tps: 392623.83711
+  hps: 10192.49223
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-LessonsoftheDarkmaster-81268"
  value: {
-  dps: 466791.33079
-  tps: 452522.17474
-  hps: 11134.62169
+  dps: 466911.16109
+  tps: 452645.77825
+  hps: 11160.65357
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-LightdrinkerIdolofRage-101200"
  value: {
-  dps: 480274.76571
-  tps: 465649.73922
-  hps: 11391.85327
+  dps: 478901.39999
+  tps: 464308.33087
+  hps: 11431.72274
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-LightdrinkerStoneofRage-101203"
  value: {
-  dps: 479146.23239
-  tps: 464655.02005
-  hps: 11348.24029
+  dps: 478688.86184
+  tps: 464216.76111
+  hps: 11381.76243
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-LightoftheCosmos-87065"
  value: {
-  dps: 405915.83454
-  tps: 390532.76571
-  hps: 10150.29676
+  dps: 404193.79785
+  tps: 388731.73848
+  hps: 10001.48836
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-LightweaveEmbroidery(Rank3)-4892"
  value: {
-  dps: 515531.6294
-  tps: 499583.5376
-  hps: 11902.98151
+  dps: 518377.79456
+  tps: 502144.40986
+  hps: 12077.20666
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-LordBlastington'sScopeofDoom-4699"
  value: {
-  dps: 510040.07404
-  tps: 494441.61641
-  hps: 11669.28085
+  dps: 511822.31054
+  tps: 495918.89043
+  hps: 11839.27368
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-MalevolentGladiator'sBadgeofConquest-91452"
  value: {
-  dps: 472362.87884
-  tps: 457773.6402
-  hps: 11244.73542
+  dps: 471639.45731
+  tps: 457081.97874
+  hps: 11275.97478
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-MalevolentGladiator'sBadgeofDominance-91753"
  value: {
-  dps: 463761.90372
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463893.7257
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-MalevolentGladiator'sBadgeofVictory-91763"
  value: {
-  dps: 466570.49499
-  tps: 452330.27017
-  hps: 11115.69957
+  dps: 466711.59883
+  tps: 452476.5367
+  hps: 11147.66769
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-MalevolentGladiator'sEmblemofCruelty-91562"
  value: {
-  dps: 391650.69887
-  tps: 374775.27384
-  hps: 13816.3152
+  dps: 388170.26143
+  tps: 371225.68616
+  hps: 13995.29763
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-MalevolentGladiator'sEmblemofMeditation-91564"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-MalevolentGladiator'sEmblemofTenacity-91563"
  value: {
-  dps: 463778.33621
-  tps: 449761.68452
-  hps: 10998.39425
+  dps: 463911.69373
+  tps: 449899.184
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-MalevolentGladiator'sInsigniaofConquest-91457"
  value: {
-  dps: 477585.07405
-  tps: 462885.83322
-  hps: 11436.50525
+  dps: 476780.80258
+  tps: 462128.75177
+  hps: 11471.71372
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-MalevolentGladiator'sInsigniaofDominance-91754"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-MalevolentGladiator'sInsigniaofVictory-91768"
  value: {
-  dps: 468128.76504
-  tps: 453842.15156
-  hps: 11193.86626
+  dps: 468276.78039
+  tps: 454007.46404
+  hps: 11236.78489
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-MarkoftheCatacombs-83731"
  value: {
-  dps: 430595.55966
-  tps: 413982.39136
-  hps: 13298.94443
+  dps: 430006.62475
+  tps: 413391.54355
+  hps: 13380.04714
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-MarkoftheHardenedGrunt-92783"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-MedallionofMystifyingVapors-93257"
  value: {
-  dps: 466960.86275
-  tps: 452944.21107
-  hps: 10998.39425
+  dps: 467252.08333
+  tps: 453239.57359
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-MedallionoftheCatacombs-83734"
  value: {
-  dps: 466038.76141
-  tps: 452022.10973
-  hps: 10998.39425
+  dps: 466136.1058
+  tps: 452123.59607
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-MendingBadgeoftheShieldwall-93348"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-MirrorScope-4700"
  value: {
-  dps: 510040.07404
-  tps: 494441.61641
-  hps: 11669.28085
+  dps: 511822.31054
+  tps: 495918.89043
+  hps: 11839.27368
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-MistdancerDefenderIdol-101089"
  value: {
-  dps: 463782.21711
-  tps: 449765.56542
-  hps: 10998.39425
+  dps: 463916.24633
+  tps: 449903.73659
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-MistdancerDefenderStone-101087"
  value: {
-  dps: 467702.53593
-  tps: 453685.88425
-  hps: 10998.39425
+  dps: 468458.71115
+  tps: 454451.29699
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-MistdancerIdolofRage-101113"
  value: {
-  dps: 479688.41898
-  tps: 465025.20833
-  hps: 11374.59141
+  dps: 478991.60459
+  tps: 464384.53194
+  hps: 11419.69512
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-MistdancerStoneofRage-101117"
  value: {
-  dps: 478901.90395
-  tps: 464410.69161
-  hps: 11348.24029
+  dps: 478791.24951
+  tps: 464319.14878
+  hps: 11381.76243
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-MistdancerStoneofWisdom-101107"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-MithrilWristwatch-257884"
  value: {
-  dps: 392074.13586
-  tps: 375190.29399
-  hps: 13833.21435
+  dps: 388358.43908
+  tps: 371398.96575
+  hps: 14023.96313
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-MountainsageIdolofDestruction-101069"
  value: {
-  dps: 460426.07139
-  tps: 445847.83163
-  hps: 10831.62419
+  dps: 467133.05821
+  tps: 452689.39951
+  hps: 10854.46663
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-MountainsageStoneofDestruction-101072"
  value: {
-  dps: 468364.42041
-  tps: 454347.76873
-  hps: 10998.39425
+  dps: 468711.9216
+  tps: 454704.50743
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-NitroBoosts-4223"
  value: {
-  dps: 517141.00444
-  tps: 501176.13904
-  hps: 11925.01344
+  dps: 520150.06864
+  tps: 503901.76797
+  hps: 12094.1058
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-OathswornDefenderIdol-101303"
  value: {
-  dps: 463782.21711
-  tps: 449765.56542
-  hps: 10998.39425
+  dps: 463916.24633
+  tps: 449903.73659
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-OathswornDefenderStone-101306"
  value: {
-  dps: 468023.89741
-  tps: 454012.70498
-  hps: 10998.39425
+  dps: 468341.63163
+  tps: 454334.21746
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-OathswornIdolofBattle-101295"
  value: {
-  dps: 395048.3733
-  tps: 377857.42603
-  hps: 14052.08907
+  dps: 391662.80363
+  tps: 374398.27634
+  hps: 14273.11902
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-OathswornStoneofBattle-101294"
  value: {
-  dps: 471525.321
-  tps: 457321.01671
-  hps: 11164.9876
+  dps: 471812.13145
+  tps: 457616.3765
+  hps: 11198.04276
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-PhaseFingers-4697"
  value: {
-  dps: 450098.40757
-  tps: 432306.04803
-  hps: 10634.41474
+  dps: 452974.81865
+  tps: 434963.28441
+  hps: 10567.51032
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-PouchofWhiteAsh-103639"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-PowerfulPrimalDiamond"
  value: {
-  dps: 489281.87704
-  tps: 473226.36279
-  hps: 12066.05135
+  dps: 493938.64986
+  tps: 477868.82137
+  hps: 11988.31377
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-PriceofProgress-81266"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-PridefulGladiator'sBadgeofConquest-103342"
  value: {
-  dps: 480657.92038
-  tps: 465460.1147
-  hps: 11489.53053
+  dps: 479815.28361
+  tps: 464649.84926
+  hps: 11519.38735
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-PridefulGladiator'sBadgeofDominance-103505"
  value: {
-  dps: 463761.90372
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463893.7257
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-PridefulGladiator'sBadgeofVictory-103511"
  value: {
-  dps: 469361.45913
-  tps: 454893.63936
-  hps: 11232.26867
+  dps: 469511.78656
+  tps: 455050.50522
+  hps: 11263.57843
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-PridefulGladiator'sEmblemofCruelty-103407"
  value: {
-  dps: 394100.14422
-  tps: 377151.6624
-  hps: 13921.92978
+  dps: 390593.08304
+  tps: 373536.04992
+  hps: 14084.12584
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-PridefulGladiator'sEmblemofMeditation-103409"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-PridefulGladiator'sEmblemofTenacity-103408"
  value: {
-  dps: 463789.23183
-  tps: 449772.58015
-  hps: 10998.39425
+  dps: 463924.47515
+  tps: 449911.96541
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-PridefulGladiator'sInsigniaofConquest-103347"
  value: {
-  dps: 491219.99982
-  tps: 475850.45498
-  hps: 11853.76865
+  dps: 490172.76381
+  tps: 474874.07626
+  hps: 11908.41978
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-PridefulGladiator'sInsigniaofDominance-103506"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-PridefulGladiator'sInsigniaofVictory-103516"
  value: {
-  dps: 472820.11207
-  tps: 458277.56585
-  hps: 11400.47241
+  dps: 472479.82569
+  tps: 457949.41413
+  hps: 11452.4438
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Primordius'TalismanofRage-96873"
  value: {
-  dps: 399356.88701
-  tps: 381991.78053
-  hps: 14286.01612
+  dps: 395420.89782
+  tps: 377971.61198
+  hps: 14422.83637
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-PrismaticPrisonofPride-105474"
  value: {
-  dps: 494747.97254
-  tps: 480814.03229
-  hps: 11177.74757
+  dps: 487917.48123
+  tps: 473817.42279
+  hps: 11256.34016
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-PurifiedBindingsofImmerseus-105422"
  value: {
-  dps: 494747.97254
-  tps: 480814.03229
-  hps: 11177.74757
+  dps: 487917.48123
+  tps: 473817.42279
+  hps: 11256.34016
  }
 }
 dps_results: {
@@ -1609,665 +1609,665 @@ dps_results: {
 dps_results: {
  key: "TestWindwalker-AllItems-Qin-xi'sPolarizingSeal-87075"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463893.7257
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-RelicofChi-Ji-79330"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-RelicofKypariZar-84075"
  value: {
-  dps: 403019.32324
-  tps: 387530.95467
-  hps: 10785.74694
+  dps: 402634.52244
+  tps: 387099.14619
+  hps: 10365.3785
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-RelicofNiuzao-79329"
  value: {
-  dps: 463781.27599
-  tps: 449764.6243
-  hps: 10998.39425
+  dps: 463915.14233
+  tps: 449902.63259
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-RelicofXuen-79327"
  value: {
-  dps: 470128.49504
-  tps: 455757.86675
-  hps: 11296.92122
+  dps: 470240.43196
+  tps: 455873.40845
+  hps: 11336.03271
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-RelicofXuen-79328"
  value: {
-  dps: 482216.79082
-  tps: 467288.99055
-  hps: 11596.66713
+  dps: 480906.7557
+  tps: 466003.53597
+  hps: 11637.95173
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-RelicofYu'lon-79331"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463893.7257
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Renataki'sSoulCharm-96741"
  value: {
-  dps: 481946.8646
-  tps: 466458.98307
-  hps: 11661.36269
+  dps: 482482.13027
+  tps: 466996.64162
+  hps: 11730.82567
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-ResolveofNiuzao-103990"
  value: {
-  dps: 469867.37468
-  tps: 455850.723
-  hps: 10998.39425
+  dps: 469907.21749
+  tps: 455894.70776
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-ReverberatingPrimalDiamond"
  value: {
-  dps: 499959.58397
-  tps: 483861.21337
-  hps: 12215.35185
+  dps: 504546.42707
+  tps: 488433.91112
+  hps: 12132.82065
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-RevitalizingPrimalDiamond"
  value: {
-  dps: 499243.54725
-  tps: 483185.73715
-  hps: 12179.76241
+  dps: 503825.47106
+  tps: 487753.34672
+  hps: 12097.27986
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-RuneofRe-Origination-96918"
  value: {
-  dps: 460740.99718
-  tps: 446100.27
-  hps: 11367.00403
+  dps: 468836.10284
+  tps: 454159.42228
+  hps: 11346.38073
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-SI:7Operative'sManual-92784"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-ScrollofReveredAncestors-89080"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-SearingWords-81267"
  value: {
-  dps: 399689.03559
-  tps: 381844.10622
-  hps: 14322.81254
+  dps: 395761.84249
+  tps: 377816.42922
+  hps: 14499.27467
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Shock-ChargerMedallion-93259"
  value: {
-  dps: 401682.01859
-  tps: 386321.4292
-  hps: 10095.65119
+  dps: 398326.25416
+  tps: 382998.18842
+  hps: 9979.30268
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-SigilofCompassion-83736"
  value: {
-  dps: 466038.76141
-  tps: 452022.10973
-  hps: 10998.39425
+  dps: 466136.1058
+  tps: 452123.59607
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-SigilofDevotion-83740"
  value: {
-  dps: 435875.92115
-  tps: 419332.19187
-  hps: 12870.50126
+  dps: 428560.73507
+  tps: 411896.90014
+  hps: 13356.69208
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-SigilofFidelity-83737"
  value: {
-  dps: 401638.88792
-  tps: 385932.53466
-  hps: 11325.1271
+  dps: 404460.7539
+  tps: 388769.60686
+  hps: 11484.04187
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-SigilofGrace-83738"
  value: {
-  dps: 462597.36021
-  tps: 448043.76977
-  hps: 10762.43233
+  dps: 457842.67862
+  tps: 443281.67514
+  hps: 10638.74646
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-SigilofKypariZar-84076"
  value: {
-  dps: 440939.29616
-  tps: 424358.56274
-  hps: 12962.95842
+  dps: 430978.30023
+  tps: 414301.26678
+  hps: 13355.73189
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-SigilofPatience-83739"
  value: {
-  dps: 466733.45186
-  tps: 452716.80017
-  hps: 10998.39425
+  dps: 466699.24751
+  tps: 452691.83335
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-SigilofRampage-105580"
  value: {
-  dps: 494144.32747
-  tps: 477748.58599
-  hps: 11885.09777
+  dps: 492653.36432
+  tps: 476366.06514
+  hps: 11941.73477
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-SigiloftheCatacombs-83732"
  value: {
-  dps: 398477.88639
-  tps: 381341.55108
-  hps: 12955.39221
+  dps: 404001.74167
+  tps: 386886.14407
+  hps: 12527.18136
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-SinisterPrimalDiamond"
  value: {
-  dps: 495160.59322
-  tps: 479019.69841
-  hps: 11982.54702
+  dps: 492465.56119
+  tps: 476367.24227
+  hps: 11897.57483
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Skeer'sBloodsoakedTalisman-105632"
  value: {
-  dps: 474567.8346
-  tps: 459074.30658
-  hps: 12143.48717
+  dps: 480487.57009
+  tps: 464808.80001
+  hps: 12357.59761
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-SkullrenderMedallion-93256"
  value: {
-  dps: 453545.89006
-  tps: 436777.72065
-  hps: 12439.43527
+  dps: 456187.98434
+  tps: 439497.15348
+  hps: 12881.71773
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-SoothingTalismanoftheShado-PanAssault-94509"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-SoulBarrier-96927"
  value: {
-  dps: 463792.86047
-  tps: 449776.20879
-  hps: 10998.39425
+  dps: 463928.73182
+  tps: 449916.22209
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-SparkofZandalar-96770"
  value: {
-  dps: 409595.43314
-  tps: 394011.4105
-  hps: 10195.14702
+  dps: 410228.24346
+  tps: 394634.91487
+  hps: 10233.70829
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-SpiritsoftheSun-87163"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-SpringrainIdolofDestruction-101023"
  value: {
-  dps: 458865.70246
-  tps: 444335.45
-  hps: 10817.58876
+  dps: 470890.15807
+  tps: 456337.13152
+  hps: 10888.39386
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-SpringrainIdolofRage-101009"
  value: {
-  dps: 479698.47906
-  tps: 465056.92231
-  hps: 11373.81184
+  dps: 478790.91775
+  tps: 464183.12452
+  hps: 11434.61827
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-SpringrainStoneofDestruction-101026"
  value: {
-  dps: 468133.07987
-  tps: 454121.88743
-  hps: 10998.39425
+  dps: 468506.23214
+  tps: 454498.81798
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-SpringrainStoneofRage-101012"
  value: {
-  dps: 478890.31807
-  tps: 464399.10574
-  hps: 11348.24029
+  dps: 478525.66325
+  tps: 464058.6581
+  hps: 11381.76243
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-SpringrainStoneofWisdom-101041"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Static-Caster'sMedallion-93254"
  value: {
-  dps: 401682.01859
-  tps: 386321.4292
-  hps: 10095.65119
+  dps: 398326.25416
+  tps: 382998.18842
+  hps: 9979.30268
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-SteadfastFootman'sMedallion-92782"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-SteadfastTalismanoftheShado-PanAssault-94507"
  value: {
-  dps: 469167.91649
-  tps: 455151.26481
-  hps: 10998.39425
+  dps: 469218.26439
+  tps: 455205.75466
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-StreamtalkerIdolofDestruction-101222"
  value: {
-  dps: 464562.04742
-  tps: 450089.95015
-  hps: 10928.27905
+  dps: 471036.6092
+  tps: 456424.12035
+  hps: 10937.50748
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-StreamtalkerIdolofRage-101217"
  value: {
-  dps: 479837.18656
-  tps: 465167.92043
-  hps: 11351.31574
+  dps: 479335.08449
+  tps: 464710.45146
+  hps: 11425.04073
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-StreamtalkerStoneofDestruction-101225"
  value: {
-  dps: 468354.41293
-  tps: 454337.76125
-  hps: 10998.39425
+  dps: 468535.14449
+  tps: 454527.73033
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-StreamtalkerStoneofRage-101220"
  value: {
-  dps: 479092.5432
-  tps: 464601.33086
-  hps: 11348.24029
+  dps: 478315.0385
+  tps: 463848.03334
+  hps: 11381.76243
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-StreamtalkerStoneofWisdom-101250"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463893.7257
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-StuffofNightmares-87160"
  value: {
-  dps: 468553.12955
-  tps: 454536.47787
-  hps: 10998.39425
+  dps: 468612.71088
+  tps: 454600.20115
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-SunsoulDefenderIdol-101160"
  value: {
-  dps: 463782.21711
-  tps: 449765.56542
-  hps: 10998.39425
+  dps: 463916.24633
+  tps: 449903.73659
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-SunsoulDefenderStone-101163"
  value: {
-  dps: 468519.22848
-  tps: 454508.03604
-  hps: 10998.39425
+  dps: 468934.2654
+  tps: 454921.75566
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-SunsoulIdolofBattle-101152"
  value: {
-  dps: 395161.89143
-  tps: 377975.58719
-  hps: 14080.56716
+  dps: 391707.42823
+  tps: 374438.76106
+  hps: 14276.77821
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-SunsoulStoneofBattle-101151"
  value: {
-  dps: 472132.06309
-  tps: 457927.7588
-  hps: 11164.9876
+  dps: 471980.49706
+  tps: 457784.74211
+  hps: 11198.04276
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-SunsoulStoneofWisdom-101138"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-SwordguardEmbroidery(Rank3)-4894"
  value: {
-  dps: 519157.70705
-  tps: 502955.53272
-  hps: 12057.68551
+  dps: 522027.4247
+  tps: 505560.89074
+  hps: 12234.15466
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-SymboloftheCatacombs-83735"
  value: {
-  dps: 449577.42679
-  tps: 434936.24944
-  hps: 11790.95823
+  dps: 456165.0184
+  tps: 441615.27803
+  hps: 11904.69105
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-SynapseSprings(MarkII)-4898"
  value: {
-  dps: 451031.99809
-  tps: 433216.44931
-  hps: 10754.77766
+  dps: 455042.11282
+  tps: 436941.68632
+  hps: 10622.84333
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-TalismanofBloodlust-96864"
  value: {
-  dps: 475866.58723
-  tps: 460319.73944
-  hps: 11219.96239
+  dps: 476575.86733
+  tps: 460939.44923
+  hps: 11328.14389
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-TerrorintheMists-87167"
  value: {
-  dps: 475453.77439
-  tps: 460243.41826
-  hps: 12034.85051
+  dps: 475693.43293
+  tps: 460438.18838
+  hps: 12124.82894
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Thok'sAcid-GroovedTooth-105607"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Thok'sTailTip-105609"
  value: {
-  dps: 505365.32848
-  tps: 490721.26497
-  hps: 11674.14704
+  dps: 499049.21998
+  tps: 484236.13339
+  hps: 11736.42174
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Thousand-YearPickledEgg-257881"
  value: {
-  dps: 467315.79401
-  tps: 452900.85252
-  hps: 10868.63589
+  dps: 471649.68336
+  tps: 457369.48642
+  hps: 10778.52425
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-TickingEbonDetonator-105612"
  value: {
-  dps: 498190.15017
-  tps: 482047.81286
-  hps: 12026.64097
+  dps: 496879.06199
+  tps: 480947.68668
+  hps: 11986.85005
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Time-LostArtifact-103678"
  value: {
-  dps: 475354.85824
-  tps: 460911.70127
-  hps: 10649.99884
+  dps: 467831.52702
+  tps: 453334.11851
+  hps: 10649.6308
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-TrailseekerIdolofRage-101054"
  value: {
-  dps: 479875.47794
-  tps: 465258.65012
-  hps: 11376.81874
+  dps: 478831.89638
+  tps: 464220.66515
+  hps: 11426.93396
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-TrailseekerStoneofRage-101057"
  value: {
-  dps: 479464.33721
-  tps: 464973.12487
-  hps: 11348.24029
+  dps: 478509.42686
+  tps: 464042.4217
+  hps: 11381.76243
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-TyrannicalGladiator'sBadgeofConquest-100043"
  value: {
-  dps: 474357.31965
-  tps: 459634.15319
-  hps: 11295.34359
+  dps: 473444.38727
+  tps: 458753.28928
+  hps: 11326.29713
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-TyrannicalGladiator'sBadgeofDominance-100016"
  value: {
-  dps: 463761.90372
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463893.7257
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-TyrannicalGladiator'sBadgeofVictory-100019"
  value: {
-  dps: 467147.4901
-  tps: 452860.21302
-  hps: 11139.7987
+  dps: 467290.5008
+  tps: 453008.67082
+  hps: 11171.63071
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-TyrannicalGladiator'sEmblemofCruelty-100066"
  value: {
-  dps: 392216.97411
-  tps: 375323.24822
-  hps: 13839.24761
+  dps: 388650.09702
+  tps: 371685.49233
+  hps: 14023.96313
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-TyrannicalGladiator'sEmblemofMeditation-99990"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-TyrannicalGladiator'sEmblemofTenacity-100092"
  value: {
-  dps: 463780.58713
-  tps: 449763.93544
-  hps: 10998.39425
+  dps: 463914.33424
+  tps: 449901.8245
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-TyrannicalGladiator'sInsigniaofConquest-100026"
  value: {
-  dps: 479982.15909
-  tps: 465113.19391
-  hps: 11493.66805
+  dps: 479045.98667
+  tps: 464236.03115
+  hps: 11543.75457
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-TyrannicalGladiator'sInsigniaofDominance-100152"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-TyrannicalGladiator'sInsigniaofVictory-100085"
  value: {
-  dps: 469023.87782
-  tps: 454677.45488
-  hps: 11235.71823
+  dps: 469291.98165
+  tps: 454959.031
+  hps: 11290.74987
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-TyrannicalPrimalDiamond"
  value: {
-  dps: 489277.62067
-  tps: 473222.10641
-  hps: 12066.05135
+  dps: 493935.15571
+  tps: 477865.32722
+  hps: 11988.31377
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-UnerringVisionofLeiShen-96930"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-VaporshieldMedallion-93262"
  value: {
-  dps: 466960.86275
-  tps: 452944.21107
-  hps: 10998.39425
+  dps: 467252.08333
+  tps: 453239.57359
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-VialofDragon'sBlood-87063"
  value: {
-  dps: 468251.25812
-  tps: 454234.60644
-  hps: 10998.39425
+  dps: 468315.37323
+  tps: 454302.8635
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-VialofIchorousBlood-100963"
  value: {
-  dps: 463767.36296
-  tps: 449750.71128
-  hps: 10998.39425
+  dps: 463898.82127
+  tps: 449886.31154
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-VialofLivingCorruption-105568"
  value: {
-  dps: 463801.39845
-  tps: 449784.74677
-  hps: 10998.39425
+  dps: 463938.74753
+  tps: 449926.2378
+  hps: 11031.02487
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-ViciousTalismanoftheShado-PanAssault-94511"
  value: {
-  dps: 480014.66163
-  tps: 464710.06499
-  hps: 11665.9929
+  dps: 485338.36987
+  tps: 470016.86466
+  hps: 11506.74148
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-VisionofthePredator-81192"
  value: {
-  dps: 454136.45112
-  tps: 439691.04621
-  hps: 11594.08899
+  dps: 457629.65235
+  tps: 443127.29261
+  hps: 11509.31061
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-VolatileTalismanoftheShado-PanAssault-94510"
  value: {
-  dps: 472633.36298
-  tps: 458177.38853
-  hps: 10916.68469
+  dps: 482449.93448
+  tps: 468130.61205
+  hps: 10870.44644
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-WindsweptPages-81125"
  value: {
-  dps: 477094.66125
-  tps: 462266.25097
-  hps: 11083.51793
+  dps: 486304.803
+  tps: 471313.38302
+  hps: 10989.2964
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-WoundripperMedallion-93253"
  value: {
-  dps: 460160.3394
-  tps: 443016.03552
-  hps: 12666.55188
+  dps: 463741.575
+  tps: 446663.94056
+  hps: 13116.3866
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Wushoolay'sFinalChoice-96785"
  value: {
-  dps: 463814.38565
-  tps: 449655.39085
-  hps: 10936.928
+  dps: 457632.61872
+  tps: 443327.72927
+  hps: 10926.75063
  }
 }
 dps_results: {
@@ -2281,33 +2281,33 @@ dps_results: {
 dps_results: {
  key: "TestWindwalker-AllItems-YaungolFireCarrier-86518"
  value: {
-  dps: 517141.00444
-  tps: 501176.13904
-  hps: 11925.01344
+  dps: 520150.06864
+  tps: 503901.76797
+  hps: 12094.1058
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-Yu'lon'sBite-103987"
  value: {
-  dps: 462437.16996
-  tps: 447832.33961
-  hps: 11299.85427
+  dps: 462784.34814
+  tps: 448133.14284
+  hps: 11337.47771
  }
 }
 dps_results: {
  key: "TestWindwalker-AllItems-ZenAlchemistStone-75274"
  value: {
-  dps: 480774.18974
-  tps: 466162.19465
-  hps: 11414.59855
+  dps: 479985.80001
+  tps: 465383.21162
+  hps: 11451.50525
  }
 }
 dps_results: {
  key: "TestWindwalker-Average-Default"
  value: {
-  dps: 520350.51178
-  tps: 503533.96705
-  hps: 12310.03294
+  dps: 521436.22182
+  tps: 504573.73728
+  hps: 12324.82957
  }
 }
 dps_results: {
@@ -2409,97 +2409,97 @@ dps_results: {
 dps_results: {
  key: "TestWindwalker-Settings-Orc-p5_bis-DefaultTalents-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.67317341714e+06
-  tps: 996552.90945
-  hps: 10096.39284
+  dps: 2.70071716913e+06
+  tps: 1.00595609827e+06
+  hps: 10035.09347
  }
 }
 dps_results: {
  key: "TestWindwalker-Settings-Orc-p5_bis-DefaultTalents-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 512296.59691
-  tps: 495889.16232
-  hps: 12429.72317
+  dps: 522602.01851
+  tps: 506023.06495
+  hps: 12295.7316
  }
 }
 dps_results: {
  key: "TestWindwalker-Settings-Orc-p5_bis-DefaultTalents-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 635582.91734
-  tps: 587855.26647
-  hps: 13363.15884
+  dps: 630527.10095
+  tps: 582418.15089
+  hps: 13572.65882
  }
 }
 dps_results: {
  key: "TestWindwalker-Settings-Orc-p5_bis-DefaultTalents-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.01867502702e+06
-  tps: 750764.7809
-  hps: 8638.54982
+  dps: 2.01022756146e+06
+  tps: 748323.6114
+  hps: 8893.46664
  }
 }
 dps_results: {
  key: "TestWindwalker-Settings-Orc-p5_bis-DefaultTalents-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 387805.92712
-  tps: 376745.65767
-  hps: 10619.9364
+  dps: 386084.03809
+  tps: 374656.14092
+  hps: 10528.7002
  }
 }
 dps_results: {
  key: "TestWindwalker-Settings-Orc-p5_bis-DefaultTalents-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 410449.44853
-  tps: 381579.39166
-  hps: 10782.69961
+  dps: 403930.49634
+  tps: 374437.94343
+  hps: 11218.45443
  }
 }
 dps_results: {
  key: "TestWindwalker-Settings-Orc-p5_bis-RushingJadeWindTalent-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3.04895307991e+06
-  tps: 1.21732148921e+06
-  hps: 11872.1053
+  dps: 3.01791804577e+06
+  tps: 1.20892967241e+06
+  hps: 11800.42313
  }
 }
 dps_results: {
  key: "TestWindwalker-Settings-Orc-p5_bis-RushingJadeWindTalent-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 494425.28372
-  tps: 491477.06518
-  hps: 12571.24717
+  dps: 500403.60533
+  tps: 497438.88429
+  hps: 12436.33894
  }
 }
 dps_results: {
  key: "TestWindwalker-Settings-Orc-p5_bis-RushingJadeWindTalent-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 596656.34003
-  tps: 581915.24733
-  hps: 13467.12529
+  dps: 605594.36654
+  tps: 590770.76134
+  hps: 13518.34364
  }
 }
 dps_results: {
  key: "TestWindwalker-Settings-Orc-p5_bis-RushingJadeWindTalent-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.37137394905e+06
-  tps: 950513.10412
-  hps: 10332.46768
+  dps: 2.34255229895e+06
+  tps: 936914.09805
+  hps: 10038.58764
  }
 }
 dps_results: {
  key: "TestWindwalker-Settings-Orc-p5_bis-RushingJadeWindTalent-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 372395.42473
-  tps: 372395.42473
-  hps: 10728.95835
+  dps: 370992.6497
+  tps: 370992.6497
+  hps: 10812.03996
  }
 }
 dps_results: {
  key: "TestWindwalker-Settings-Orc-p5_bis-RushingJadeWindTalent-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 385344.0724
-  tps: 385344.0724
-  hps: 11181.05781
+  dps: 377634.42695
+  tps: 377634.42695
+  hps: 11411.5952
  }
 }
 dps_results: {
@@ -2601,104 +2601,104 @@ dps_results: {
 dps_results: {
  key: "TestWindwalker-Settings-Troll-p5_bis-DefaultTalents-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.68059695584e+06
-  tps: 998602.37834
-  hps: 10276.7107
+  dps: 2.72348527656e+06
+  tps: 1.01840796699e+06
+  hps: 10273.76253
  }
 }
 dps_results: {
  key: "TestWindwalker-Settings-Troll-p5_bis-DefaultTalents-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 520747.6982
-  tps: 504610.93132
-  hps: 11928.42005
+  dps: 525573.60353
+  tps: 509200.66341
+  hps: 12095.48432
  }
 }
 dps_results: {
  key: "TestWindwalker-Settings-Troll-p5_bis-DefaultTalents-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 612937.75724
-  tps: 565955.30547
-  hps: 13045.92209
+  dps: 622739.15399
+  tps: 575363.4598
+  hps: 13373.89524
  }
 }
 dps_results: {
  key: "TestWindwalker-Settings-Troll-p5_bis-DefaultTalents-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.07291601966e+06
-  tps: 769501.73716
-  hps: 8811.57377
+  dps: 2.03444537789e+06
+  tps: 756760.2886
+  hps: 8951.328
  }
 }
 dps_results: {
  key: "TestWindwalker-Settings-Troll-p5_bis-DefaultTalents-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 393191.81526
-  tps: 382273.29398
-  hps: 10595.18717
+  dps: 388427.60878
+  tps: 377521.5154
+  hps: 10562.98046
  }
 }
 dps_results: {
  key: "TestWindwalker-Settings-Troll-p5_bis-DefaultTalents-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 439592.19802
-  tps: 411223.12202
-  hps: 10896.17923
+  dps: 440434.70784
+  tps: 411589.02635
+  hps: 10977.7904
  }
 }
 dps_results: {
  key: "TestWindwalker-Settings-Troll-p5_bis-RushingJadeWindTalent-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3.05092001279e+06
-  tps: 1.22118771876e+06
-  hps: 11739.84359
+  dps: 3.12034798006e+06
+  tps: 1.25630915806e+06
+  hps: 11710.54893
  }
 }
 dps_results: {
  key: "TestWindwalker-Settings-Troll-p5_bis-RushingJadeWindTalent-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 502658.49636
-  tps: 499718.84113
-  hps: 12463.9248
+  dps: 504532.5461
+  tps: 501576.38837
+  hps: 12408.96243
  }
 }
 dps_results: {
  key: "TestWindwalker-Settings-Troll-p5_bis-RushingJadeWindTalent-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 609468.45021
-  tps: 594770.17407
-  hps: 13576.75652
+  dps: 617608.32403
+  tps: 602827.53539
+  hps: 13597.48207
  }
 }
 dps_results: {
  key: "TestWindwalker-Settings-Troll-p5_bis-RushingJadeWindTalent-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.37450226166e+06
-  tps: 956554.31155
-  hps: 10227.16204
+  dps: 2.40067222594e+06
+  tps: 965653.26751
+  hps: 10092.1821
  }
 }
 dps_results: {
  key: "TestWindwalker-Settings-Troll-p5_bis-RushingJadeWindTalent-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 376141.2557
-  tps: 376141.2557
-  hps: 10566.80478
+  dps: 369461.81076
+  tps: 369461.81076
+  hps: 10513.48498
  }
 }
 dps_results: {
  key: "TestWindwalker-Settings-Troll-p5_bis-RushingJadeWindTalent-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 396705.5944
-  tps: 396705.5944
-  hps: 10791.11344
+  dps: 399901.17927
+  tps: 399901.17927
+  hps: 10870.46698
  }
 }
 dps_results: {
  key: "TestWindwalker-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 445271.88132
-  tps: 429425.93427
-  hps: 12047.92355
+  dps: 442425.70114
+  tps: 426590.7861
+  hps: 12314.07627
  }
 }

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -879,10 +879,10 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-Fen-Yu,FuryofXuen-102248"
  value: {
-  dps: 602631.93152
-  tps: 3.82945780476e+06
+  dps: 603511.19184
+  tps: 3.83231423361e+06
   dtps: 43944.18029
-  hps: 79731.18024
+  hps: 79943.3361
  }
 }
 dps_results: {
@@ -969,10 +969,10 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-Gong-Lu,StrengthofXuen-102249"
  value: {
-  dps: 610076.04738
-  tps: 3.87516892717e+06
+  dps: 610270.62107
+  tps: 3.87712120882e+06
   dtps: 43746.74644
-  hps: 80564.85361
+  hps: 80551.38661
  }
 }
 dps_results: {

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -33,1544 +33,1544 @@ character_stats_results: {
 dps_results: {
  key: "TestRetribution-AllItems-AgilePrimalDiamond"
  value: {
-  dps: 450145.44934
-  tps: 425018.95798
+  dps: 449479.39906
+  tps: 424612.34579
   hps: 15.43942
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AlacrityofXuen-103989"
  value: {
-  dps: 424278.15901
-  tps: 401762.17849
+  dps: 424774.12703
+  tps: 402235.25027
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ArcaneBadgeoftheShieldwall-93347"
  value: {
-  dps: 406418.49303
-  tps: 386675.00117
+  dps: 406245.34334
+  tps: 386636.95171
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ArrowflightMedallion-93258"
  value: {
-  dps: 406552.58062
-  tps: 386506.13105
+  dps: 406227.58321
+  tps: 386402.94516
   hps: 16.60794
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AssuranceofConsequence-105472"
  value: {
-  dps: 400693.62508
-  tps: 381038.74305
+  dps: 400387.8148
+  tps: 380954.76194
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AusterePrimalDiamond"
  value: {
-  dps: 444890.24755
-  tps: 419788.14646
+  dps: 444232.45972
+  tps: 419389.90061
   hps: 15.24848
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BadJuju-96781"
  value: {
-  dps: 409674.98341
-  tps: 390088.6607
+  dps: 409305.26864
+  tps: 389940.77511
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BadgeofKypariZar-84079"
  value: {
-  dps: 407648.72895
-  tps: 387905.74653
-  hps: 15.57764
+  dps: 407245.34504
+  tps: 387730.94835
+  hps: 16.30556
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BattlegearofWingedTriumph"
  value: {
-  dps: 353853.15929
-  tps: 332834.93291
+  dps: 353475.88713
+  tps: 332692.24632
   hps: 15.58113
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BattlegearoftheLightningEmperor"
  value: {
-  dps: 346618.52306
-  tps: 325829.43585
+  dps: 346758.43861
+  tps: 326073.79456
   hps: 16.23106
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BlackBloodofY'Shaarj-105648"
  value: {
-  dps: 418308.73679
-  tps: 398434.71549
-  hps: 15.57764
+  dps: 418320.12695
+  tps: 398625.46519
+  hps: 15.88646
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BlossomofPureSnow-89081"
  value: {
-  dps: 405604.76705
-  tps: 385623.25179
+  dps: 405278.13698
+  tps: 385518.43324
   hps: 16.60794
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BottleofInfiniteStars-87057"
  value: {
-  dps: 406691.96117
-  tps: 387133.22458
+  dps: 406434.87883
+  tps: 387097.97141
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BraidofTenSongs-84072"
  value: {
-  dps: 407275.86476
-  tps: 387560.44151
+  dps: 405520.16176
+  tps: 386095.68063
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Brawler'sStatue-257885"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BreathoftheHydra-96827"
  value: {
-  dps: 411368.73422
-  tps: 391402.50385
+  dps: 411173.44071
+  tps: 391443.46735
   hps: 15.63408
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BroochofMunificentDeeds-87500"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BrutalTalismanoftheShado-PanAssault-94508"
  value: {
-  dps: 418641.1585
-  tps: 397750.4353
+  dps: 419104.03705
+  tps: 398313.57651
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BurningPrimalDiamond"
  value: {
-  dps: 450084.98206
-  tps: 424958.4907
+  dps: 449418.93178
+  tps: 424551.87851
   hps: 15.43942
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CapacitivePrimalDiamond"
  value: {
-  dps: 460486.69993
-  tps: 435529.40251
+  dps: 460125.35142
+  tps: 435343.41685
   hps: 15.24848
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CarbonicCarbuncle-81138"
  value: {
-  dps: 413869.67232
-  tps: 393199.51696
-  hps: 16.29912
+  dps: 413722.22171
+  tps: 393249.23784
+  hps: 16.60794
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Cha-Ye'sEssenceofBrilliance-96888"
  value: {
-  dps: 409157.26112
-  tps: 389226.0747
+  dps: 408898.18294
+  tps: 389188.82569
   hps: 15.88646
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CharmofTenSongs-84071"
  value: {
-  dps: 408509.94187
-  tps: 388429.00821
+  dps: 406626.32336
+  tps: 387001.8372
   hps: 15.28311
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CommunalIdolofDestruction-101168"
  value: {
-  dps: 410953.23297
-  tps: 391331.06117
+  dps: 411007.86962
+  tps: 391532.35093
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CommunalStoneofDestruction-101171"
  value: {
-  dps: 406711.49661
-  tps: 387162.94336
+  dps: 406643.77173
+  tps: 387317.04766
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CommunalStoneofWisdom-101183"
  value: {
-  dps: 399677.18257
-  tps: 380117.85172
+  dps: 399372.6175
+  tps: 380035.11582
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ContemplationofChi-Ji-103988"
  value: {
-  dps: 399724.09523
-  tps: 380175.54199
+  dps: 399419.53016
+  tps: 380092.80609
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Coren'sColdChromiumCoaster-257880"
  value: {
-  dps: 411521.95928
-  tps: 391319.39511
+  dps: 411215.27556
+  tps: 391234.54056
   hps: 15.88646
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CoreofDecency-87497"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CourageousPrimalDiamond"
  value: {
-  dps: 444890.24755
-  tps: 419788.14646
+  dps: 444232.45972
+  tps: 419389.90061
   hps: 15.24848
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CraftedDreadfulGladiator'sBadgeofConquest-93419"
  value: {
-  dps: 399762.45535
-  tps: 380190.5306
+  dps: 399457.89028
+  tps: 380107.7947
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CraftedDreadfulGladiator'sBadgeofDominance-93600"
  value: {
-  dps: 399730.86889
-  tps: 380171.53804
+  dps: 399426.30382
+  tps: 380088.80213
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CraftedDreadfulGladiator'sBadgeofVictory-93606"
  value: {
-  dps: 405959.12397
-  tps: 385670.42356
+  dps: 405654.55496
+  tps: 385587.68383
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CraftedDreadfulGladiator'sEmblemofCruelty-93485"
  value: {
-  dps: 403693.39246
-  tps: 383934.55922
+  dps: 403394.89315
+  tps: 383857.88909
   hps: 15.28311
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CraftedDreadfulGladiator'sEmblemofMeditation-93487"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CraftedDreadfulGladiator'sEmblemofTenacity-93486"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CraftedDreadfulGladiator'sInsigniaofConquest-93424"
  value: {
-  dps: 400127.58289
-  tps: 380555.65814
+  dps: 399798.64484
+  tps: 380448.54926
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CraftedDreadfulGladiator'sInsigniaofDominance-93601"
  value: {
-  dps: 399778.03202
-  tps: 380218.70117
+  dps: 399468.72766
+  tps: 380131.22598
   hps: 15.28311
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CraftedDreadfulGladiator'sInsigniaofVictory-93611"
  value: {
-  dps: 408709.86376
-  tps: 388267.27411
+  dps: 408388.92088
+  tps: 388225.40217
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CraftedMalevolentGladiator'sBadgeofConquest-98755"
  value: {
-  dps: 399792.55916
-  tps: 380220.63441
+  dps: 399487.99409
+  tps: 380137.89851
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CraftedMalevolentGladiator'sBadgeofDominance-98910"
  value: {
-  dps: 399755.57132
-  tps: 380196.24047
+  dps: 399451.00625
+  tps: 380113.50457
   hps: 15.28311
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CraftedMalevolentGladiator'sBadgeofVictory-98912"
  value: {
-  dps: 407115.77988
-  tps: 386691.94113
+  dps: 406811.21156
+  tps: 386609.20194
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CraftedMalevolentGladiator'sEmblemofCruelty-98811"
  value: {
-  dps: 404654.91901
-  tps: 384896.08578
+  dps: 404356.77122
+  tps: 384819.76716
   hps: 15.28311
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CraftedMalevolentGladiator'sEmblemofMeditation-98813"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CraftedMalevolentGladiator'sEmblemofTenacity-98812"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CraftedMalevolentGladiator'sInsigniaofConquest-98760"
  value: {
-  dps: 400071.33866
-  tps: 380512.60207
+  dps: 399762.37221
+  tps: 380425.46478
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CraftedMalevolentGladiator'sInsigniaofDominance-98911"
  value: {
-  dps: 399807.0338
-  tps: 380230.02575
-  hps: 14.97429
+  dps: 399501.11186
+  tps: 380145.93297
+  hps: 15.28311
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CraftedMalevolentGladiator'sInsigniaofVictory-98917"
  value: {
-  dps: 410343.32684
-  tps: 389822.96389
+  dps: 410063.20451
+  tps: 389765.95143
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CurseofHubris-105645"
  value: {
-  dps: 417583.7785
-  tps: 397036.00279
+  dps: 417308.32579
+  tps: 396981.49161
   hps: 18.91041
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CutstitcherMedallion-93255"
  value: {
-  dps: 399666.40496
-  tps: 380117.85172
+  dps: 399361.83989
+  tps: 380035.11582
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Daelo'sFinalWords-87496"
  value: {
-  dps: 407652.73768
-  tps: 387497.91335
+  dps: 407348.1724
+  tps: 387415.17724
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkglowEmbroidery(Rank3)-4893"
  value: {
-  dps: 459857.57636
-  tps: 434961.31787
+  dps: 459471.24969
+  tps: 434777.74897
   hps: 15.24848
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmistVortex-87172"
  value: {
-  dps: 422942.35812
-  tps: 400984.14575
+  dps: 421261.91304
+  tps: 399795.87132
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DeadeyeBadgeoftheShieldwall-93346"
  value: {
-  dps: 404233.69862
-  tps: 384685.14538
+  dps: 403903.17698
+  tps: 384576.45291
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DelicateVialoftheSanguinaire-96895"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DestructivePrimalDiamond"
  value: {
-  dps: 446542.27261
-  tps: 421323.32817
+  dps: 445912.31153
+  tps: 420952.90908
   hps: 15.24848
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DisciplineofXuen-103986"
  value: {
-  dps: 413739.34811
-  tps: 394158.35469
+  dps: 413112.34191
+  tps: 393753.17765
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Dominator'sArcaneBadge-93342"
  value: {
-  dps: 406418.49303
-  tps: 386675.00117
+  dps: 406245.34334
+  tps: 386636.95171
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Dominator'sDeadeyeBadge-93341"
  value: {
-  dps: 404233.69862
-  tps: 384685.14538
+  dps: 403903.17698
+  tps: 384576.45291
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Dominator'sDurableBadge-93345"
  value: {
-  dps: 403892.51883
-  tps: 384343.96559
+  dps: 403557.18251
+  tps: 384230.45844
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Dominator'sKnightlyBadge-93344"
  value: {
-  dps: 410263.74574
-  tps: 390293.74928
+  dps: 409928.42834
+  tps: 390180.26091
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Dominator'sMendingBadge-93343"
  value: {
-  dps: 399663.02255
-  tps: 380114.46931
+  dps: 399358.45748
+  tps: 380031.73341
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DreadfulGladiator'sBadgeofConquest-84344"
  value: {
-  dps: 399762.45535
-  tps: 380190.5306
+  dps: 399457.89028
+  tps: 380107.7947
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DreadfulGladiator'sBadgeofDominance-84488"
  value: {
-  dps: 399730.86889
-  tps: 380171.53804
+  dps: 399426.30382
+  tps: 380088.80213
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DreadfulGladiator'sBadgeofVictory-84490"
  value: {
-  dps: 405959.12397
-  tps: 385670.42356
+  dps: 405654.55496
+  tps: 385587.68383
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DreadfulGladiator'sEmblemofCruelty-84399"
  value: {
-  dps: 403693.39246
-  tps: 383934.55922
+  dps: 403394.89315
+  tps: 383857.88909
   hps: 15.28311
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DreadfulGladiator'sEmblemofMeditation-84401"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DreadfulGladiator'sEmblemofTenacity-84400"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DreadfulGladiator'sInsigniaofConquest-84349"
  value: {
-  dps: 400098.76762
-  tps: 380540.03103
+  dps: 399835.55649
+  tps: 380485.46091
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DreadfulGladiator'sInsigniaofDominance-84489"
  value: {
-  dps: 399774.10526
-  tps: 380214.77441
+  dps: 399461.88748
+  tps: 380124.38579
   hps: 15.28311
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DreadfulGladiator'sInsigniaofVictory-84495"
  value: {
-  dps: 408723.87113
-  tps: 388264.35487
+  dps: 408401.28367
+  tps: 388209.25224
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DurableBadgeoftheShieldwall-93350"
  value: {
-  dps: 403892.51883
-  tps: 384343.96559
+  dps: 403557.18251
+  tps: 384230.45844
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DysmorphicSamophlangeofDiscontinuity-105615"
  value: {
-  dps: 399808.0705
-  tps: 380248.73964
+  dps: 399503.50542
+  tps: 380166.00374
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EffulgentPrimalDiamond"
  value: {
-  dps: 444890.24755
-  tps: 419788.14646
+  dps: 444232.45972
+  tps: 419389.90061
   hps: 15.24848
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EmberPrimalDiamond"
  value: {
-  dps: 444890.24755
-  tps: 419788.14646
+  dps: 444232.45972
+  tps: 419389.90061
   hps: 15.24848
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EmblemofKypariZar-84077"
  value: {
-  dps: 409492.61506
-  tps: 389266.46008
+  dps: 406022.76582
+  tps: 386354.15247
   hps: 15.28311
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EmblemoftheCatacombs-83733"
  value: {
-  dps: 410122.27155
-  tps: 390397.25586
+  dps: 410026.99709
+  tps: 390488.61676
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EmptyFruitBarrel-81133"
  value: {
-  dps: 399629.80775
-  tps: 380081.25451
+  dps: 399325.24268
+  tps: 379998.51861
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnchantWeapon-BloodyDancingSteel-5125"
  value: {
-  dps: 460388.40493
-  tps: 435370.93178
+  dps: 460027.06235
+  tps: 435184.95206
   hps: 15.24848
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnchantWeapon-Colossus-4445"
  value: {
-  dps: 453638.76043
-  tps: 429136.48765
+  dps: 453277.39431
+  tps: 428950.48453
   hps: 15.24848
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnchantWeapon-ElementalForce-4443"
  value: {
-  dps: 454778.36437
-  tps: 430272.45881
+  dps: 454416.9576
+  tps: 430086.41504
   hps: 15.24848
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnchantWeapon-JadeSpirit-4442"
  value: {
-  dps: 453671.96836
-  tps: 429171.92494
+  dps: 453310.60224
+  tps: 428985.92182
   hps: 15.24848
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnchantWeapon-River'sSong-4446"
  value: {
-  dps: 453636.53107
-  tps: 429136.48765
+  dps: 453275.16495
+  tps: 428950.48453
   hps: 15.24848
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnchantWeapon-SpiritofConquest-5124"
  value: {
-  dps: 453644.27257
-  tps: 429166.23374
+  dps: 453282.90644
+  tps: 428980.23062
   hps: 15.24848
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnchantWeapon-Windsong-4441"
  value: {
-  dps: 455089.91614
-  tps: 430446.37671
+  dps: 454766.91341
+  tps: 430271.20096
   hps: 15.8984
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnigmaticPrimalDiamond"
  value: {
-  dps: 446542.27261
-  tps: 421323.32817
+  dps: 445912.31153
+  tps: 420952.90908
   hps: 15.24848
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EssenceofTerror-87175"
  value: {
-  dps: 404046.3308
-  tps: 384131.59185
+  dps: 403280.2689
+  tps: 383665.47036
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EternalPrimalDiamond"
  value: {
-  dps: 444890.24755
-  tps: 419788.14646
+  dps: 444232.45972
+  tps: 419389.90061
   hps: 15.24848
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EvilEyeofGalakras-105491"
  value: {
-  dps: 469504.36969
-  tps: 443080.62485
+  dps: 470458.0057
+  tps: 444178.04999
   hps: 22.01849
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FabledFeatherofJi-Kun-96842"
  value: {
-  dps: 418664.21139
-  tps: 397469.36484
+  dps: 417917.92741
+  tps: 397187.38537
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FearwurmBadge-84074"
  value: {
-  dps: 409869.58341
-  tps: 389741.49421
+  dps: 407477.90919
+  tps: 388003.04539
   hps: 15.28311
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FearwurmRelic-84070"
  value: {
-  dps: 410248.79112
-  tps: 390228.58639
+  dps: 410005.26463
+  tps: 390252.403
   hps: 15.28311
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FelsoulIdolofDestruction-101263"
  value: {
-  dps: 410221.95466
-  tps: 390346.3645
+  dps: 410096.09868
+  tps: 390371.38564
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FelsoulStoneofDestruction-101266"
  value: {
-  dps: 406868.40447
-  tps: 387319.85123
+  dps: 406652.23361
+  tps: 387325.50954
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Fen-Yu,FuryofXuen-102248"
  value: {
-  dps: 435897.00824
-  tps: 412081.23578
+  dps: 435443.20354
+  tps: 411765.95979
   hps: 15.24848
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FlashfrozenResinGlobule-100951"
  value: {
-  dps: 399686.91601
-  tps: 380109.90796
+  dps: 399382.35094
+  tps: 380027.17205
   hps: 15.28311
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FlashingSteelTalisman-81265"
  value: {
-  dps: 399742.74012
-  tps: 380170.81537
+  dps: 399442.98973
+  tps: 380092.89415
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FleetPrimalDiamond"
  value: {
-  dps: 447714.53768
-  tps: 422612.43658
+  dps: 447053.94817
+  tps: 422211.38907
   hps: 15.24848
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForlornPrimalDiamond"
  value: {
-  dps: 444890.24755
-  tps: 419788.14646
+  dps: 444232.45972
+  tps: 419389.90061
   hps: 15.24848
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FortitudeoftheZandalari-96793"
  value: {
-  dps: 409167.44979
-  tps: 389618.89655
+  dps: 408861.29571
+  tps: 389534.57164
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FrenziedCrystalofRage-105572"
  value: {
-  dps: 399888.93192
-  tps: 380302.93126
-  hps: 15.28311
+  dps: 399578.75857
+  tps: 380212.41173
+  hps: 15.65361
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Fusion-FireCore-105459"
  value: {
-  dps: 429969.7327
-  tps: 408272.65075
+  dps: 430559.31536
+  tps: 408969.25259
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GazeoftheTwins-96915"
  value: {
-  dps: 421484.10493
-  tps: 400654.10006
+  dps: 421067.43279
+  tps: 400476.40934
   hps: 15.57764
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Gerp'sPerfectArrow-87495"
  value: {
-  dps: 403378.36229
-  tps: 383646.92981
+  dps: 403077.80371
+  tps: 383568.2004
   hps: 15.28311
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GrievousGladiator'sBadgeofConquest-103145"
  value: {
-  dps: 399908.31726
-  tps: 380336.39251
+  dps: 399603.75219
+  tps: 380253.65661
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GrievousGladiator'sBadgeofDominance-103308"
  value: {
-  dps: 399797.81307
-  tps: 380220.80502
+  dps: 399491.89113
+  tps: 380136.71224
   hps: 15.28311
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GrievousGladiator'sBadgeofVictory-103314"
  value: {
-  dps: 411129.35788
-  tps: 390236.7458
+  dps: 410824.81223
+  tps: 390154.02943
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GrievousGladiator'sEmblemofCruelty-103210"
  value: {
-  dps: 407527.98398
-  tps: 387633.13995
+  dps: 407212.69905
+  tps: 387539.6842
   hps: 15.88646
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GrievousGladiator'sEmblemofMeditation-103212"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GrievousGladiator'sEmblemofTenacity-103211"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GrievousGladiator'sInsigniaofConquest-103150"
  value: {
-  dps: 400308.29682
-  tps: 380749.56022
+  dps: 399907.92194
+  tps: 380571.01452
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GrievousGladiator'sInsigniaofDominance-103309"
  value: {
-  dps: 399863.24216
-  tps: 380286.23411
+  dps: 399547.45819
+  tps: 380192.2793
   hps: 15.88646
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GrievousGladiator'sInsigniaofVictory-103319"
  value: {
-  dps: 415966.26504
-  tps: 394900.43848
+  dps: 415667.14015
+  tps: 394871.46263
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Haromm'sTalisman-105527"
  value: {
-  dps: 412782.79677
-  tps: 393172.52352
+  dps: 413200.50998
+  tps: 393807.8513
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Hawkmaster'sTalon-89082"
  value: {
-  dps: 408053.18081
-  tps: 388109.93624
+  dps: 407850.32423
+  tps: 388016.02666
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Heart-LesionDefenderIdol-100999"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Heart-LesionDefenderStone-101002"
  value: {
-  dps: 406731.09925
-  tps: 387182.54601
+  dps: 406518.73425
+  tps: 387192.01018
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Heart-LesionIdolofBattle-100991"
  value: {
-  dps: 414944.9039
-  tps: 394202.17035
+  dps: 414784.46514
+  tps: 394296.06652
   hps: 15.28311
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Heart-LesionStoneofBattle-100990"
  value: {
-  dps: 414892.16819
-  tps: 394811.73233
+  dps: 414721.22693
+  tps: 394862.62025
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HeartofFire-81181"
  value: {
-  dps: 404237.1357
-  tps: 384688.58246
+  dps: 403931.80243
+  tps: 384605.07836
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HeartwarmerMedallion-93260"
  value: {
-  dps: 399666.40496
-  tps: 380117.85172
+  dps: 399361.83989
+  tps: 380035.11582
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HelmbreakerMedallion-93261"
  value: {
-  dps: 415266.2104
-  tps: 394623.21219
+  dps: 414937.53366
+  tps: 394516.34696
   hps: 16.60794
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Horridon'sLastGasp-96757"
  value: {
-  dps: 399734.87284
-  tps: 380182.34199
+  dps: 399430.30777
+  tps: 380099.60609
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpassivePrimalDiamond"
  value: {
-  dps: 446542.27261
-  tps: 421323.32817
+  dps: 445912.31153
+  tps: 420952.90908
   hps: 15.24848
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IndomitablePrimalDiamond"
  value: {
-  dps: 444890.24755
-  tps: 419788.14646
+  dps: 444232.45972
+  tps: 419389.90061
   hps: 15.24848
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InscribedBagofHydra-Spawn-96828"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InsigniaofKypariZar-84078"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IronBellyWok-89083"
  value: {
-  dps: 416285.12116
-  tps: 395767.42308
+  dps: 416082.26545
+  tps: 395673.51437
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-IronProtectorTalisman-85181"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-JadeBanditFigurine-86772"
  value: {
-  dps: 407642.1832
-  tps: 388185.87585
+  dps: 407119.38118
+  tps: 387754.77419
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-JadeCharioteerFigurine-86771"
  value: {
-  dps: 414944.46433
-  tps: 394993.31154
+  dps: 414421.83801
+  tps: 394562.38573
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-JadeCourtesanFigurine-86774"
  value: {
-  dps: 399666.40496
-  tps: 380117.85172
+  dps: 399361.83989
+  tps: 380035.11582
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-JadeMagistrateFigurine-86773"
  value: {
-  dps: 404822.38782
-  tps: 384868.45867
+  dps: 404501.38507
+  tps: 384765.05283
   hps: 16.60794
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-JadeWarlordFigurine-86775"
  value: {
-  dps: 404670.99382
-  tps: 385122.44058
+  dps: 404330.04714
+  tps: 385003.32307
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Ji-Kun'sRisingWinds-96843"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Juggernaut'sFocusingCrystal-105514"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
-  hps: 12053.7617
+  dps: 399318.23248
+  tps: 379991.50841
+  hps: 12051.88248
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Kardris'ToxicTotem-105540"
  value: {
-  dps: 412476.81059
-  tps: 392879.55482
-  hps: 16.25697
+  dps: 412747.14621
+  tps: 393364.70995
+  hps: 16.60794
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-KnightlyBadgeoftheShieldwall-93349"
  value: {
-  dps: 410263.74574
-  tps: 390293.74928
+  dps: 409928.42834
+  tps: 390180.26091
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-KnotofTenSongs-84073"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Kor'kronBookofHurting-92785"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Lao-Chin'sLiquidCourage-89079"
  value: {
-  dps: 405322.62971
-  tps: 385774.07647
+  dps: 404976.98679
+  tps: 385650.26272
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LeiShen'sFinalOrders-87072"
  value: {
-  dps: 422772.42092
-  tps: 401290.31402
+  dps: 422282.75339
+  tps: 401086.55517
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LessonsoftheDarkmaster-81268"
  value: {
-  dps: 409160.16085
-  tps: 387971.31035
+  dps: 408855.59072
+  tps: 387888.56939
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightdrinkerIdolofRage-101200"
  value: {
-  dps: 405577.39399
-  tps: 386018.6574
+  dps: 405299.66676
+  tps: 385962.75934
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightdrinkerStoneofRage-101203"
  value: {
-  dps: 407302.57962
-  tps: 387754.02638
+  dps: 407018.54261
+  tps: 387691.81854
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightoftheCosmos-87065"
  value: {
-  dps: 410866.97357
-  tps: 390583.28093
+  dps: 410393.00123
+  tps: 390353.72198
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LightweaveEmbroidery(Rank3)-4892"
  value: {
-  dps: 459873.77933
-  tps: 434975.29149
+  dps: 459514.84757
+  tps: 434791.72259
   hps: 15.24848
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LordBlastington'sScopeofDoom-4699"
  value: {
-  dps: 453638.76043
-  tps: 429136.48765
+  dps: 453277.39431
+  tps: 428950.48453
   hps: 15.24848
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MalevolentGladiator'sBadgeofConquest-91452"
  value: {
-  dps: 399792.55916
-  tps: 380220.63441
+  dps: 399487.99409
+  tps: 380137.89851
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MalevolentGladiator'sBadgeofDominance-91753"
  value: {
-  dps: 399755.57132
-  tps: 380196.24047
+  dps: 399451.00625
+  tps: 380113.50457
   hps: 15.28311
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MalevolentGladiator'sBadgeofVictory-91763"
  value: {
-  dps: 407115.77988
-  tps: 386691.94113
+  dps: 406811.21156
+  tps: 386609.20194
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MalevolentGladiator'sEmblemofCruelty-91562"
  value: {
-  dps: 404654.91901
-  tps: 384896.08578
+  dps: 404356.77122
+  tps: 384819.76716
   hps: 15.28311
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MalevolentGladiator'sEmblemofMeditation-91564"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MalevolentGladiator'sEmblemofTenacity-91563"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MalevolentGladiator'sInsigniaofConquest-91457"
  value: {
-  dps: 400208.03445
-  tps: 380636.1097
+  dps: 399820.09552
+  tps: 380469.99994
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MalevolentGladiator'sInsigniaofDominance-91754"
  value: {
-  dps: 399802.71942
-  tps: 380225.71136
-  hps: 14.97429
+  dps: 399493.41506
+  tps: 380138.23618
+  hps: 15.28311
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MalevolentGladiator'sInsigniaofVictory-91768"
  value: {
-  dps: 410434.83725
-  tps: 389872.40094
+  dps: 410099.31177
+  tps: 389791.29453
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MarkoftheCatacombs-83731"
  value: {
-  dps: 406571.07204
-  tps: 386885.55087
+  dps: 406242.5882
+  tps: 386778.8962
   hps: 15.28311
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MarkoftheHardenedGrunt-92783"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MedallionofMystifyingVapors-93257"
  value: {
-  dps: 405707.90348
-  tps: 386159.35024
+  dps: 405359.48395
+  tps: 386032.75988
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MedallionoftheCatacombs-83734"
  value: {
-  dps: 402984.1277
-  tps: 383435.57446
+  dps: 402679.00303
+  tps: 383352.27896
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MendingBadgeoftheShieldwall-93348"
  value: {
-  dps: 399663.02255
-  tps: 380114.46931
+  dps: 399358.45748
+  tps: 380031.73341
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MirrorScope-4700"
  value: {
-  dps: 453638.76043
-  tps: 429136.48765
+  dps: 453277.39431
+  tps: 428950.48453
   hps: 15.24848
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MistdancerDefenderIdol-101089"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MistdancerDefenderStone-101087"
  value: {
-  dps: 406674.31146
-  tps: 387125.75822
+  dps: 406655.72987
+  tps: 387329.0058
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MistdancerIdolofRage-101113"
  value: {
-  dps: 405500.16112
-  tps: 385918.05302
+  dps: 405222.09998
+  tps: 385872.00441
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MistdancerStoneofRage-101117"
  value: {
-  dps: 407108.28116
-  tps: 387559.72792
+  dps: 406994.4618
+  tps: 387667.73773
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MistdancerStoneofWisdom-101107"
  value: {
-  dps: 399666.40496
-  tps: 380117.85172
+  dps: 399361.83989
+  tps: 380035.11582
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MithrilWristwatch-257884"
  value: {
-  dps: 405376.99919
-  tps: 385579.78134
+  dps: 405070.30727
+  tps: 385494.91859
   hps: 15.88646
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MountainsageIdolofDestruction-101069"
  value: {
-  dps: 408687.90043
-  tps: 388887.29107
+  dps: 408622.05505
+  tps: 389087.21772
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MountainsageStoneofDestruction-101072"
  value: {
-  dps: 406912.21603
-  tps: 387363.66278
+  dps: 406722.76175
+  tps: 387396.03768
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-OathswornDefenderIdol-101303"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-OathswornDefenderStone-101306"
  value: {
-  dps: 406793.38539
-  tps: 387244.83215
+  dps: 406707.84598
+  tps: 387381.12191
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-OathswornIdolofBattle-101295"
  value: {
-  dps: 414997.77658
-  tps: 394258.83131
+  dps: 414687.09739
+  tps: 394233.49204
   hps: 15.28311
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-OathswornStoneofBattle-101294"
  value: {
-  dps: 414773.04354
-  tps: 394692.60768
+  dps: 414707.37758
+  tps: 394848.77089
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PhaseFingers-4697"
  value: {
-  dps: 459072.01283
-  tps: 434204.75966
+  dps: 458683.26852
+  tps: 434018.77326
   hps: 15.24848
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PlateofWingedTriumph"
  value: {
-  dps: 319236.77922
-  tps: 299189.432
+  dps: 318586.09729
+  tps: 298765.52458
   hps: 15.24848
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PlateoftheLightningEmperor"
  value: {
-  dps: 307544.8267
-  tps: 287813.99499
+  dps: 307227.03135
+  tps: 287712.7687
   hps: 15.24848
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PouchofWhiteAsh-103639"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PowerfulPrimalDiamond"
  value: {
-  dps: 444890.24755
-  tps: 419788.14646
+  dps: 444232.45972
+  tps: 419389.90061
   hps: 15.24848
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PriceofProgress-81266"
  value: {
-  dps: 399663.02255
-  tps: 380114.46931
+  dps: 399358.45748
+  tps: 380031.73341
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PridefulGladiator'sBadgeofConquest-103342"
  value: {
-  dps: 400044.81281
-  tps: 380462.70471
+  dps: 399740.24774
+  tps: 380379.96881
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PridefulGladiator'sBadgeofDominance-103505"
  value: {
-  dps: 399840.54785
-  tps: 380263.53979
+  dps: 399534.6259
+  tps: 380179.44702
   hps: 15.88646
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PridefulGladiator'sBadgeofVictory-103511"
  value: {
-  dps: 414562.30042
-  tps: 393268.6696
+  dps: 414257.75122
+  tps: 393185.94956
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PridefulGladiator'sEmblemofCruelty-103407"
  value: {
-  dps: 409775.30023
-  tps: 389808.05979
+  dps: 409515.12382
+  tps: 389769.71255
   hps: 16.30556
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PridefulGladiator'sEmblemofMeditation-103409"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PridefulGladiator'sEmblemofTenacity-103408"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PridefulGladiator'sInsigniaofConquest-103347"
  value: {
-  dps: 400629.55254
-  tps: 381048.55911
+  dps: 400312.84442
+  tps: 380953.68017
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PridefulGladiator'sInsigniaofDominance-103506"
  value: {
-  dps: 399885.88269
-  tps: 380308.87464
-  hps: 15.57764
+  dps: 399576.57834
+  tps: 380221.39946
+  hps: 15.88646
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PridefulGladiator'sInsigniaofVictory-103516"
  value: {
-  dps: 420773.46559
-  tps: 399247.02645
+  dps: 420664.64147
+  tps: 399377.67234
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Primordius'TalismanofRage-96873"
  value: {
-  dps: 422544.99506
-  tps: 401771.33916
+  dps: 421794.18927
+  tps: 401277.18008
   hps: 15.88646
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PrismaticPrisonofPride-105474"
  value: {
-  dps: 423860.91363
-  tps: 403765.77122
+  dps: 423635.09457
+  tps: 403739.95494
   hps: 15.22881
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PurifiedBindingsofImmerseus-105422"
  value: {
-  dps: 424227.87998
-  tps: 404075.783
+  dps: 423994.19283
+  tps: 404042.09863
   hps: 15.95679
  }
 }
@@ -1593,704 +1593,704 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-Qin-xi'sPolarizingSeal-87075"
  value: {
-  dps: 399636.18066
-  tps: 380087.62741
+  dps: 399331.61558
+  tps: 380004.89151
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelicofChi-Ji-79330"
  value: {
-  dps: 399666.40496
-  tps: 380117.85172
+  dps: 399361.83989
+  tps: 380035.11582
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelicofKypariZar-84075"
  value: {
-  dps: 408973.10579
-  tps: 388773.9784
+  dps: 408560.63109
+  tps: 388615.28706
   hps: 15.88646
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelicofNiuzao-79329"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelicofXuen-79327"
  value: {
-  dps: 414157.80211
-  tps: 393378.45016
+  dps: 413917.58241
+  tps: 393382.44425
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelicofXuen-79328"
  value: {
-  dps: 400198.93751
-  tps: 380640.20092
+  dps: 400047.75817
+  tps: 380701.78207
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RelicofYu'lon-79331"
  value: {
-  dps: 399769.58166
-  tps: 380192.5736
+  dps: 399463.65971
+  tps: 380108.48083
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Renataki'sSoulCharm-96741"
  value: {
-  dps: 400318.71758
-  tps: 380736.05539
+  dps: 399928.04711
+  tps: 380564.66826
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ResolveofNiuzao-103990"
  value: {
-  dps: 408649.90301
-  tps: 389101.34977
+  dps: 408343.83509
+  tps: 389017.11102
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ReverberatingPrimalDiamond"
  value: {
-  dps: 451816.47687
-  tps: 426574.50267
+  dps: 451150.40836
+  tps: 426167.8724
   hps: 15.43942
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RevitalizingPrimalDiamond"
  value: {
-  dps: 450084.98206
-  tps: 424958.4907
+  dps: 449418.93178
+  tps: 424551.87851
   hps: 15.43942
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RuneofRe-Origination-96918"
  value: {
-  dps: 409362.31599
-  tps: 390916.36413
-  hps: 14.70233
+  dps: 407947.78615
+  tps: 389672.11848
+  hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SI:7Operative'sManual-92784"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ScrollofReveredAncestors-89080"
  value: {
-  dps: 399666.40496
-  tps: 380117.85172
+  dps: 399361.83989
+  tps: 380035.11582
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SearingWords-81267"
  value: {
-  dps: 404338.29335
-  tps: 384579.46011
+  dps: 404066.26227
+  tps: 384519.53466
   hps: 15.28311
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Shock-ChargerMedallion-93259"
  value: {
-  dps: 407911.2151
-  tps: 387904.5112
+  dps: 407105.56502
+  tps: 387461.33039
   hps: 15.28311
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SigilofCompassion-83736"
  value: {
-  dps: 402984.1277
-  tps: 383435.57446
+  dps: 402679.00303
+  tps: 383352.27896
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SigilofDevotion-83740"
  value: {
-  dps: 406743.87257
-  tps: 387058.35141
+  dps: 406460.8512
+  tps: 386997.15921
   hps: 15.28311
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SigilofFidelity-83737"
  value: {
-  dps: 409895.02367
-  tps: 389945.56392
+  dps: 409636.08164
+  tps: 389856.58038
   hps: 15.7022
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SigilofGrace-83738"
  value: {
-  dps: 407405.06893
-  tps: 387594.03162
+  dps: 406897.91317
+  tps: 386980.69831
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SigilofKypariZar-84076"
  value: {
-  dps: 406965.9556
-  tps: 387280.43444
+  dps: 406687.14691
+  tps: 387223.45492
   hps: 15.28311
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SigilofPatience-83739"
  value: {
-  dps: 403758.72702
-  tps: 384210.17378
+  dps: 403540.07735
+  tps: 384213.35328
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SigilofRampage-105580"
  value: {
-  dps: 400626.9387
-  tps: 381005.36741
+  dps: 400196.32979
+  tps: 380783.39952
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SigiloftheCatacombs-83732"
  value: {
-  dps: 408215.60707
-  tps: 388201.05337
+  dps: 407423.23976
+  tps: 387673.50772
   hps: 15.28311
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SinisterPrimalDiamond"
  value: {
-  dps: 447366.05906
-  tps: 422059.38369
+  dps: 446552.42583
+  tps: 421523.65606
   hps: 15.24848
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Skeer'sBloodsoakedTalisman-105632"
  value: {
-  dps: 436228.5777
-  tps: 414290.21019
-  hps: 16.40355
+  dps: 439840.39655
+  tps: 417721.46271
+  hps: 17.41748
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SkullrenderMedallion-93256"
  value: {
-  dps: 415266.2104
-  tps: 394623.21219
+  dps: 414937.53366
+  tps: 394516.34696
   hps: 16.60794
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SoothingTalismanoftheShado-PanAssault-94509"
  value: {
-  dps: 399719.79413
-  tps: 380171.24089
+  dps: 399415.22906
+  tps: 380088.50499
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SoulBarrier-96927"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SparkofZandalar-96770"
  value: {
-  dps: 423573.60745
-  tps: 403101.30782
+  dps: 423047.29565
+  tps: 402818.87585
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SpiritsoftheSun-87163"
  value: {
-  dps: 399689.99416
-  tps: 380141.44092
+  dps: 399385.42909
+  tps: 380058.70502
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SpringrainIdolofDestruction-101023"
  value: {
-  dps: 408676.07153
-  tps: 388865.05441
+  dps: 408323.53923
+  tps: 388727.61544
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SpringrainIdolofRage-101009"
  value: {
-  dps: 405577.1765
-  tps: 386018.43991
+  dps: 405357.70354
+  tps: 386007.60796
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SpringrainStoneofDestruction-101026"
  value: {
-  dps: 406797.10372
-  tps: 387248.55048
+  dps: 406642.10397
+  tps: 387315.3799
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SpringrainStoneofRage-101012"
  value: {
-  dps: 407219.79172
-  tps: 387671.23848
+  dps: 407070.42591
+  tps: 387743.70184
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SpringrainStoneofWisdom-101041"
  value: {
-  dps: 399675.29122
-  tps: 380126.73798
+  dps: 399370.72615
+  tps: 380044.00208
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Static-Caster'sMedallion-93254"
  value: {
-  dps: 407911.2151
-  tps: 387904.5112
+  dps: 407105.56502
+  tps: 387461.33039
   hps: 15.28311
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SteadfastFootman'sMedallion-92782"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SteadfastTalismanoftheShado-PanAssault-94507"
  value: {
-  dps: 407614.80944
-  tps: 388066.2562
+  dps: 407308.91385
+  tps: 387982.18978
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-StreamtalkerIdolofDestruction-101222"
  value: {
-  dps: 406488.60715
-  tps: 386694.17718
+  dps: 406555.72004
+  tps: 386921.46188
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-StreamtalkerIdolofRage-101217"
  value: {
-  dps: 405585.02805
-  tps: 386013.1033
+  dps: 405369.52033
+  tps: 386019.42475
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-StreamtalkerStoneofDestruction-101225"
  value: {
-  dps: 406669.13733
-  tps: 387120.58409
+  dps: 406535.97091
+  tps: 387209.24684
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-StreamtalkerStoneofRage-101220"
  value: {
-  dps: 407168.30761
-  tps: 387619.75436
+  dps: 407016.81558
+  tps: 387690.09151
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-StreamtalkerStoneofWisdom-101250"
  value: {
-  dps: 399691.42618
-  tps: 380125.19574
+  dps: 399386.86111
+  tps: 380042.45984
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-StuffofNightmares-87160"
  value: {
-  dps: 406705.01668
-  tps: 387156.46344
+  dps: 406399.27255
+  tps: 387072.54848
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SunsoulDefenderIdol-101160"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SunsoulDefenderStone-101163"
  value: {
-  dps: 406828.66351
-  tps: 387280.11027
+  dps: 406705.22682
+  tps: 387378.50275
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SunsoulIdolofBattle-101152"
  value: {
-  dps: 415049.20641
-  tps: 394354.84113
+  dps: 414784.63908
+  tps: 394327.04515
   hps: 15.28311
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SunsoulStoneofBattle-101151"
  value: {
-  dps: 415024.22612
-  tps: 394943.79026
+  dps: 414775.52474
+  tps: 394916.91805
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SunsoulStoneofWisdom-101138"
  value: {
-  dps: 399686.06883
-  tps: 380126.73798
+  dps: 399381.50376
+  tps: 380044.00208
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SwordguardEmbroidery(Rank3)-4894"
  value: {
-  dps: 463810.82246
-  tps: 438502.91991
+  dps: 463424.49579
+  tps: 438319.35101
   hps: 15.24848
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SymboloftheCatacombs-83735"
  value: {
-  dps: 407797.36023
-  tps: 388067.84075
-  hps: 15.88646
+  dps: 407141.02037
+  tps: 387613.99528
+  hps: 16.30556
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SynapseSprings(MarkII)-4898"
  value: {
-  dps: 462165.70715
-  tps: 436776.39414
+  dps: 461817.44348
+  tps: 436696.37462
   hps: 15.24848
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TalismanofBloodlust-96864"
  value: {
-  dps: 411998.07403
-  tps: 391769.22136
+  dps: 411613.61606
+  tps: 391790.3082
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TerrorintheMists-87167"
  value: {
-  dps: 412164.89474
-  tps: 391350.22938
-  hps: 15.28311
+  dps: 412103.35207
+  tps: 391587.18629
+  hps: 17.71989
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Thok'sAcid-GroovedTooth-105607"
  value: {
-  dps: 399638.7063
-  tps: 380090.15306
+  dps: 399334.14123
+  tps: 380007.41716
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Thok'sTailTip-105609"
  value: {
-  dps: 454757.21015
-  tps: 429889.01454
+  dps: 454531.39223
+  tps: 429863.19939
   hps: 15.22881
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Thousand-YearPickledEgg-257881"
  value: {
-  dps: 400174.78942
-  tps: 380552.87401
+  dps: 400025.58701
+  tps: 380596.63828
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TickingEbonDetonator-105612"
  value: {
-  dps: 413134.23316
-  tps: 393548.54122
+  dps: 412827.7546
+  tps: 393463.89183
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Time-LostArtifact-103678"
  value: {
-  dps: 417772.92031
-  tps: 397530.94193
+  dps: 416503.30905
+  tps: 396454.58835
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TrailseekerIdolofRage-101054"
  value: {
-  dps: 405638.21101
-  tps: 386079.47442
+  dps: 405383.96102
+  tps: 386033.86545
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TrailseekerStoneofRage-101057"
  value: {
-  dps: 407193.37566
-  tps: 387644.82242
+  dps: 407014.79559
+  tps: 387688.07152
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TyrannicalGladiator'sBadgeofConquest-100043"
  value: {
-  dps: 399795.37681
-  tps: 380223.45206
+  dps: 399490.81174
+  tps: 380140.71616
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TyrannicalGladiator'sBadgeofDominance-100016"
  value: {
-  dps: 399769.78116
-  tps: 380210.45031
+  dps: 399463.85921
+  tps: 380126.35753
   hps: 15.28311
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TyrannicalGladiator'sBadgeofVictory-100019"
  value: {
-  dps: 408655.36345
-  tps: 388051.70655
+  dps: 408350.81502
+  tps: 387968.9873
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TyrannicalGladiator'sEmblemofCruelty-100066"
  value: {
-  dps: 405749.90228
-  tps: 385944.07556
+  dps: 405406.30004
+  tps: 385822.30249
   hps: 15.88646
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TyrannicalGladiator'sEmblemofMeditation-99990"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TyrannicalGladiator'sEmblemofTenacity-100092"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TyrannicalGladiator'sInsigniaofConquest-100026"
  value: {
-  dps: 400229.01156
-  tps: 380670.27497
+  dps: 400102.19511
+  tps: 380765.28769
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TyrannicalGladiator'sInsigniaofDominance-100152"
  value: {
-  dps: 399794.7197
-  tps: 380217.71165
+  dps: 399488.79776
+  tps: 380133.61887
   hps: 15.28311
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TyrannicalGladiator'sInsigniaofVictory-100085"
  value: {
-  dps: 412587.51916
-  tps: 391766.95941
+  dps: 412317.32961
+  tps: 391800.96832
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TyrannicalPrimalDiamond"
  value: {
-  dps: 444890.24755
-  tps: 419788.14646
+  dps: 444232.45972
+  tps: 419389.90061
   hps: 15.24848
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-UnerringVisionofLeiShen-96930"
  value: {
-  dps: 399734.87284
-  tps: 380175.54199
+  dps: 399430.30777
+  tps: 380092.80609
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-VaporshieldMedallion-93262"
  value: {
-  dps: 405707.90348
-  tps: 386159.35024
+  dps: 405359.48395
+  tps: 386032.75988
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-VestmentsofWingedTriumph"
  value: {
-  dps: 256181.33522
-  tps: 240822.29241
+  dps: 255723.18365
+  tps: 240568.9899
   hps: 16.23106
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-VestmentsoftheLightningEmperor"
  value: {
-  dps: 263348.48677
-  tps: 247192.66379
+  dps: 262542.90229
+  tps: 246628.91403
   hps: 17.06595
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-VialofDragon'sBlood-87063"
  value: {
-  dps: 406259.04624
-  tps: 386710.493
+  dps: 405952.62233
+  tps: 386625.89826
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-VialofIchorousBlood-100963"
  value: {
-  dps: 399663.02255
-  tps: 380114.46931
+  dps: 399358.45748
+  tps: 380031.73341
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-VialofLivingCorruption-105568"
  value: {
-  dps: 399622.79755
-  tps: 380074.24431
+  dps: 399318.23248
+  tps: 379991.50841
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ViciousTalismanoftheShado-PanAssault-94511"
  value: {
-  dps: 400028.34131
-  tps: 380437.06942
+  dps: 399841.91783
+  tps: 380459.28695
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-VisionofthePredator-81192"
  value: {
-  dps: 406438.2312
-  tps: 386442.85914
+  dps: 406133.49596
+  tps: 386364.16767
   hps: 15.63408
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-VolatileTalismanoftheShado-PanAssault-94510"
  value: {
-  dps: 403020.14286
-  tps: 383299.74287
+  dps: 402767.23324
+  tps: 383281.86127
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WhiteTigerBattlegear"
  value: {
-  dps: 328277.15261
-  tps: 307976.81508
+  dps: 328041.42382
+  tps: 307950.73292
   hps: 15.58113
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WhiteTigerPlate"
  value: {
-  dps: 289180.61923
-  tps: 271068.1847
+  dps: 288915.24879
+  tps: 271010.74589
   hps: 15.24848
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WhiteTigerVestments"
  value: {
-  dps: 257734.09714
-  tps: 242002.41989
+  dps: 257695.77888
+  tps: 242168.78135
   hps: 17.06595
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WindsweptPages-81125"
  value: {
-  dps: 405035.92995
-  tps: 384928.98139
+  dps: 405369.81813
+  tps: 385516.04001
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WoundripperMedallion-93253"
  value: {
-  dps: 406552.58062
-  tps: 386506.13105
+  dps: 406227.58321
+  tps: 386402.94516
   hps: 16.60794
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Wushoolay'sFinalChoice-96785"
  value: {
-  dps: 399935.83636
-  tps: 380358.8283
+  dps: 399631.27129
+  tps: 380276.0924
   hps: 15.28311
  }
 }
@@ -2305,1706 +2305,1706 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-Yu'lon'sBite-103987"
  value: {
-  dps: 412963.39678
-  tps: 392053.51103
+  dps: 412626.33374
+  tps: 391945.38481
   hps: 15.97178
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ZenAlchemistStone-75274"
  value: {
-  dps: 414274.57507
-  tps: 393857.31985
+  dps: 413826.32558
+  tps: 393677.75861
   hps: 14.97429
  }
 }
 dps_results: {
  key: "TestRetribution-Average-Default"
  value: {
-  dps: 463772.31657
-  tps: 438434.25314
+  dps: 463464.69236
+  tps: 438303.90239
   hps: 15.42529
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DefaultTalents-Seal of Insight-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.77641358674e+06
-  tps: 2.76048466619e+06
-  hps: 17662.4297
+  dps: 2.77459524147e+06
+  tps: 2.75870870724e+06
+  hps: 17684.36972
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DefaultTalents-Seal of Insight-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 420984.45602
-  tps: 395577.46176
-  hps: 21595.26043
+  dps: 420982.59263
+  tps: 395621.04497
+  hps: 21574.3502
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DefaultTalents-Seal of Insight-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 565180.75287
-  tps: 506609.50109
-  hps: 26300.54314
+  dps: 567101.28928
+  tps: 507894.17105
+  hps: 26328.79205
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DefaultTalents-Seal of Insight-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.07899684871e+06
-  tps: 2.07768096622e+06
-  hps: 13177.14622
+  dps: 2.07663592887e+06
+  tps: 2.07546535829e+06
+  hps: 13158.09289
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DefaultTalents-Seal of Insight-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 300298.00348
-  tps: 285994.07888
-  hps: 16231.61014
+  dps: 299802.39553
+  tps: 285724.27759
+  hps: 16299.9886
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DefaultTalents-Seal of Insight-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 351693.3906
-  tps: 327327.76764
-  hps: 17207.13268
+  dps: 352494.20774
+  tps: 328168.81264
+  hps: 17231.78785
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DefaultTalents-Seal of Justice-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.79181906115e+06
-  tps: 2.77611364483e+06
+  dps: 2.78997320247e+06
+  tps: 2.77438135466e+06
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DefaultTalents-Seal of Justice-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 447782.32565
-  tps: 422840.1194
+  dps: 447447.18079
+  tps: 422619.78271
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DefaultTalents-Seal of Justice-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 602054.96671
-  tps: 543105.07894
+  dps: 603654.49556
+  tps: 544435.91662
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DefaultTalents-Seal of Justice-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.09127916853e+06
-  tps: 2.09017677818e+06
+  dps: 2.08989913001e+06
+  tps: 2.08889154629e+06
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DefaultTalents-Seal of Justice-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 317545.41639
-  tps: 303774.84861
+  dps: 317291.00998
+  tps: 303703.84377
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DefaultTalents-Seal of Justice-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 377658.16843
-  tps: 353496.35449
+  dps: 378410.79148
+  tps: 353999.88477
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DefaultTalents-Seal of Righteousness-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3.0044357131e+06
-  tps: 2.98896178866e+06
+  dps: 3.00469604764e+06
+  tps: 2.98925630177e+06
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DefaultTalents-Seal of Righteousness-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 433774.25445
-  tps: 408903.63323
+  dps: 433598.81596
+  tps: 408778.16579
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DefaultTalents-Seal of Righteousness-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 586760.05539
-  tps: 527801.47895
+  dps: 588135.73903
+  tps: 528908.47142
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DefaultTalents-Seal of Righteousness-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.25703923927e+06
-  tps: 2.25606202739e+06
+  dps: 2.25733631993e+06
+  tps: 2.25635226424e+06
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DefaultTalents-Seal of Righteousness-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 309197.35218
-  tps: 295478.66312
+  dps: 309016.08517
+  tps: 295475.04638
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DefaultTalents-Seal of Righteousness-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 370206.33735
-  tps: 345977.72409
+  dps: 370871.92047
+  tps: 346461.01376
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DefaultTalents-Seal of Truth-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.80280278725e+06
-  tps: 2.78672140208e+06
+  dps: 2.80088633569e+06
+  tps: 2.7849266757e+06
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DefaultTalents-Seal of Truth-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 464357.28271
-  tps: 439455.08021
+  dps: 464025.80876
+  tps: 439297.12594
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DefaultTalents-Seal of Truth-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 619328.02911
-  tps: 560448.91555
+  dps: 620201.83159
+  tps: 561736.30606
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DefaultTalents-Seal of Truth-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.10188299564e+06
-  tps: 2.10069449855e+06
+  dps: 2.10023285684e+06
+  tps: 2.0991526043e+06
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DefaultTalents-Seal of Truth-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 327939.61129
-  tps: 313985.86575
+  dps: 327317.67757
+  tps: 313553.67797
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DefaultTalents-Seal of Truth-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 386749.57059
-  tps: 362546.3089
+  dps: 387645.31741
+  tps: 363412.90906
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_ExecutionSentence-Seal of Insight-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3.21206597136e+06
-  tps: 3.19591841386e+06
-  hps: 17099.32974
+  dps: 3.20938747401e+06
+  tps: 3.19337636343e+06
+  hps: 17115.64038
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_ExecutionSentence-Seal of Insight-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 401451.25502
-  tps: 376102.45116
-  hps: 22776.72404
+  dps: 401716.96184
+  tps: 376517.18055
+  hps: 22805.71534
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_ExecutionSentence-Seal of Insight-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 510221.27398
-  tps: 451865.18046
-  hps: 27507.36112
+  dps: 512249.34982
+  tps: 453343.08488
+  hps: 27535.28799
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_ExecutionSentence-Seal of Insight-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.40839943473e+06
-  tps: 2.40682818081e+06
-  hps: 12574.1208
+  dps: 2.4050838359e+06
+  tps: 2.40361743974e+06
+  hps: 12562.15966
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_ExecutionSentence-Seal of Insight-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 290638.10141
-  tps: 276525.51224
-  hps: 17289.88757
+  dps: 291055.81572
+  tps: 277108.71092
+  hps: 17308.5316
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_ExecutionSentence-Seal of Insight-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 324882.01027
-  tps: 300116.23924
-  hps: 18467.85048
+  dps: 326845.63019
+  tps: 302019.88805
+  hps: 18490.55474
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_ExecutionSentence-Seal of Justice-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3.23093689595e+06
-  tps: 3.21480786612e+06
+  dps: 3.22779923287e+06
+  tps: 3.21184196691e+06
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_ExecutionSentence-Seal of Justice-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 423854.38703
-  tps: 398499.52262
+  dps: 423608.67044
+  tps: 398393.14159
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_ExecutionSentence-Seal of Justice-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 542787.80775
-  tps: 484055.01667
+  dps: 543757.78574
+  tps: 484831.29097
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_ExecutionSentence-Seal of Justice-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.41752381247e+06
-  tps: 2.41583109587e+06
+  dps: 2.41504072643e+06
+  tps: 2.41343889123e+06
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_ExecutionSentence-Seal of Justice-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 311482.12239
-  tps: 297267.48586
+  dps: 311409.36981
+  tps: 297343.22909
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_ExecutionSentence-Seal of Justice-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 350626.01808
-  tps: 325935.76472
+  dps: 351804.82849
+  tps: 326848.47038
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_ExecutionSentence-Seal of Righteousness-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3.44812765461e+06
-  tps: 3.43237982907e+06
+  dps: 3.44784612808e+06
+  tps: 3.43214928307e+06
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_ExecutionSentence-Seal of Righteousness-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 413859.40136
-  tps: 388634.53105
+  dps: 413866.48622
+  tps: 388711.99382
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_ExecutionSentence-Seal of Righteousness-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 526777.43519
-  tps: 468044.64411
+  dps: 527518.67833
+  tps: 468592.18356
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_ExecutionSentence-Seal of Righteousness-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.59601458766e+06
-  tps: 2.59447140475e+06
+  dps: 2.59609357895e+06
+  tps: 2.59450922394e+06
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_ExecutionSentence-Seal of Righteousness-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 301560.56355
-  tps: 287378.71019
+  dps: 301181.61648
+  tps: 287157.56089
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_ExecutionSentence-Seal of Righteousness-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 344186.57587
-  tps: 319429.52319
+  dps: 345469.14039
+  tps: 320512.78229
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_ExecutionSentence-Seal of Truth-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3.24814983468e+06
-  tps: 3.23220981071e+06
+  dps: 3.2448141138e+06
+  tps: 3.22899794111e+06
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_ExecutionSentence-Seal of Truth-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 440757.76541
-  tps: 415619.62661
+  dps: 440525.90053
+  tps: 415554.03935
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_ExecutionSentence-Seal of Truth-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 564361.10577
-  tps: 503955.67612
+  dps: 565569.69676
+  tps: 505459.42255
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_ExecutionSentence-Seal of Truth-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.42764633237e+06
-  tps: 2.42607916568e+06
+  dps: 2.42483673209e+06
+  tps: 2.42336893718e+06
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_ExecutionSentence-Seal of Truth-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 321150.40391
-  tps: 307358.51803
+  dps: 320917.36584
+  tps: 307296.21619
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_ExecutionSentence-Seal of Truth-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 360351.05895
-  tps: 336804.1333
+  dps: 361774.61381
+  tps: 338152.0317
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_HolyPrism-Seal of Insight-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3.27854272442e+06
-  tps: 3.26251330694e+06
-  hps: 18112.62099
+  dps: 3.27501269462e+06
+  tps: 3.25905224341e+06
+  hps: 18122.55906
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_HolyPrism-Seal of Insight-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 394495.81827
-  tps: 368658.67286
-  hps: 23864.01938
+  dps: 394990.49031
+  tps: 369272.78058
+  hps: 23882.61873
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_HolyPrism-Seal of Insight-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 495581.973
-  tps: 436232.36288
-  hps: 28302.79395
+  dps: 498677.86083
+  tps: 438811.47625
+  hps: 28447.53332
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_HolyPrism-Seal of Insight-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.45004946785e+06
-  tps: 2.44910535679e+06
-  hps: 13691.58411
+  dps: 2.44925146032e+06
+  tps: 2.44841019367e+06
+  hps: 13680.82008
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_HolyPrism-Seal of Insight-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 288194.78999
-  tps: 274050.93876
-  hps: 18254.08174
+  dps: 288768.4944
+  tps: 274817.43137
+  hps: 18280.14265
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_HolyPrism-Seal of Insight-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 321383.13501
-  tps: 296979.93406
-  hps: 19186.88806
+  dps: 322584.09737
+  tps: 298090.29595
+  hps: 19275.36536
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_HolyPrism-Seal of Justice-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3.28578879584e+06
-  tps: 3.27002010252e+06
-  hps: 1016.27404
+  dps: 3.28437293724e+06
+  tps: 3.26875221599e+06
+  hps: 1008.62808
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_HolyPrism-Seal of Justice-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 423267.37451
-  tps: 398120.57876
+  dps: 423260.28137
+  tps: 398274.06353
   hps: 820.95714
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_HolyPrism-Seal of Justice-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 538986.61095
-  tps: 479293.07131
+  dps: 539954.16501
+  tps: 480068.05059
   hps: 245.61457
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_HolyPrism-Seal of Justice-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.45590664856e+06
-  tps: 2.45473034663e+06
-  hps: 1004.95543
+  dps: 2.45504127716e+06
+  tps: 2.45399528852e+06
+  hps: 1008.25405
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_HolyPrism-Seal of Justice-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 307095.09108
-  tps: 293329.55351
-  hps: 755.4678
+  dps: 307029.32688
+  tps: 293422.35185
+  hps: 761.69058
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_HolyPrism-Seal of Justice-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 338314.10002
-  tps: 314252.66589
+  dps: 339372.9186
+  tps: 315080.3011
   hps: 383.5641
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_HolyPrism-Seal of Righteousness-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3.51088535981e+06
-  tps: 3.49546148221e+06
+  dps: 3.51093003317e+06
+  tps: 3.49555300617e+06
   hps: 1000.17998
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_HolyPrism-Seal of Righteousness-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 411312.48248
-  tps: 386319.82072
-  hps: 824.78023
+  dps: 411595.62023
+  tps: 386679.0562
+  hps: 823.98084
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_HolyPrism-Seal of Righteousness-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 523373.52781
-  tps: 463679.98818
+  dps: 524324.02678
+  tps: 464437.91236
   hps: 245.61457
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_HolyPrism-Seal of Righteousness-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.63580154169e+06
-  tps: 2.63479340079e+06
+  dps: 2.63554716944e+06
+  tps: 2.6345011808e+06
   hps: 1001.10437
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_HolyPrism-Seal of Righteousness-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 297979.75211
-  tps: 284259.64744
-  hps: 755.4678
+  dps: 297912.32272
+  tps: 284294.25089
+  hps: 761.69058
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_HolyPrism-Seal of Righteousness-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 331708.94833
-  tps: 307580.71489
+  dps: 332997.89427
+  tps: 308705.27677
   hps: 383.5641
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_HolyPrism-Seal of Truth-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3.30210795607e+06
-  tps: 3.28652834948e+06
-  hps: 1004.34644
+  dps: 3.30088834632e+06
+  tps: 3.28542109493e+06
+  hps: 996.35648
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_HolyPrism-Seal of Truth-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 434040.17901
-  tps: 408773.14069
-  hps: 832.77019
+  dps: 434181.70742
+  tps: 409090.68359
+  hps: 828.14772
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_HolyPrism-Seal of Truth-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 555520.50946
-  tps: 495050.6654
+  dps: 556165.51277
+  tps: 495922.05466
   hps: 245.61457
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_HolyPrism-Seal of Truth-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.46856509016e+06
-  tps: 2.46749291791e+06
-  hps: 1004.85618
+  dps: 2.46752910507e+06
+  tps: 2.46658897852e+06
+  hps: 1004.54685
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_HolyPrism-Seal of Truth-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 317221.79678
-  tps: 303574.69791
-  hps: 758.77772
+  dps: 317192.97094
+  tps: 303727.52562
+  hps: 768.31042
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_HolyPrism-Seal of Truth-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 355211.41436
-  tps: 331852.77719
+  dps: 356486.55853
+  tps: 333047.73877
   hps: 383.5641
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_LightsHammer-Seal of Insight-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3.30034663992e+06
-  tps: 3.28419872837e+06
-  hps: 21753.30863
+  dps: 3.29723083456e+06
+  tps: 3.28121936993e+06
+  hps: 21732.80046
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_LightsHammer-Seal of Insight-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 394988.05657
-  tps: 369657.59886
-  hps: 27952.09662
+  dps: 395065.30851
+  tps: 369883.87337
+  hps: 27843.29047
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_LightsHammer-Seal of Insight-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 499225.11037
-  tps: 440960.74759
-  hps: 34270.42241
+  dps: 500840.22414
+  tps: 442025.68994
+  hps: 34113.73392
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_LightsHammer-Seal of Insight-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.47383788545e+06
-  tps: 2.47226663154e+06
-  hps: 16182.14398
+  dps: 2.47023620764e+06
+  tps: 2.46876981148e+06
+  hps: 16135.68212
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_LightsHammer-Seal of Insight-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 285181.75599
-  tps: 271069.16682
-  hps: 21287.19171
+  dps: 285806.37243
+  tps: 271859.26763
+  hps: 21159.54933
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_LightsHammer-Seal of Insight-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 316831.72567
-  tps: 292065.95464
-  hps: 23617.28812
+  dps: 318439.88748
+  tps: 293614.14534
+  hps: 23383.75855
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_LightsHammer-Seal of Justice-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3.31861029474e+06
-  tps: 3.30248091087e+06
-  hps: 4630.06034
+  dps: 3.31506368716e+06
+  tps: 3.29910606716e+06
+  hps: 4598.32175
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_LightsHammer-Seal of Justice-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 417052.64034
-  tps: 391716.12208
-  hps: 4932.67294
+  dps: 417028.5083
+  tps: 391831.3256
+  hps: 4880.92621
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_LightsHammer-Seal of Justice-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 531469.35924
-  tps: 472828.29889
-  hps: 6666.77976
+  dps: 532328.89341
+  tps: 473494.12937
+  hps: 6561.43495
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_LightsHammer-Seal of Justice-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.48270829305e+06
-  tps: 2.48101557645e+06
-  hps: 3617.72937
+  dps: 2.48006092417e+06
+  tps: 2.47845908897e+06
+  hps: 3592.80941
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_LightsHammer-Seal of Justice-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 306254.41532
-  tps: 292039.77879
-  hps: 3829.81271
+  dps: 306434.5149
+  tps: 292368.37418
+  hps: 3759.16361
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_LightsHammer-Seal of Justice-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 342312.32541
-  tps: 317622.07205
-  hps: 5008.85388
+  dps: 343388.10104
+  tps: 318431.74293
+  hps: 4864.83609
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_LightsHammer-Seal of Righteousness-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3.53537219932e+06
-  tps: 3.51962401973e+06
-  hps: 4589.38519
+  dps: 3.5349984066e+06
+  tps: 3.51930120755e+06
+  hps: 4585.68917
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_LightsHammer-Seal of Righteousness-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 407084.57865
-  tps: 381878.05448
-  hps: 4922.99189
+  dps: 407316.42436
+  tps: 382180.27811
+  hps: 4877.94957
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_LightsHammer-Seal of Righteousness-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 515456.87574
-  tps: 456815.8154
-  hps: 6666.77976
+  dps: 516087.67506
+  tps: 457252.91102
+  hps: 6561.43495
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_LightsHammer-Seal of Righteousness-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.66098628917e+06
-  tps: 2.65944310626e+06
-  hps: 3593.32443
+  dps: 2.66103376879e+06
+  tps: 2.65944941378e+06
+  hps: 3590.28997
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_LightsHammer-Seal of Righteousness-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 296261.19802
-  tps: 282079.34465
-  hps: 3809.06061
+  dps: 296234.20018
+  tps: 282210.14458
+  hps: 3752.72142
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_LightsHammer-Seal of Righteousness-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 335864.94712
-  tps: 311107.89444
-  hps: 4993.3414
+  dps: 337051.89896
+  tps: 312095.54085
+  hps: 4864.83609
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_LightsHammer-Seal of Truth-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3.33555694735e+06
-  tps: 3.31961656934e+06
-  hps: 4619.24257
+  dps: 3.33197935353e+06
+  tps: 3.3161628268e+06
+  hps: 4598.36666
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_LightsHammer-Seal of Truth-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 433960.06575
-  tps: 408840.2731
-  hps: 4860.77512
+  dps: 433833.14717
+  tps: 408879.63214
+  hps: 4824.95344
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_LightsHammer-Seal of Truth-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 553511.86088
-  tps: 493198.16197
-  hps: 6597.35519
+  dps: 554592.74244
+  tps: 494574.19896
+  hps: 6500.64732
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_LightsHammer-Seal of Truth-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.49290629471e+06
-  tps: 2.49133912802e+06
-  hps: 3612.6437
+  dps: 2.48989080946e+06
+  tps: 2.48842301455e+06
+  hps: 3590.07398
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_LightsHammer-Seal of Truth-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 315852.14834
-  tps: 302060.26246
-  hps: 3766.96698
+  dps: 316020.10587
+  tps: 302398.95623
+  hps: 3725.96792
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-DivinePurpose_LightsHammer-Seal of Truth-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 351926.86154
-  tps: 328379.93589
-  hps: 4962.44692
+  dps: 353331.99685
+  tps: 329709.41473
+  hps: 4835.65191
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_ExecutionSentence-Seal of Insight-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.7291147639e+06
-  tps: 2.71364606518e+06
-  hps: 18339.22364
+  dps: 2.7260469915e+06
+  tps: 2.71074325825e+06
+  hps: 18352.22279
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_ExecutionSentence-Seal of Insight-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 393524.54889
-  tps: 368177.59389
-  hps: 22379.50459
+  dps: 394014.91171
+  tps: 368849.96989
+  hps: 22442.39914
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_ExecutionSentence-Seal of Insight-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 537092.17848
-  tps: 478863.39851
-  hps: 28244.68637
+  dps: 540066.72841
+  tps: 481281.93413
+  hps: 28337.31522
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_ExecutionSentence-Seal of Insight-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.07706452195e+06
-  tps: 2.07561426315e+06
-  hps: 13636.84752
+  dps: 2.07440617365e+06
+  tps: 2.07316367944e+06
+  hps: 13629.72312
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_ExecutionSentence-Seal of Insight-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 284242.15472
-  tps: 270161.13623
-  hps: 17023.28784
+  dps: 284630.45823
+  tps: 270715.47037
+  hps: 17077.01258
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_ExecutionSentence-Seal of Insight-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 342709.19182
-  tps: 318292.73147
-  hps: 19384.15307
+  dps: 343650.51702
+  tps: 319208.10951
+  hps: 19469.0686
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_ExecutionSentence-Seal of Justice-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.73646392497e+06
-  tps: 2.72112766371e+06
+  dps: 2.73495774569e+06
+  tps: 2.7198241392e+06
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_ExecutionSentence-Seal of Justice-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 419614.33991
-  tps: 394887.06004
+  dps: 419398.81321
+  tps: 394752.40072
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_ExecutionSentence-Seal of Justice-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 575175.1098
-  tps: 516557.36782
+  dps: 576489.2544
+  tps: 517682.23028
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_ExecutionSentence-Seal of Justice-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.08755290571e+06
-  tps: 2.08650600984e+06
+  dps: 2.08725977198e+06
+  tps: 2.08634794962e+06
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_ExecutionSentence-Seal of Justice-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 302186.81498
-  tps: 288322.33731
+  dps: 302082.64633
+  tps: 288359.57875
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_ExecutionSentence-Seal of Justice-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 369902.03494
-  tps: 345497.78835
+  dps: 371400.20137
+  tps: 346746.23772
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_ExecutionSentence-Seal of Righteousness-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.95436965498e+06
-  tps: 2.93940259029e+06
+  dps: 2.95396695188e+06
+  tps: 2.93905408512e+06
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_ExecutionSentence-Seal of Righteousness-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 405575.60739
-  tps: 380837.97917
+  dps: 405235.04775
+  tps: 380607.58215
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_ExecutionSentence-Seal of Righteousness-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 560885.31519
-  tps: 502267.57321
+  dps: 562268.76949
+  tps: 503461.74538
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_ExecutionSentence-Seal of Righteousness-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.2583153183e+06
-  tps: 2.2574960005e+06
+  dps: 2.25769387477e+06
+  tps: 2.25685965198e+06
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_ExecutionSentence-Seal of Righteousness-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 294181.6718
-  tps: 280354.77655
+  dps: 294183.13442
+  tps: 280504.21994
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_ExecutionSentence-Seal of Righteousness-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 355695.58525
-  tps: 331224.53935
+  dps: 356931.25997
+  tps: 332277.29632
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_ExecutionSentence-Seal of Truth-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.76185069263e+06
-  tps: 2.74614595003e+06
+  dps: 2.75971484554e+06
+  tps: 2.74419922987e+06
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_ExecutionSentence-Seal of Truth-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 435657.94434
-  tps: 410874.45626
+  dps: 435458.76021
+  tps: 410883.59229
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_ExecutionSentence-Seal of Truth-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 599786.36497
-  tps: 540298.42435
+  dps: 600344.681
+  tps: 541166.28943
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_ExecutionSentence-Seal of Truth-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.09960066675e+06
-  tps: 2.09833040824e+06
+  dps: 2.09870146188e+06
+  tps: 2.0975515904e+06
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_ExecutionSentence-Seal of Truth-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 313910.95584
-  tps: 300216.39361
+  dps: 313756.13331
+  tps: 300195.28676
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_ExecutionSentence-Seal of Truth-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 376025.1516
-  tps: 351879.64377
+  dps: 377361.34237
+  tps: 353124.45371
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_HolyPrism-Seal of Insight-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.80222466265e+06
-  tps: 2.78688795337e+06
-  hps: 19943.45019
+  dps: 2.79863597203e+06
+  tps: 2.78340975827e+06
+  hps: 19948.08967
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_HolyPrism-Seal of Insight-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 387673.8123
-  tps: 362237.19985
-  hps: 23950.2518
+  dps: 388312.00084
+  tps: 362982.22061
+  hps: 24070.5047
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_HolyPrism-Seal of Insight-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 534208.37375
-  tps: 474255.73231
-  hps: 29281.45132
+  dps: 537626.61929
+  tps: 477039.31607
+  hps: 29281.58822
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_HolyPrism-Seal of Insight-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.12429439737e+06
-  tps: 2.12387430527e+06
-  hps: 14997.88477
+  dps: 2.12258146279e+06
+  tps: 2.12236101758e+06
+  hps: 14948.47319
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_HolyPrism-Seal of Insight-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 280988.7828
-  tps: 267107.70148
-  hps: 18319.71083
+  dps: 281278.50243
+  tps: 267636.53569
+  hps: 18360.2981
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_HolyPrism-Seal of Insight-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 342624.84446
-  tps: 318844.76065
-  hps: 20466.19966
+  dps: 343636.57069
+  tps: 319768.14358
+  hps: 20563.13023
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_HolyPrism-Seal of Justice-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.81811708781e+06
-  tps: 2.8029719466e+06
-  hps: 1462.68876
+  dps: 2.81295782771e+06
+  tps: 2.79797636562e+06
+  hps: 1465.39652
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_HolyPrism-Seal of Justice-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 413347.81562
-  tps: 387852.96846
-  hps: 1281.04355
+  dps: 413680.02511
+  tps: 388234.26649
+  hps: 1300.51363
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_HolyPrism-Seal of Justice-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 572542.6432
-  tps: 512162.68117
+  dps: 574237.91593
+  tps: 513630.38288
   hps: 241.01048
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_HolyPrism-Seal of Justice-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.11878369797e+06
-  tps: 2.11834199123e+06
-  hps: 1399.8225
+  dps: 2.11809018444e+06
+  tps: 2.11770596725e+06
+  hps: 1386.45048
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_HolyPrism-Seal of Justice-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 300507.66916
-  tps: 286704.7356
-  hps: 1104.0458
+  dps: 300858.86944
+  tps: 287198.26679
+  hps: 1097.02912
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_HolyPrism-Seal of Justice-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 358859.52542
-  tps: 334981.44807
+  dps: 359800.75503
+  tps: 335730.35652
   hps: 676.47029
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_HolyPrism-Seal of Righteousness-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3.03184495137e+06
-  tps: 3.01699193974e+06
+  dps: 3.03161177185e+06
+  tps: 3.01680093525e+06
   hps: 1484.51194
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_HolyPrism-Seal of Righteousness-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 401259.7965
-  tps: 375763.12427
-  hps: 1293.09663
+  dps: 401843.71154
+  tps: 376382.43039
+  hps: 1304.33672
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_HolyPrism-Seal of Righteousness-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 561026.04172
-  tps: 500646.07969
+  dps: 562818.0598
+  tps: 502210.52675
   hps: 241.01048
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_HolyPrism-Seal of Righteousness-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.29237381914e+06
-  tps: 2.29207004206e+06
-  hps: 1385.98415
+  dps: 2.29212802085e+06
+  tps: 2.29177264598e+06
+  hps: 1379.06628
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_HolyPrism-Seal of Righteousness-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 291484.91804
-  tps: 277705.94171
-  hps: 1100.3386
+  dps: 291530.57361
+  tps: 277884.70427
+  hps: 1090.012
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_HolyPrism-Seal of Righteousness-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 354461.8743
-  tps: 330500.2978
+  dps: 355510.11729
+  tps: 331439.71879
   hps: 676.47029
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_HolyPrism-Seal of Truth-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.83657180279e+06
-  tps: 2.82129973356e+06
-  hps: 1466.51184
+  dps: 2.83323520384e+06
+  tps: 2.8181057316e+06
+  hps: 1465.39652
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_HolyPrism-Seal of Truth-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 426420.15226
-  tps: 401452.94109
-  hps: 1308.61803
+  dps: 426625.74731
+  tps: 401777.55003
+  hps: 1312.32647
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_HolyPrism-Seal of Truth-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 591042.74466
-  tps: 531418.78975
+  dps: 592215.94066
+  tps: 532859.38879
   hps: 241.01048
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_HolyPrism-Seal of Truth-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.12974199605e+06
-  tps: 2.12938668475e+06
-  hps: 1396.51258
+  dps: 2.12884443424e+06
+  tps: 2.12855397913e+06
+  hps: 1386.45048
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_HolyPrism-Seal of Truth-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 310219.52801
-  tps: 296479.5688
-  hps: 1110.66564
+  dps: 310247.36795
+  tps: 296661.74949
+  hps: 1097.02912
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_HolyPrism-Seal of Truth-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 381068.86085
-  tps: 357588.89752
+  dps: 382184.96596
+  tps: 358748.97625
   hps: 676.47029
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_LightsHammer-Seal of Insight-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.8193399116e+06
-  tps: 2.80393731812e+06
-  hps: 23095.96809
+  dps: 2.81532698673e+06
+  tps: 2.80008935872e+06
+  hps: 23047.51788
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_LightsHammer-Seal of Insight-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 386904.75341
-  tps: 361550.41695
-  hps: 27521.6187
+  dps: 387495.59013
+  tps: 362323.26686
+  hps: 27416.63354
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_LightsHammer-Seal of Insight-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 525962.71631
-  tps: 467697.02907
-  hps: 34964.02248
+  dps: 528704.54967
+  tps: 469882.84811
+  hps: 34838.20475
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_LightsHammer-Seal of Insight-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.14350067265e+06
-  tps: 2.14205041385e+06
-  hps: 17318.38523
+  dps: 2.14002128518e+06
+  tps: 2.13877879097e+06
+  hps: 17246.43249
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_LightsHammer-Seal of Insight-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 278741.97153
-  tps: 264660.95305
-  hps: 21033.60993
+  dps: 279433.93755
+  tps: 265518.94969
+  hps: 20962.64824
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_LightsHammer-Seal of Insight-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 334569.65821
-  tps: 310153.19786
-  hps: 24535.85189
+  dps: 334961.84026
+  tps: 310519.43275
+  hps: 24339.52237
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_LightsHammer-Seal of Justice-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.82571543263e+06
-  tps: 2.81044527662e+06
-  hps: 4723.76099
+  dps: 2.8235595759e+06
+  tps: 2.80849207466e+06
+  hps: 4678.05878
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_LightsHammer-Seal of Justice-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 412881.10602
-  tps: 388146.44469
-  hps: 4917.36405
+  dps: 413018.11818
+  tps: 388364.32423
+  hps: 4857.98256
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_LightsHammer-Seal of Justice-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 563925.33256
-  tps: 505270.6833
-  hps: 6623.49721
+  dps: 565110.9443
+  tps: 506267.01291
+  hps: 6483.25415
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_LightsHammer-Seal of Justice-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.15341586022e+06
-  tps: 2.15235323217e+06
-  hps: 3663.88905
+  dps: 2.15256440581e+06
+  tps: 2.15163685128e+06
+  hps: 3623.83711
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_LightsHammer-Seal of Justice-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 296804.34154
-  tps: 282918.88764
-  hps: 3835.0351
+  dps: 297014.29697
+  tps: 283270.25315
+  hps: 3756.74654
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_LightsHammer-Seal of Justice-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 361573.44614
-  tps: 337169.19955
-  hps: 5020.99415
+  dps: 362758.3082
+  tps: 338104.34456
+  hps: 4846.20687
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_LightsHammer-Seal of Righteousness-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3.04321948384e+06
-  tps: 3.02831852439e+06
-  hps: 4670.88565
+  dps: 3.04255425396e+06
+  tps: 3.02770749244e+06
+  hps: 4658.57586
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_LightsHammer-Seal of Righteousness-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 398843.05838
-  tps: 374098.0487
-  hps: 4909.34985
+  dps: 398852.24733
+  tps: 374217.40027
+  hps: 4856.22675
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_LightsHammer-Seal of Righteousness-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 549634.92408
-  tps: 490980.27482
-  hps: 6623.49721
+  dps: 550889.84554
+  tps: 492045.91415
+  hps: 6483.25415
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_LightsHammer-Seal of Righteousness-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.32376371699e+06
-  tps: 2.32292866702e+06
-  hps: 3625.90901
+  dps: 2.3229558201e+06
+  tps: 2.32210586514e+06
+  hps: 3616.77332
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_LightsHammer-Seal of Righteousness-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 288872.52587
-  tps: 275045.63062
-  hps: 3822.88127
+  dps: 289057.92529
+  tps: 275379.01081
+  hps: 3748.78445
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_LightsHammer-Seal of Righteousness-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 347351.59104
-  tps: 322880.54513
-  hps: 4998.05957
+  dps: 348288.80558
+  tps: 323634.84194
+  hps: 4846.20687
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_LightsHammer-Seal of Truth-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.85066904199e+06
-  tps: 2.83503040464e+06
-  hps: 4700.07418
+  dps: 2.84818831564e+06
+  tps: 2.83273880521e+06
+  hps: 4671.53365
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_LightsHammer-Seal of Truth-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 428852.67675
-  tps: 404061.80721
-  hps: 4833.67665
+  dps: 428912.75599
+  tps: 404330.20661
+  hps: 4791.24316
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_LightsHammer-Seal of Truth-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 588769.49029
-  tps: 529244.6424
-  hps: 6526.88646
+  dps: 589260.98277
+  tps: 530045.68393
+  hps: 6431.04884
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_LightsHammer-Seal of Truth-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.16548473607e+06
-  tps: 2.16419874539e+06
-  hps: 3648.12477
+  dps: 2.16411591475e+06
+  tps: 2.16295031109e+06
+  hps: 3618.48292
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_LightsHammer-Seal of Truth-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 308558.88092
-  tps: 294864.31869
-  hps: 3763.47794
+  dps: 308685.35432
+  tps: 295124.50777
+  hps: 3718.34465
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-HolyAvenger_LightsHammer-Seal of Truth-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 367572.9763
-  tps: 343427.46848
-  hps: 4930.42388
+  dps: 368754.00897
+  tps: 344517.12031
+  hps: 4817.08756
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_HolyPrism-Seal of Insight-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.82685127781e+06
-  tps: 2.81092898567e+06
-  hps: 19177.59781
+  dps: 2.82422270725e+06
+  tps: 2.80842311404e+06
+  hps: 19183.74067
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_HolyPrism-Seal of Insight-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 416956.41502
-  tps: 391221.76458
-  hps: 23101.34497
+  dps: 416957.54198
+  tps: 391388.1171
+  hps: 23120.23984
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_HolyPrism-Seal of Insight-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 556572.28105
-  tps: 496004.35818
-  hps: 27460.54406
+  dps: 558659.13742
+  tps: 497765.09306
+  hps: 27527.63471
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_HolyPrism-Seal of Insight-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.10298685379e+06
-  tps: 2.10205800927e+06
-  hps: 14327.29301
+  dps: 2.10172934282e+06
+  tps: 2.10094142456e+06
+  hps: 14292.32401
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_HolyPrism-Seal of Insight-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 296750.36983
-  tps: 282380.61037
-  hps: 17552.49585
+  dps: 296914.01598
+  tps: 282700.89154
+  hps: 17570.02114
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_HolyPrism-Seal of Insight-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 347790.00716
-  tps: 324067.36847
-  hps: 18264.6821
+  dps: 348435.96357
+  tps: 324631.58156
+  hps: 18318.13579
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_HolyPrism-Seal of Justice-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.84628081482e+06
-  tps: 2.83064356591e+06
-  hps: 1380.179
+  dps: 2.8430004549e+06
+  tps: 2.82755805608e+06
+  hps: 1356.36132
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_HolyPrism-Seal of Justice-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 440531.10013
-  tps: 415330.41697
-  hps: 1095.63746
+  dps: 440634.34014
+  tps: 415526.57369
+  hps: 1114.86752
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_HolyPrism-Seal of Justice-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 589184.31609
-  tps: 528448.31655
+  dps: 590960.02976
+  tps: 530054.02469
   hps: 296.91444
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_HolyPrism-Seal of Justice-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.11292863014e+06
-  tps: 2.11210818774e+06
-  hps: 1155.19244
+  dps: 2.1121328973e+06
+  tps: 2.1113911626e+06
+  hps: 1127.81889
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_HolyPrism-Seal of Justice-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 315953.90074
-  tps: 302165.72025
-  hps: 986.18448
+  dps: 315555.52455
+  tps: 301931.6813
+  hps: 988.31885
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_HolyPrism-Seal of Justice-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 367952.08044
-  tps: 344065.99271
+  dps: 368431.50947
+  tps: 344353.5298
   hps: 515.73826
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_HolyPrism-Seal of Righteousness-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3.05819571599e+06
-  tps: 3.04281770193e+06
+  dps: 3.0581877382e+06
+  tps: 3.04290742278e+06
   hps: 1352.19444
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_HolyPrism-Seal of Righteousness-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 430461.45803
-  tps: 405366.50946
-  hps: 1099.46054
+  dps: 430437.41209
+  tps: 405371.13579
+  hps: 1110.8533
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_HolyPrism-Seal of Righteousness-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 578005.09268
-  tps: 517260.40447
+  dps: 579802.16251
+  tps: 518887.46876
   hps: 296.91444
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_HolyPrism-Seal of Righteousness-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.2798722329e+06
-  tps: 2.279170609e+06
-  hps: 1127.81889
+  dps: 2.27966678201e+06
+  tps: 2.2789380326e+06
+  hps: 1124.50897
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_HolyPrism-Seal of Righteousness-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 305812.44577
-  tps: 292046.92711
-  hps: 975.12616
+  dps: 305385.54857
+  tps: 291809.18278
+  hps: 988.31885
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_HolyPrism-Seal of Righteousness-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 354921.02787
-  tps: 330951.44101
+  dps: 355307.27927
+  tps: 331229.2996
   hps: 515.73826
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_HolyPrism-Seal of Truth-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.86196885055e+06
-  tps: 2.84637624205e+06
-  hps: 1380.179
+  dps: 2.85971580292e+06
+  tps: 2.84424975508e+06
+  hps: 1356.36132
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_HolyPrism-Seal of Truth-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 452525.92584
-  tps: 427620.73081
-  hps: 1114.98195
+  dps: 452567.49417
+  tps: 427833.98434
+  hps: 1114.79081
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_HolyPrism-Seal of Truth-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 604891.85072
-  tps: 545997.7838
+  dps: 606429.80926
+  tps: 547750.26575
   hps: 296.91444
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_HolyPrism-Seal of Truth-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.12766937724e+06
-  tps: 2.12676402347e+06
-  hps: 1148.37396
+  dps: 2.12713357463e+06
+  tps: 2.12634315313e+06
+  hps: 1127.81889
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_HolyPrism-Seal of Truth-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 325796.93966
-  tps: 311703.95462
-  hps: 988.96277
+  dps: 325515.36682
+  tps: 311669.73433
+  hps: 988.31885
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_HolyPrism-Seal of Truth-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 378266.09886
-  tps: 354132.95853
+  dps: 378764.92826
+  tps: 354611.30333
   hps: 515.73826
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_LightsHammer-Seal of Insight-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.86620339205e+06
-  tps: 2.85033387006e+06
-  hps: 22434.39655
+  dps: 2.86383799109e+06
+  tps: 2.84801085543e+06
+  hps: 22415.16239
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_LightsHammer-Seal of Insight-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 414036.06013
-  tps: 388604.96457
-  hps: 26792.57995
+  dps: 414118.15706
+  tps: 388732.50811
+  hps: 26626.60357
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_LightsHammer-Seal of Insight-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 554039.92272
-  tps: 495348.16448
-  hps: 33053.04872
+  dps: 555765.96045
+  tps: 496438.33577
+  hps: 32897.02692
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_LightsHammer-Seal of Insight-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.14562514711e+06
-  tps: 2.14430926462e+06
-  hps: 16828.44099
+  dps: 2.14273241221e+06
+  tps: 2.14156184164e+06
+  hps: 16777.70554
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_LightsHammer-Seal of Insight-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 294670.67983
-  tps: 280366.75524
-  hps: 20304.23855
+  dps: 294346.16547
+  tps: 280254.06337
+  hps: 20232.04941
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_LightsHammer-Seal of Insight-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 344165.72715
-  tps: 319800.10419
-  hps: 22483.09292
+  dps: 344431.76743
+  tps: 320106.37232
+  hps: 22258.1486
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_LightsHammer-Seal of Justice-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.88179979874e+06
-  tps: 2.86615378098e+06
-  hps: 4755.4262
+  dps: 2.87953370642e+06
+  tps: 2.86400125718e+06
+  hps: 4729.02457
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_LightsHammer-Seal of Justice-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 440874.02705
-  tps: 415907.7195
-  hps: 4997.8818
+  dps: 440677.40781
+  tps: 415825.90844
+  hps: 4949.52596
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_LightsHammer-Seal of Justice-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 590791.31186
-  tps: 531720.91764
-  hps: 6666.0103
+  dps: 592299.5348
+  tps: 532960.4494
+  hps: 6551.0901
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_LightsHammer-Seal of Justice-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.1573470931e+06
-  tps: 2.15624470275e+06
-  hps: 3645.90616
+  dps: 2.1556592607e+06
+  tps: 2.15465167699e+06
+  hps: 3627.59948
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_LightsHammer-Seal of Justice-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 311950.36473
-  tps: 298168.1646
-  hps: 3943.25519
+  dps: 311897.04966
+  tps: 298298.2511
+  hps: 3860.64029
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_LightsHammer-Seal of Justice-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 369869.12926
-  tps: 345707.31531
-  hps: 5159.83063
+  dps: 370341.38923
+  tps: 345930.48252
+  hps: 5012.96635
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_LightsHammer-Seal of Righteousness-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 3.09385702904e+06
-  tps: 3.07844250317e+06
-  hps: 4717.35828
+  dps: 3.09411904932e+06
+  tps: 3.07873870201e+06
+  hps: 4717.08683
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_LightsHammer-Seal of Righteousness-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 426846.3527
-  tps: 401951.63018
-  hps: 4987.16358
+  dps: 426857.96759
+  tps: 402013.21613
+  hps: 4938.69186
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_LightsHammer-Seal of Righteousness-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 575497.79843
-  tps: 516418.71554
-  hps: 6666.0103
+  dps: 576782.17615
+  tps: 517434.40208
+  hps: 6551.0901
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_LightsHammer-Seal of Righteousness-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.32276641088e+06
-  tps: 2.321789199e+06
-  hps: 3624.81945
+  dps: 2.32311388591e+06
+  tps: 2.32212983023e+06
+  hps: 3624.96718
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_LightsHammer-Seal of Righteousness-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 303609.92594
-  tps: 289891.23687
-  hps: 3930.65686
+  dps: 303643.23349
+  tps: 290102.1947
+  hps: 3852.25387
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_LightsHammer-Seal of Righteousness-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 362403.98426
-  tps: 338175.371
-  hps: 5136.89647
+  dps: 362796.6264
+  tps: 338385.71969
+  hps: 5005.54467
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_LightsHammer-Seal of Truth-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.8926599523e+06
-  tps: 2.8766379657e+06
-  hps: 4745.10265
+  dps: 2.8904459354e+06
+  tps: 2.87454567396e+06
+  hps: 4725.80736
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_LightsHammer-Seal of Truth-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 457252.597
-  tps: 432326.29321
-  hps: 4922.61809
+  dps: 457070.52914
+  tps: 432317.74504
+  hps: 4879.92477
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_LightsHammer-Seal of Truth-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 608402.48351
-  tps: 549402.86348
-  hps: 6620.85046
+  dps: 609163.42548
+  tps: 550577.39349
+  hps: 6533.58501
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_LightsHammer-Seal of Truth-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 2.16795313075e+06
-  tps: 2.16676463366e+06
-  hps: 3641.87171
+  dps: 2.166003457e+06
+  tps: 2.16492320446e+06
+  hps: 3625.07558
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_LightsHammer-Seal of Truth-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 322189.70606
-  tps: 308235.96052
-  hps: 3883.04139
+  dps: 321839.36289
+  tps: 308075.36329
+  hps: 3822.25533
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-p5-SanctifiedWrath_LightsHammer-Seal of Truth-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 379013.96232
-  tps: 354810.70063
-  hps: 5106.53979
+  dps: 379602.63059
+  tps: 355370.22224
+  hps: 4990.70047
  }
 }
 dps_results: {
  key: "TestRetribution-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 437138.68425
-  tps: 414145.79531
+  dps: 436895.8713
+  tps: 414045.75657
   hps: 15.24848
  }
 }

--- a/sim/rogue/assassination/TestAssassination.results
+++ b/sim/rogue/assassination/TestAssassination.results
@@ -730,8 +730,8 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-Fen-Yu,FuryofXuen-102248"
  value: {
-  dps: 129764.85033
-  tps: 91294.81942
+  dps: 130101.84331
+  tps: 91517.31146
  }
 }
 dps_results: {
@@ -814,8 +814,8 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-Gong-Lu,StrengthofXuen-102249"
  value: {
-  dps: 123560.08827
-  tps: 86921.41163
+  dps: 123751.59924
+  tps: 87041.66709
  }
 }
 dps_results: {

--- a/sim/rogue/combat/TestCombat.results
+++ b/sim/rogue/combat/TestCombat.results
@@ -698,8 +698,8 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-Fen-Yu,FuryofXuen-102248"
  value: {
-  dps: 112435.55875
-  tps: 79230.60023
+  dps: 118453.19801
+  tps: 83487.47915
  }
 }
 dps_results: {
@@ -782,8 +782,8 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-Gong-Lu,StrengthofXuen-102249"
  value: {
-  dps: 106884.558
-  tps: 75297.9726
+  dps: 112003.3914
+  tps: 78937.48029
  }
 }
 dps_results: {

--- a/sim/rogue/combat/TestCombat.results
+++ b/sim/rogue/combat/TestCombat.results
@@ -166,8 +166,8 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-CapacitivePrimalDiamond"
  value: {
-  dps: 104811.75037
-  tps: 73825.59997
+  dps: 103354.62845
+  tps: 72786.91912
  }
 }
 dps_results: {
@@ -698,8 +698,8 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-Fen-Yu,FuryofXuen-102248"
  value: {
-  dps: 118453.19801
-  tps: 83487.47915
+  dps: 112415.09728
+  tps: 79209.91445
  }
 }
 dps_results: {
@@ -782,8 +782,8 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-Gong-Lu,StrengthofXuen-102249"
  value: {
-  dps: 112003.3914
-  tps: 78937.48029
+  dps: 106984.63023
+  tps: 75361.30279
  }
 }
 dps_results: {

--- a/sim/rogue/combat/mastery.go
+++ b/sim/rogue/combat/mastery.go
@@ -10,7 +10,7 @@ func (comRogue *CombatRogue) applyMastery() {
 		ActionID:       core.ActionID{SpellID: 86392},
 		SpellSchool:    core.SpellSchoolPhysical,
 		ProcMask:       core.ProcMaskMeleeProc,
-		Flags:          core.SpellFlagMeleeMetrics | core.SpellFlagNoOnCastComplete | core.SpellFlagPassiveSpell | rogue.SpellFlagMainGauche,
+		Flags:          core.SpellFlagMeleeMetrics | core.SpellFlagNoOnCastComplete | core.SpellFlagPassiveSpell,
 		ClassSpellMask: rogue.RogueSpellMainGauche,
 
 		DamageMultiplier:         1.2,
@@ -30,8 +30,7 @@ func (comRogue *CombatRogue) applyMastery() {
 		Name:               "Mastery: Main Gauche",
 		Callback:           core.CallbackOnSpellHitDealt,
 		Outcome:            core.OutcomeLanded,
-		ProcMask:           core.ProcMaskMeleeMH | core.ProcMaskMeleeProc,
-		SpellFlagsExclude:  rogue.SpellFlagMainGauche,
+		ProcMask:           core.ProcMaskMeleeMH,
 		TriggerImmediately: true,
 
 		ExtraCondition: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) bool {

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -9,10 +9,9 @@ import (
 )
 
 const (
-	SpellFlagMainGauche = core.SpellFlagAgentReserved1
-	SpellFlagBuilder    = core.SpellFlagAgentReserved2
-	SpellFlagFinisher   = core.SpellFlagAgentReserved3
-	SpellFlagSealFate   = core.SpellFlagAgentReserved4
+	SpellFlagBuilder  = core.SpellFlagAgentReserved2
+	SpellFlagFinisher = core.SpellFlagAgentReserved3
+	SpellFlagSealFate = core.SpellFlagAgentReserved4
 )
 
 const RogueBleedTag = "RogueBleed"

--- a/sim/rogue/subtlety/TestSubtlety.results
+++ b/sim/rogue/subtlety/TestSubtlety.results
@@ -698,8 +698,8 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-Fen-Yu,FuryofXuen-102248"
  value: {
-  dps: 128487.65285
-  tps: 90539.98181
+  dps: 128595.48822
+  tps: 90610.3948
  }
 }
 dps_results: {
@@ -782,8 +782,8 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-Gong-Lu,StrengthofXuen-102249"
  value: {
-  dps: 120329.98289
-  tps: 84777.83669
+  dps: 120397.17421
+  tps: 84819.8275
  }
 }
 dps_results: {

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -705,8 +705,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-Fen-Yu,FuryofXuen-102248"
  value: {
-  dps: 242852.52848
-  tps: 206310.33546
+  dps: 247138.49112
+  tps: 210937.67457
  }
 }
 dps_results: {
@@ -782,8 +782,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-Gong-Lu,StrengthofXuen-102249"
  value: {
-  dps: 234326.61871
-  tps: 199038.05829
+  dps: 239756.23646
+  tps: 204453.23018
  }
 }
 dps_results: {

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -40,29 +40,29 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-AlacrityofXuen-103989"
  value: {
-  dps: 220713.60233
-  tps: 186801.24496
+  dps: 218401.98086
+  tps: 184717.35022
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ArcaneBadgeoftheShieldwall-93347"
  value: {
-  dps: 213661.60458
-  tps: 182828.69751
+  dps: 211854.30086
+  tps: 180711.29999
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ArrowflightMedallion-93258"
  value: {
-  dps: 220553.55406
-  tps: 187597.28049
+  dps: 220643.84284
+  tps: 187536.18882
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AssuranceofConsequence-105472"
  value: {
-  dps: 257132.56655
-  tps: 204750.67533
+  dps: 254172.9165
+  tps: 202338.69522
  }
 }
 dps_results: {
@@ -75,15 +75,15 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-BadJuju-96781"
  value: {
-  dps: 228552.75679
-  tps: 193067.88175
+  dps: 228209.61553
+  tps: 192530.03151
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BadgeofKypariZar-84079"
  value: {
-  dps: 213207.89743
-  tps: 181596.1745
+  dps: 211676.85151
+  tps: 180244.8602
  }
 }
 dps_results: {
@@ -103,57 +103,57 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-BlackBloodofY'Shaarj-105648"
  value: {
-  dps: 215720.53548
-  tps: 183858.1188
+  dps: 216528.16449
+  tps: 184537.03465
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlossomofPureSnow-89081"
  value: {
-  dps: 213071.93758
-  tps: 181623.71859
+  dps: 212098.02386
+  tps: 180616.748
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BottleofInfiniteStars-87057"
  value: {
-  dps: 223239.97763
-  tps: 189511.66392
+  dps: 222370.37321
+  tps: 188795.45186
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BraidofTenSongs-84072"
  value: {
-  dps: 212830.04966
-  tps: 181656.07883
+  dps: 211175.39395
+  tps: 180220.60329
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Brawler'sStatue-257885"
  value: {
-  dps: 209164.21924
-  tps: 178286.40823
+  dps: 208582.034
+  tps: 177718.50846
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BreathoftheHydra-96827"
  value: {
-  dps: 213438.74456
-  tps: 181925.8089
+  dps: 213607.8829
+  tps: 182526.90919
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BroochofMunificentDeeds-87500"
  value: {
-  dps: 209164.21924
-  tps: 178286.40823
+  dps: 208582.034
+  tps: 177718.50846
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BrutalTalismanoftheShado-PanAssault-94508"
  value: {
-  dps: 215172.71357
-  tps: 182910.19472
+  dps: 214506.75851
+  tps: 182267.82317
  }
 }
 dps_results: {
@@ -166,15 +166,15 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-CapacitivePrimalDiamond"
  value: {
-  dps: 231296.7881
-  tps: 195672.94344
+  dps: 231812.39337
+  tps: 195579.87414
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CarbonicCarbuncle-81138"
  value: {
-  dps: 214505.78764
-  tps: 182526.56155
+  dps: 214448.54025
+  tps: 182572.34401
  }
 }
 dps_results: {
@@ -194,57 +194,57 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-Cha-Ye'sEssenceofBrilliance-96888"
  value: {
-  dps: 214624.86602
-  tps: 182945.47842
+  dps: 213697.13127
+  tps: 182171.9804
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CharmofTenSongs-84071"
  value: {
-  dps: 212103.73606
-  tps: 180754.8079
+  dps: 214011.59085
+  tps: 182514.03059
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CommunalIdolofDestruction-101168"
  value: {
-  dps: 215353.61056
-  tps: 182730.03205
+  dps: 215805.35548
+  tps: 182957.57892
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CommunalStoneofDestruction-101171"
  value: {
-  dps: 214517.90613
-  tps: 182327.23583
+  dps: 213950.99048
+  tps: 181780.83058
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CommunalStoneofWisdom-101183"
  value: {
-  dps: 209470.97693
-  tps: 178573.39217
+  dps: 208842.28423
+  tps: 177962.67726
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ContemplationofChi-Ji-103988"
  value: {
-  dps: 209678.62583
-  tps: 178770.97021
+  dps: 208971.54801
+  tps: 178080.46722
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Coren'sColdChromiumCoaster-257880"
  value: {
-  dps: 218434.39289
-  tps: 185647.85466
+  dps: 218250.58582
+  tps: 185515.27552
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CoreofDecency-87497"
  value: {
-  dps: 209164.21924
-  tps: 178286.30462
+  dps: 208582.034
+  tps: 177718.40485
  }
 }
 dps_results: {
@@ -257,176 +257,176 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-CraftedDreadfulGladiator'sBadgeofConquest-93419"
  value: {
-  dps: 214436.099
-  tps: 182326.90644
+  dps: 214281.38874
+  tps: 182180.09741
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CraftedDreadfulGladiator'sBadgeofDominance-93600"
  value: {
-  dps: 209406.0934
-  tps: 178500.53555
+  dps: 208747.20667
+  tps: 177853.87179
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CraftedDreadfulGladiator'sBadgeofVictory-93606"
  value: {
-  dps: 211410.55736
-  tps: 180019.68139
+  dps: 210784.55038
+  tps: 179410.74106
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CraftedDreadfulGladiator'sEmblemofCruelty-93485"
  value: {
-  dps: 210623.48757
-  tps: 179527.58919
+  dps: 211207.23212
+  tps: 179995.81322
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CraftedDreadfulGladiator'sEmblemofMeditation-93487"
  value: {
-  dps: 209164.21924
-  tps: 178286.27854
+  dps: 208582.034
+  tps: 177718.37876
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CraftedDreadfulGladiator'sEmblemofTenacity-93486"
  value: {
-  dps: 209164.21924
-  tps: 178286.40823
+  dps: 208582.034
+  tps: 177718.50846
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CraftedDreadfulGladiator'sInsigniaofConquest-93424"
  value: {
-  dps: 217649.14198
-  tps: 184931.11722
+  dps: 216153.12401
+  tps: 183605.53329
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CraftedDreadfulGladiator'sInsigniaofDominance-93601"
  value: {
-  dps: 209577.96102
-  tps: 178656.09423
+  dps: 208897.72025
+  tps: 177981.52574
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CraftedDreadfulGladiator'sInsigniaofVictory-93611"
  value: {
-  dps: 212456.25188
-  tps: 180857.51265
+  dps: 211796.61857
+  tps: 180225.20453
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CraftedMalevolentGladiator'sBadgeofConquest-98755"
  value: {
-  dps: 215744.66737
-  tps: 183344.36322
+  dps: 215309.68995
+  tps: 182970.30256
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CraftedMalevolentGladiator'sBadgeofDominance-98910"
  value: {
-  dps: 209482.61801
-  tps: 178562.0354
+  dps: 208806.76258
+  tps: 177910.69769
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CraftedMalevolentGladiator'sBadgeofVictory-98912"
  value: {
-  dps: 211820.70025
-  tps: 180336.14739
+  dps: 211186.69217
+  tps: 179719.71377
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CraftedMalevolentGladiator'sEmblemofCruelty-98811"
  value: {
-  dps: 211069.35457
-  tps: 179808.73554
+  dps: 211287.50277
+  tps: 180030.41633
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CraftedMalevolentGladiator'sEmblemofMeditation-98813"
  value: {
-  dps: 209164.21924
-  tps: 178286.25571
+  dps: 208582.034
+  tps: 177718.35594
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CraftedMalevolentGladiator'sEmblemofTenacity-98812"
  value: {
-  dps: 209164.21924
-  tps: 178286.40823
+  dps: 208582.034
+  tps: 177718.50846
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CraftedMalevolentGladiator'sInsigniaofConquest-98760"
  value: {
-  dps: 218750.70542
-  tps: 185798.82885
+  dps: 217799.45184
+  tps: 185074.23901
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CraftedMalevolentGladiator'sInsigniaofDominance-98911"
  value: {
-  dps: 209602.26929
-  tps: 178674.62558
+  dps: 208942.66583
+  tps: 178023.81264
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CraftedMalevolentGladiator'sInsigniaofVictory-98917"
  value: {
-  dps: 213089.8007
-  tps: 181368.16491
+  dps: 212460.06264
+  tps: 180767.62529
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CurseofHubris-105645"
  value: {
-  dps: 219307.99213
-  tps: 186658.90497
+  dps: 220090.0862
+  tps: 187616.83701
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CutstitcherMedallion-93255"
  value: {
-  dps: 209497.1433
-  tps: 178598.30637
+  dps: 208871.41078
+  tps: 177988.80849
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Daelo'sFinalWords-87496"
  value: {
-  dps: 213802.20192
-  tps: 182276.1182
+  dps: 213126.00727
+  tps: 181676.49787
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkglowEmbroidery(Rank3)-4893"
  value: {
-  dps: 230123.88152
-  tps: 194607.14705
+  dps: 232191.08424
+  tps: 196004.51432
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmistVortex-87172"
  value: {
-  dps: 217277.31055
-  tps: 183973.67782
+  dps: 219024.83161
+  tps: 185382.41161
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DeadeyeBadgeoftheShieldwall-93346"
  value: {
-  dps: 217775.12789
-  tps: 185406.9
+  dps: 217689.26407
+  tps: 185181.02621
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DelicateVialoftheSanguinaire-96895"
  value: {
-  dps: 209164.21924
-  tps: 178286.40823
+  dps: 208582.034
+  tps: 177718.50846
  }
 }
 dps_results: {
@@ -439,120 +439,120 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-DisciplineofXuen-103986"
  value: {
-  dps: 228456.60887
-  tps: 193127.96006
+  dps: 228793.46988
+  tps: 193475.5865
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Dominator'sArcaneBadge-93342"
  value: {
-  dps: 213661.60458
-  tps: 182828.69751
+  dps: 211854.30086
+  tps: 180711.29999
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Dominator'sDeadeyeBadge-93341"
  value: {
-  dps: 217775.12789
-  tps: 185406.9
+  dps: 217689.26407
+  tps: 185181.02621
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Dominator'sDurableBadge-93345"
  value: {
-  dps: 212131.88578
-  tps: 180713.28735
+  dps: 211494.56434
+  tps: 180094.58698
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Dominator'sKnightlyBadge-93344"
  value: {
-  dps: 214367.21161
-  tps: 182528.86927
+  dps: 213725.00694
+  tps: 181905.61323
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Dominator'sMendingBadge-93343"
  value: {
-  dps: 209400.1867
-  tps: 178506.85863
+  dps: 208768.47418
+  tps: 177894.2262
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DreadfulGladiator'sBadgeofConquest-84344"
  value: {
-  dps: 214436.099
-  tps: 182326.90644
+  dps: 214281.38874
+  tps: 182180.09741
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DreadfulGladiator'sBadgeofDominance-84488"
  value: {
-  dps: 209406.0934
-  tps: 178500.53555
+  dps: 208747.20667
+  tps: 177853.87179
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DreadfulGladiator'sBadgeofVictory-84490"
  value: {
-  dps: 211410.55736
-  tps: 180019.68139
+  dps: 210784.55038
+  tps: 179410.74106
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DreadfulGladiator'sEmblemofCruelty-84399"
  value: {
-  dps: 210623.48757
-  tps: 179527.58919
+  dps: 211207.23212
+  tps: 179995.81322
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DreadfulGladiator'sEmblemofMeditation-84401"
  value: {
-  dps: 209164.21924
-  tps: 178286.27854
+  dps: 208582.034
+  tps: 177718.37876
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DreadfulGladiator'sEmblemofTenacity-84400"
  value: {
-  dps: 209164.21924
-  tps: 178286.40823
+  dps: 208582.034
+  tps: 177718.50846
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DreadfulGladiator'sInsigniaofConquest-84349"
  value: {
-  dps: 217425.82618
-  tps: 184690.88492
+  dps: 216062.78418
+  tps: 183598.82928
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DreadfulGladiator'sInsigniaofDominance-84489"
  value: {
-  dps: 209577.33763
-  tps: 178657.31004
+  dps: 208895.2126
+  tps: 177979.32631
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DreadfulGladiator'sInsigniaofVictory-84495"
  value: {
-  dps: 212469.98597
-  tps: 180876.11473
+  dps: 211810.70601
+  tps: 180236.30018
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DurableBadgeoftheShieldwall-93350"
  value: {
-  dps: 212131.88578
-  tps: 180713.28735
+  dps: 211494.56434
+  tps: 180094.58698
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DysmorphicSamophlangeofDiscontinuity-105615"
  value: {
-  dps: 209890.70746
-  tps: 178937.35736
+  dps: 209158.51319
+  tps: 178229.71264
  }
 }
 dps_results: {
@@ -572,71 +572,71 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-EmblemofKypariZar-84077"
  value: {
-  dps: 212986.71616
-  tps: 181805.66547
+  dps: 211838.10682
+  tps: 180294.95335
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmblemoftheCatacombs-83733"
  value: {
-  dps: 211219.07696
-  tps: 179819.85414
+  dps: 210753.18863
+  tps: 179890.18817
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmptyFruitBarrel-81133"
  value: {
-  dps: 209164.21924
-  tps: 178286.27264
+  dps: 208582.034
+  tps: 177718.37286
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnchantWeapon-BloodyDancingSteel-5125"
  value: {
-  dps: 231710.58202
-  tps: 196012.10294
+  dps: 229961.92113
+  tps: 194159.50165
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnchantWeapon-Colossus-4445"
  value: {
-  dps: 226640.98052
-  tps: 191967.00356
+  dps: 225185.35122
+  tps: 190306.80724
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnchantWeapon-ElementalForce-4443"
  value: {
-  dps: 228609.57956
-  tps: 193854.60437
+  dps: 226898.36626
+  tps: 191869.56847
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnchantWeapon-JadeSpirit-4442"
  value: {
-  dps: 226903.8443
-  tps: 192215.98316
+  dps: 225466.46842
+  tps: 190562.51123
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnchantWeapon-River'sSong-4446"
  value: {
-  dps: 226640.98052
-  tps: 191967.00356
+  dps: 225185.35122
+  tps: 190306.80724
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnchantWeapon-SpiritofConquest-5124"
  value: {
-  dps: 226848.76848
-  tps: 192172.07006
+  dps: 225283.36814
+  tps: 190397.53562
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnchantWeapon-Windsong-4441"
  value: {
-  dps: 227289.80602
-  tps: 192545.24174
+  dps: 226037.81948
+  tps: 191383.36314
  }
 }
 dps_results: {
@@ -649,8 +649,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-EssenceofTerror-87175"
  value: {
-  dps: 215806.49771
-  tps: 182547.80795
+  dps: 214961.49852
+  tps: 182383.13859
  }
 }
 dps_results: {
@@ -663,64 +663,64 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-EvilEyeofGalakras-105491"
  value: {
-  dps: 217255.62472
-  tps: 184668.2493
+  dps: 216543.07708
+  tps: 183984.16078
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FabledFeatherofJi-Kun-96842"
  value: {
-  dps: 220089.8241
-  tps: 187391.53263
+  dps: 216782.56703
+  tps: 184170.07814
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FearwurmBadge-84074"
  value: {
-  dps: 213978.67059
-  tps: 182555.58159
+  dps: 213015.31262
+  tps: 181662.65326
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FearwurmRelic-84070"
  value: {
-  dps: 212329.10622
-  tps: 180972.4603
+  dps: 212925.2216
+  tps: 181805.20572
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FelsoulIdolofDestruction-101263"
  value: {
-  dps: 214893.29976
-  tps: 182127.03928
+  dps: 216625.14309
+  tps: 183453.30095
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FelsoulStoneofDestruction-101266"
  value: {
-  dps: 214561.46766
-  tps: 182361.41055
+  dps: 214052.59687
+  tps: 181875.58699
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Fen-Yu,FuryofXuen-102248"
  value: {
-  dps: 247138.49112
-  tps: 210937.67457
+  dps: 239510.14221
+  tps: 203012.64109
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FlashfrozenResinGlobule-100951"
  value: {
-  dps: 210967.81251
-  tps: 180063.19484
+  dps: 210320.79953
+  tps: 179500.5648
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FlashingSteelTalisman-81265"
  value: {
-  dps: 219188.6853
-  tps: 186717.57965
+  dps: 217363.07775
+  tps: 184987.80104
  }
 }
 dps_results: {
@@ -740,36 +740,36 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-FortitudeoftheZandalari-96793"
  value: {
-  dps: 214086.73587
-  tps: 182344.59929
+  dps: 213490.62069
+  tps: 181764.0867
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FrenziedCrystalofRage-105572"
  value: {
-  dps: 210138.89143
-  tps: 179215.51937
+  dps: 209495.76628
+  tps: 178596.76602
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Fusion-FireCore-105459"
  value: {
-  dps: 218748.34315
-  tps: 185634.47142
+  dps: 218265.82398
+  tps: 185158.55759
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GazeoftheTwins-96915"
  value: {
-  dps: 220258.91049
-  tps: 187319.36812
+  dps: 218435.7689
+  tps: 185621.46761
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Gerp'sPerfectArrow-87495"
  value: {
-  dps: 217428.21099
-  tps: 184407.17612
+  dps: 217561.26089
+  tps: 184497.80423
  }
 }
 dps_results: {
@@ -782,141 +782,141 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-Gong-Lu,StrengthofXuen-102249"
  value: {
-  dps: 239756.23646
-  tps: 204453.23018
+  dps: 234734.85513
+  tps: 199919.76774
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GrievousGladiator'sBadgeofConquest-103145"
  value: {
-  dps: 219450.84953
-  tps: 186223.70646
+  dps: 218885.85096
+  tps: 185792.30134
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GrievousGladiator'sBadgeofDominance-103308"
  value: {
-  dps: 209565.94737
-  tps: 178618.10083
+  dps: 208906.09721
+  tps: 177984.44114
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GrievousGladiator'sBadgeofVictory-103314"
  value: {
-  dps: 213243.41811
-  tps: 181433.91565
+  dps: 212581.65553
+  tps: 180791.48899
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GrievousGladiator'sEmblemofCruelty-103210"
  value: {
-  dps: 212158.3933
-  tps: 180782.36272
+  dps: 212128.9728
+  tps: 180823.45407
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GrievousGladiator'sEmblemofMeditation-103212"
  value: {
-  dps: 209164.21924
-  tps: 178286.17637
+  dps: 208582.034
+  tps: 177718.2766
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GrievousGladiator'sEmblemofTenacity-103211"
  value: {
-  dps: 209164.21924
-  tps: 178286.40823
+  dps: 208582.034
+  tps: 177718.50846
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GrievousGladiator'sInsigniaofConquest-103150"
  value: {
-  dps: 224965.17816
-  tps: 190732.33859
+  dps: 222341.97501
+  tps: 188447.4633
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GrievousGladiator'sInsigniaofDominance-103309"
  value: {
-  dps: 209819.75791
-  tps: 178905.26756
+  dps: 209115.35714
+  tps: 178199.38774
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GrievousGladiator'sInsigniaofVictory-103319"
  value: {
-  dps: 215114.82561
-  tps: 182951.21494
+  dps: 214377.59631
+  tps: 182258.42885
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Haromm'sTalisman-105527"
  value: {
-  dps: 241092.00102
-  tps: 204776.27917
+  dps: 240986.84673
+  tps: 204302.43002
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Hawkmaster'sTalon-89082"
  value: {
-  dps: 219738.86989
-  tps: 187724.22259
+  dps: 218209.84699
+  tps: 185821.81242
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Heart-LesionDefenderIdol-100999"
  value: {
-  dps: 209162.02962
-  tps: 178286.40823
+  dps: 208582.034
+  tps: 177718.50846
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Heart-LesionDefenderStone-101002"
  value: {
-  dps: 214187.10483
-  tps: 182021.33389
+  dps: 213702.86059
+  tps: 181558.67623
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Heart-LesionIdolofBattle-100991"
  value: {
-  dps: 214831.60523
-  tps: 182754.95115
+  dps: 214787.70594
+  tps: 182760.30224
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Heart-LesionStoneofBattle-100990"
  value: {
-  dps: 217023.6742
-  tps: 184313.18336
+  dps: 216543.70223
+  tps: 183851.11985
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofFire-81181"
  value: {
-  dps: 211543.99754
-  tps: 180248.33051
+  dps: 210955.07791
+  tps: 179674.3331
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartwarmerMedallion-93260"
  value: {
-  dps: 209497.1433
-  tps: 178598.30637
+  dps: 208871.41078
+  tps: 177988.80849
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HelmbreakerMedallion-93261"
  value: {
-  dps: 216410.54785
-  tps: 184220.30769
+  dps: 215649.02864
+  tps: 183417.46916
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Horridon'sLastGasp-96757"
  value: {
-  dps: 209687.23718
-  tps: 178778.23345
+  dps: 208976.97477
+  tps: 178080.46441
  }
 }
 dps_results: {
@@ -936,373 +936,373 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-InscribedBagofHydra-Spawn-96828"
  value: {
-  dps: 209164.21924
-  tps: 178286.13212
+  dps: 208582.034
+  tps: 177718.23234
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InsigniaofKypariZar-84078"
  value: {
-  dps: 209164.21924
-  tps: 178286.40823
+  dps: 208582.034
+  tps: 177718.50846
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IronBellyWok-89083"
  value: {
-  dps: 214911.6474
-  tps: 183657.9606
+  dps: 213425.16618
+  tps: 182035.44046
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IronProtectorTalisman-85181"
  value: {
-  dps: 209162.02962
-  tps: 178286.40823
+  dps: 208582.034
+  tps: 177718.50846
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-JadeBanditFigurine-86772"
  value: {
-  dps: 217514.21866
-  tps: 185225.45739
+  dps: 218174.58569
+  tps: 185955.96447
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-JadeCharioteerFigurine-86771"
  value: {
-  dps: 213997.8744
-  tps: 182520.47064
+  dps: 214741.45179
+  tps: 183098.60233
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-JadeCourtesanFigurine-86774"
  value: {
-  dps: 209470.97693
-  tps: 178573.39471
+  dps: 208815.2204
+  tps: 177937.75958
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-JadeMagistrateFigurine-86773"
  value: {
-  dps: 213427.53814
-  tps: 182174.80134
+  dps: 211906.37253
+  tps: 180657.38732
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-JadeWarlordFigurine-86775"
  value: {
-  dps: 212672.96423
-  tps: 181155.76698
+  dps: 212025.5901
+  tps: 180527.80442
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Ji-Kun'sRisingWinds-96843"
  value: {
-  dps: 209164.21924
-  tps: 178286.40823
+  dps: 208582.034
+  tps: 177718.50846
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Juggernaut'sFocusingCrystal-105514"
  value: {
-  dps: 209411.06017
-  tps: 178487.5986
-  hps: 5931.76002
+  dps: 208587.11286
+  tps: 177723.58731
+  hps: 5904.05544
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Kardris'ToxicTotem-105540"
  value: {
-  dps: 220467.93557
-  tps: 189253.67187
+  dps: 219080.29514
+  tps: 187854.35626
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-KnightlyBadgeoftheShieldwall-93349"
  value: {
-  dps: 214367.21161
-  tps: 182528.86927
+  dps: 213725.00694
+  tps: 181905.61323
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-KnotofTenSongs-84073"
  value: {
-  dps: 209164.21924
-  tps: 178286.40823
+  dps: 208582.034
+  tps: 177718.50846
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Kor'kronBookofHurting-92785"
  value: {
-  dps: 209164.21924
-  tps: 178286.40823
+  dps: 208582.034
+  tps: 177718.50846
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Lao-Chin'sLiquidCourage-89079"
  value: {
-  dps: 213125.88326
-  tps: 181526.15218
+  dps: 212470.09436
+  tps: 180890.43653
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LeiShen'sFinalOrders-87072"
  value: {
-  dps: 214387.14106
-  tps: 182731.45834
+  dps: 214785.88192
+  tps: 182927.8571
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LessonsoftheDarkmaster-81268"
  value: {
-  dps: 212321.94292
-  tps: 180473.11072
+  dps: 211712.94915
+  tps: 179886.08847
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LightdrinkerIdolofRage-101200"
  value: {
-  dps: 221546.56058
-  tps: 188189.37098
+  dps: 220211.05965
+  tps: 187121.36454
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LightdrinkerStoneofRage-101203"
  value: {
-  dps: 221191.60617
-  tps: 187796.73427
+  dps: 220544.6855
+  tps: 187090.1634
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LightoftheCosmos-87065"
  value: {
-  dps: 210497.86655
-  tps: 179702.54217
+  dps: 211087.31731
+  tps: 180035.29548
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LightweaveEmbroidery(Rank3)-4892"
  value: {
-  dps: 230362.00097
-  tps: 194846.09264
+  dps: 232373.84014
+  tps: 196182.697
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LordBlastington'sScopeofDoom-4699"
  value: {
-  dps: 226640.98052
-  tps: 191967.00356
+  dps: 225185.35122
+  tps: 190306.80724
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MalevolentGladiator'sBadgeofConquest-91452"
  value: {
-  dps: 215744.66737
-  tps: 183344.36322
+  dps: 215309.68995
+  tps: 182970.30256
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MalevolentGladiator'sBadgeofDominance-91753"
  value: {
-  dps: 209482.61801
-  tps: 178562.0354
+  dps: 208806.76258
+  tps: 177910.69769
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MalevolentGladiator'sBadgeofVictory-91763"
  value: {
-  dps: 211820.70025
-  tps: 180336.14739
+  dps: 211186.69217
+  tps: 179719.71377
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MalevolentGladiator'sEmblemofCruelty-91562"
  value: {
-  dps: 211069.35457
-  tps: 179808.73554
+  dps: 211287.50277
+  tps: 180030.41633
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MalevolentGladiator'sEmblemofMeditation-91564"
  value: {
-  dps: 209164.21924
-  tps: 178286.25571
+  dps: 208582.034
+  tps: 177718.35594
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MalevolentGladiator'sEmblemofTenacity-91563"
  value: {
-  dps: 209164.21924
-  tps: 178286.40823
+  dps: 208582.034
+  tps: 177718.50846
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MalevolentGladiator'sInsigniaofConquest-91457"
  value: {
-  dps: 218913.30358
-  tps: 185975.79117
+  dps: 218010.94121
+  tps: 185218.84193
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MalevolentGladiator'sInsigniaofDominance-91754"
  value: {
-  dps: 209573.17952
-  tps: 178647.71305
+  dps: 208926.50864
+  tps: 178012.34996
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MalevolentGladiator'sInsigniaofVictory-91768"
  value: {
-  dps: 213128.55041
-  tps: 181396.77235
+  dps: 212440.45786
+  tps: 180732.34806
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MarkoftheCatacombs-83731"
  value: {
-  dps: 213022.34472
-  tps: 181639.77979
+  dps: 213166.03373
+  tps: 181502.40849
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MarkoftheHardenedGrunt-92783"
  value: {
-  dps: 209164.21924
-  tps: 178286.40823
+  dps: 208582.034
+  tps: 177718.50846
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MedallionofMystifyingVapors-93257"
  value: {
-  dps: 213393.6675
-  tps: 181745.13904
+  dps: 212732.90345
+  tps: 181104.83946
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MedallionoftheCatacombs-83734"
  value: {
-  dps: 210895.57778
-  tps: 179715.57711
+  dps: 210310.68582
+  tps: 179143.2355
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MendingBadgeoftheShieldwall-93348"
  value: {
-  dps: 209400.1867
-  tps: 178506.85863
+  dps: 208768.47418
+  tps: 177894.2262
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MirrorScope-4700"
  value: {
-  dps: 226640.98052
-  tps: 191967.00356
+  dps: 225185.35122
+  tps: 190306.80724
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MistdancerDefenderIdol-101089"
  value: {
-  dps: 209164.21924
-  tps: 178286.40823
+  dps: 208582.034
+  tps: 177718.50846
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MistdancerDefenderStone-101087"
  value: {
-  dps: 214212.89242
-  tps: 182039.58477
+  dps: 213657.64089
+  tps: 181505.04048
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MistdancerIdolofRage-101113"
  value: {
-  dps: 220730.79088
-  tps: 187329.65973
+  dps: 220445.85721
+  tps: 187157.44012
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MistdancerStoneofRage-101117"
  value: {
-  dps: 221126.74243
-  tps: 187733.56809
+  dps: 220467.24152
+  tps: 187017.93651
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MistdancerStoneofWisdom-101107"
  value: {
-  dps: 209470.97693
-  tps: 178573.39217
+  dps: 208842.28423
+  tps: 177962.67726
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MithrilWristwatch-257884"
  value: {
-  dps: 211714.5457
-  tps: 180359.58658
+  dps: 211484.72485
+  tps: 180213.70756
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MountainsageIdolofDestruction-101069"
  value: {
-  dps: 216431.34189
-  tps: 183861.40814
+  dps: 213948.04515
+  tps: 181301.99875
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MountainsageStoneofDestruction-101072"
  value: {
-  dps: 214541.65153
-  tps: 182343.15025
+  dps: 213986.92651
+  tps: 181817.194
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-NitroBoosts-4223"
  value: {
-  dps: 231296.7881
-  tps: 195672.94344
+  dps: 231812.39337
+  tps: 195579.87414
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-OathswornDefenderIdol-101303"
  value: {
-  dps: 209162.02962
-  tps: 178286.40823
+  dps: 208582.034
+  tps: 177718.50846
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-OathswornDefenderStone-101306"
  value: {
-  dps: 214143.35436
-  tps: 181983.05808
+  dps: 213619.42246
+  tps: 181485.32078
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-OathswornIdolofBattle-101295"
  value: {
-  dps: 214889.92293
-  tps: 182807.837
+  dps: 214775.91598
+  tps: 182750.49263
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-OathswornStoneofBattle-101294"
  value: {
-  dps: 216942.41618
-  tps: 184270.96132
+  dps: 216426.10887
+  tps: 183772.46507
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PhaseFingers-4697"
  value: {
-  dps: 230776.56686
-  tps: 195246.74106
+  dps: 231293.02321
+  tps: 195155.98174
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PouchofWhiteAsh-103639"
  value: {
-  dps: 209164.21924
-  tps: 178286.40823
+  dps: 208582.034
+  tps: 177718.50846
  }
 }
 dps_results: {
@@ -1315,113 +1315,113 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-PriceofProgress-81266"
  value: {
-  dps: 209419.43904
-  tps: 178524.67698
+  dps: 208790.7918
+  tps: 177914.89929
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PridefulGladiator'sBadgeofConquest-103342"
  value: {
-  dps: 222604.01038
-  tps: 188872.01778
+  dps: 221541.02252
+  tps: 187830.82285
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PridefulGladiator'sBadgeofDominance-103505"
  value: {
-  dps: 209705.3875
-  tps: 178762.23346
+  dps: 209026.66571
+  tps: 178107.14404
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PridefulGladiator'sBadgeofVictory-103511"
  value: {
-  dps: 214460.50878
-  tps: 182373.02208
+  dps: 213775.0031
+  tps: 181708.35921
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PridefulGladiator'sEmblemofCruelty-103407"
  value: {
-  dps: 214818.40139
-  tps: 183154.34804
+  dps: 213289.46324
+  tps: 181775.50337
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PridefulGladiator'sEmblemofMeditation-103409"
  value: {
-  dps: 209164.21924
-  tps: 178286.10836
+  dps: 208582.034
+  tps: 177718.20859
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PridefulGladiator'sEmblemofTenacity-103408"
  value: {
-  dps: 209164.21924
-  tps: 178286.40823
+  dps: 208582.034
+  tps: 177718.50846
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PridefulGladiator'sInsigniaofConquest-103347"
  value: {
-  dps: 228847.71673
-  tps: 193634.74322
+  dps: 227510.27874
+  tps: 192721.69339
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PridefulGladiator'sInsigniaofDominance-103506"
  value: {
-  dps: 209915.39444
-  tps: 179024.12036
+  dps: 209264.17409
+  tps: 178343.25997
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PridefulGladiator'sInsigniaofVictory-103516"
  value: {
-  dps: 216922.44405
-  tps: 184366.52234
+  dps: 216224.87999
+  tps: 183707.78215
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Primordius'TalismanofRage-96873"
  value: {
-  dps: 218901.04703
-  tps: 186400.85476
+  dps: 217829.87311
+  tps: 185515.57922
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PrismaticPrisonofPride-105474"
  value: {
-  dps: 218083.05221
-  tps: 186146.12176
+  dps: 217128.86142
+  tps: 185511.03032
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PurifiedBindingsofImmerseus-105422"
  value: {
-  dps: 219130.91037
-  tps: 187041.85371
+  dps: 218083.2117
+  tps: 186310.51229
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Qian-Le,CourageofNiuzao-102245"
  value: {
-  dps: 227003.81291
-  tps: 192641.70867
+  dps: 225636.22521
+  tps: 190780.41574
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Qian-Ying,FortitudeofNiuzao-102250"
  value: {
-  dps: 215283.60095
-  tps: 182900.58675
+  dps: 217436.70187
+  tps: 184437.5608
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Qin-xi'sPolarizingSeal-87075"
  value: {
-  dps: 209164.21924
-  tps: 178286.21503
+  dps: 208582.034
+  tps: 177718.31526
  }
 }
 dps_results: {
@@ -1441,57 +1441,57 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-RelicofChi-Ji-79330"
  value: {
-  dps: 209502.39737
-  tps: 178603.56025
+  dps: 208871.41078
+  tps: 177988.80831
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RelicofKypariZar-84075"
  value: {
-  dps: 213968.17084
-  tps: 183000.80278
+  dps: 212676.64888
+  tps: 181717.5034
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RelicofNiuzao-79329"
  value: {
-  dps: 209164.21924
-  tps: 178286.40823
+  dps: 208582.034
+  tps: 177718.50846
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RelicofXuen-79327"
  value: {
-  dps: 214393.78599
-  tps: 182456.45924
+  dps: 213772.65364
+  tps: 181860.21067
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RelicofXuen-79328"
  value: {
-  dps: 222727.56379
-  tps: 189191.48564
+  dps: 220928.17927
+  tps: 187746.40774
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RelicofYu'lon-79331"
  value: {
-  dps: 209717.69973
-  tps: 178798.37961
+  dps: 209099.91506
+  tps: 178180.92344
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Renataki'sSoulCharm-96741"
  value: {
-  dps: 224814.57315
-  tps: 190392.65957
+  dps: 222822.45061
+  tps: 188537.81688
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ResolveofNiuzao-103990"
  value: {
-  dps: 213819.81858
-  tps: 182124.54898
+  dps: 213224.45874
+  tps: 181544.7203
  }
 }
 dps_results: {
@@ -1511,92 +1511,92 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-RuneofRe-Origination-96918"
  value: {
-  dps: 228125.51794
-  tps: 194587.80871
+  dps: 226771.54306
+  tps: 193288.67243
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SI:7Operative'sManual-92784"
  value: {
-  dps: 209164.21924
-  tps: 178286.40823
+  dps: 208582.034
+  tps: 177718.50846
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ScrollofReveredAncestors-89080"
  value: {
-  dps: 209488.44664
-  tps: 178589.61242
+  dps: 208847.68847
+  tps: 177965.0889
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SearingWords-81267"
  value: {
-  dps: 220826.89257
-  tps: 187649.48892
+  dps: 219229.21565
+  tps: 186063.9619
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Shock-ChargerMedallion-93259"
  value: {
-  dps: 211116.50918
-  tps: 180215.31813
+  dps: 211231.92306
+  tps: 180687.81531
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SigilofCompassion-83736"
  value: {
-  dps: 210895.57778
-  tps: 179715.57711
+  dps: 210310.68582
+  tps: 179143.2355
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SigilofDevotion-83740"
  value: {
-  dps: 213070.06439
-  tps: 181671.34916
+  dps: 213181.61761
+  tps: 181497.91274
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SigilofFidelity-83737"
  value: {
-  dps: 212078.47027
-  tps: 181006.54862
+  dps: 211538.96799
+  tps: 180521.12618
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SigilofGrace-83738"
  value: {
-  dps: 212581.39698
-  tps: 181046.30786
+  dps: 211089.72413
+  tps: 179753.81474
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SigilofKypariZar-84076"
  value: {
-  dps: 213145.37898
-  tps: 181654.72781
+  dps: 213266.51594
+  tps: 181550.63924
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SigilofPatience-83739"
  value: {
-  dps: 211479.87646
-  tps: 180120.92085
+  dps: 210906.56855
+  tps: 179563.14079
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SigilofRampage-105580"
  value: {
-  dps: 233896.73013
-  tps: 197347.34082
+  dps: 233230.11885
+  tps: 196939.33027
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SigiloftheCatacombs-83732"
  value: {
-  dps: 212352.1747
-  tps: 180823.51999
+  dps: 212398.52245
+  tps: 180716.77045
  }
 }
 dps_results: {
@@ -1609,330 +1609,330 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-Skeer'sBloodsoakedTalisman-105632"
  value: {
-  dps: 226164.48026
-  tps: 191480.4904
+  dps: 224417.19646
+  tps: 189779.19257
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkullrenderMedallion-93256"
  value: {
-  dps: 216410.54785
-  tps: 184220.30769
+  dps: 215649.02864
+  tps: 183417.46916
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SoothingTalismanoftheShado-PanAssault-94509"
  value: {
-  dps: 209618.50251
-  tps: 178713.55609
+  dps: 208934.30932
+  tps: 178047.54555
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SoulBarrier-96927"
  value: {
-  dps: 209164.21924
-  tps: 178286.40823
+  dps: 208582.034
+  tps: 177718.50846
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SparkofZandalar-96770"
  value: {
-  dps: 217499.74644
-  tps: 185409.33028
+  dps: 217131.79378
+  tps: 185496.44706
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SpiritsoftheSun-87163"
  value: {
-  dps: 209568.33791
-  tps: 178666.29835
+  dps: 208900.82618
+  tps: 178018.21861
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SpringrainIdolofDestruction-101023"
  value: {
-  dps: 215504.8943
-  tps: 183030.69322
+  dps: 215227.18704
+  tps: 182656.39651
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SpringrainIdolofRage-101009"
  value: {
-  dps: 221042.88241
-  tps: 187700.12975
+  dps: 219615.91166
+  tps: 186448.37809
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SpringrainStoneofDestruction-101026"
  value: {
-  dps: 214533.60292
-  tps: 182333.22607
+  dps: 214035.42109
+  tps: 181863.65637
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SpringrainStoneofRage-101012"
  value: {
-  dps: 221162.46426
-  tps: 187765.13218
+  dps: 220559.28964
+  tps: 187104.83029
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SpringrainStoneofWisdom-101041"
  value: {
-  dps: 209470.97693
-  tps: 178573.39217
+  dps: 208842.28423
+  tps: 177962.67726
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Static-Caster'sMedallion-93254"
  value: {
-  dps: 211116.50918
-  tps: 180215.31813
+  dps: 211231.92306
+  tps: 180687.81531
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SteadfastFootman'sMedallion-92782"
  value: {
-  dps: 209164.21924
-  tps: 178286.40823
+  dps: 208582.034
+  tps: 177718.50846
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SteadfastTalismanoftheShado-PanAssault-94507"
  value: {
-  dps: 213285.98402
-  tps: 181684.44835
+  dps: 212692.13484
+  tps: 181105.9875
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StreamtalkerIdolofDestruction-101222"
  value: {
-  dps: 217231.03188
-  tps: 184662.7733
+  dps: 215691.06976
+  tps: 183031.02834
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StreamtalkerIdolofRage-101217"
  value: {
-  dps: 221320.6618
-  tps: 187923.54831
+  dps: 220160.26408
+  tps: 186920.92649
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StreamtalkerStoneofDestruction-101225"
  value: {
-  dps: 214469.69892
-  tps: 182274.21671
+  dps: 213882.6931
+  tps: 181708.29602
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StreamtalkerStoneofRage-101220"
  value: {
-  dps: 221159.91599
-  tps: 187758.79962
+  dps: 220500.10576
+  tps: 187041.14166
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StreamtalkerStoneofWisdom-101250"
  value: {
-  dps: 209470.97693
-  tps: 178573.39217
+  dps: 208842.28423
+  tps: 177962.67726
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StuffofNightmares-87160"
  value: {
-  dps: 212816.77153
-  tps: 181297.62306
+  dps: 212224.25015
+  tps: 180720.36446
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SunsoulDefenderIdol-101160"
  value: {
-  dps: 209162.02962
-  tps: 178286.40823
+  dps: 208582.034
+  tps: 177718.50846
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SunsoulDefenderStone-101163"
  value: {
-  dps: 214219.49347
-  tps: 182034.56848
+  dps: 213809.48456
+  tps: 181641.37621
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SunsoulIdolofBattle-101152"
  value: {
-  dps: 214918.66852
-  tps: 182833.20975
+  dps: 214812.62492
+  tps: 182781.27322
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SunsoulStoneofBattle-101151"
  value: {
-  dps: 217066.71915
-  tps: 184364.27089
+  dps: 216484.23572
+  tps: 183795.46906
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SunsoulStoneofWisdom-101138"
  value: {
-  dps: 209470.97693
-  tps: 178573.39217
+  dps: 208842.28423
+  tps: 177962.67726
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwordguardEmbroidery(Rank3)-4894"
  value: {
-  dps: 233401.80405
-  tps: 197130.14819
+  dps: 235506.09171
+  tps: 198568.50732
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SymboloftheCatacombs-83735"
  value: {
-  dps: 212618.65485
-  tps: 180992.02616
+  dps: 211873.08359
+  tps: 180349.23795
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SynapseSprings(MarkII)-4898"
  value: {
-  dps: 233767.54723
-  tps: 197606.99818
+  dps: 234339.13539
+  tps: 197547.81028
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TalismanofBloodlust-96864"
  value: {
-  dps: 226078.68493
-  tps: 192284.8794
+  dps: 226057.47619
+  tps: 192286.07625
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TerrorintheMists-87167"
  value: {
-  dps: 225612.17929
-  tps: 190968.78279
+  dps: 224483.44408
+  tps: 190201.36574
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheGloamingBlade-88149"
  value: {
-  dps: 231296.7881
-  tps: 195672.94344
+  dps: 231812.39337
+  tps: 195579.87414
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Thok'sAcid-GroovedTooth-105607"
  value: {
-  dps: 209164.21924
-  tps: 178286.40823
+  dps: 208582.034
+  tps: 177718.50846
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Thok'sTailTip-105609"
  value: {
-  dps: 228602.4482
-  tps: 193431.67238
+  dps: 227535.02351
+  tps: 192712.87538
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Thousand-YearPickledEgg-257881"
  value: {
-  dps: 209488.44664
-  tps: 178589.61242
+  dps: 208847.68847
+  tps: 177965.0889
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TickingEbonDetonator-105612"
  value: {
-  dps: 239066.05377
-  tps: 200154.66816
+  dps: 240140.86083
+  tps: 202098.48578
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Time-LostArtifact-103678"
  value: {
-  dps: 217003.7543
-  tps: 185107.4511
+  dps: 216454.87257
+  tps: 184441.27652
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TrailseekerIdolofRage-101054"
  value: {
-  dps: 221182.05394
-  tps: 187908.80828
+  dps: 220326.35388
+  tps: 187156.27295
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TrailseekerStoneofRage-101057"
  value: {
-  dps: 221218.07373
-  tps: 187819.15629
+  dps: 220532.42195
+  tps: 187082.36674
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TyrannicalGladiator'sBadgeofConquest-100043"
  value: {
-  dps: 217449.67082
-  tps: 184727.924
+  dps: 216943.58176
+  tps: 184301.50756
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TyrannicalGladiator'sBadgeofDominance-100016"
  value: {
-  dps: 209523.36386
-  tps: 178586.59373
+  dps: 208863.95399
+  tps: 177945.0773
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TyrannicalGladiator'sBadgeofVictory-100019"
  value: {
-  dps: 212366.44593
-  tps: 180757.24444
+  dps: 211721.7914
+  tps: 180130.84004
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TyrannicalGladiator'sEmblemofCruelty-100066"
  value: {
-  dps: 211741.27547
-  tps: 180379.34504
+  dps: 211338.97542
+  tps: 180055.89967
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TyrannicalGladiator'sEmblemofMeditation-99990"
  value: {
-  dps: 209164.21924
-  tps: 178286.22528
+  dps: 208582.034
+  tps: 177718.32551
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TyrannicalGladiator'sEmblemofTenacity-100092"
  value: {
-  dps: 209164.21924
-  tps: 178286.40823
+  dps: 208582.034
+  tps: 177718.50846
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TyrannicalGladiator'sInsigniaofConquest-100026"
  value: {
-  dps: 221627.51519
-  tps: 188183.93648
+  dps: 219705.8739
+  tps: 186561.97085
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TyrannicalGladiator'sInsigniaofDominance-100152"
  value: {
-  dps: 209689.83195
-  tps: 178793.29335
+  dps: 209007.51628
+  tps: 178089.17544
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TyrannicalGladiator'sInsigniaofVictory-100085"
  value: {
-  dps: 213844.49961
-  tps: 181941.62135
+  dps: 213203.25144
+  tps: 181326.99001
  }
 }
 dps_results: {
@@ -1945,749 +1945,749 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-UnerringVisionofLeiShen-96930"
  value: {
-  dps: 209687.23718
-  tps: 178778.23345
+  dps: 208976.97477
+  tps: 178080.46441
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-VaporshieldMedallion-93262"
  value: {
-  dps: 213393.6675
-  tps: 181745.13904
+  dps: 212732.90345
+  tps: 181104.83946
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-VialofDragon'sBlood-87063"
  value: {
-  dps: 212586.37977
-  tps: 181107.68489
+  dps: 211994.51037
+  tps: 180531.01662
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-VialofIchorousBlood-100963"
  value: {
-  dps: 209392.66755
-  tps: 178499.34196
+  dps: 208750.61775
+  tps: 177877.90752
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-VialofLivingCorruption-105568"
  value: {
-  dps: 209164.21924
-  tps: 178286.40823
+  dps: 208582.034
+  tps: 177718.50846
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousTalismanoftheShado-PanAssault-94511"
  value: {
-  dps: 229691.38131
-  tps: 193624.85756
+  dps: 226673.8065
+  tps: 190761.51125
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-VisionofthePredator-81192"
  value: {
-  dps: 211880.86477
-  tps: 180328.2198
+  dps: 212551.96239
+  tps: 181111.17659
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-VolatileTalismanoftheShado-PanAssault-94510"
  value: {
-  dps: 214468.85738
-  tps: 182276.03165
+  dps: 213320.18256
+  tps: 181797.81003
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WindsweptPages-81125"
  value: {
-  dps: 217481.34105
-  tps: 184837.49277
+  dps: 217403.36998
+  tps: 184784.40851
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WoundripperMedallion-93253"
  value: {
-  dps: 220553.55406
-  tps: 187597.28049
+  dps: 220643.84284
+  tps: 187536.18882
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Wushoolay'sFinalChoice-96785"
  value: {
-  dps: 214161.9678
-  tps: 182803.14475
+  dps: 210944.62573
+  tps: 179776.14872
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Xing-Ho,BreathofYu'lon-102246"
  value: {
-  dps: 227453.51276
-  tps: 193304.73095
+  dps: 226789.40944
+  tps: 193070.55049
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-YaungolFireCarrier-86518"
  value: {
-  dps: 231296.7881
-  tps: 195672.94344
+  dps: 231812.39337
+  tps: 195579.87414
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Yu'lon'sBite-103987"
  value: {
-  dps: 218055.50865
-  tps: 184693.91538
+  dps: 216320.19232
+  tps: 183310.09609
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ZenAlchemistStone-75274"
  value: {
-  dps: 221819.08312
-  tps: 188494.18101
+  dps: 219487.58614
+  tps: 186462.43866
  }
 }
 dps_results: {
  key: "TestEnhancement-Average-Default"
  value: {
-  dps: 236957.55686
-  tps: 199735.04074
+  dps: 236180.31726
+  tps: 199032.70071
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-AlliancePandaren-simtest-DefaultTalents-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 331122.86874
-  tps: 290698.98294
+  dps: 335501.38446
+  tps: 295804.68527
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-AlliancePandaren-simtest-DefaultTalents-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 231197.86698
-  tps: 196230.62327
+  dps: 231713.96715
+  tps: 196119.63612
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-AlliancePandaren-simtest-DefaultTalents-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 379448.33552
-  tps: 260389.97675
+  dps: 383851.69284
+  tps: 262729.85043
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-AlliancePandaren-simtest-DefaultTalents-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 261375.96514
-  tps: 234246.26046
+  dps: 260561.2836
+  tps: 232766.46041
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-AlliancePandaren-simtest-DefaultTalents-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 182635.11293
-  tps: 156835.80659
+  dps: 182552.53376
+  tps: 156719.61693
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-AlliancePandaren-simtest-DefaultTalents-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 295293.6859
-  tps: 209750.3318
+  dps: 292061.25249
+  tps: 206782.30653
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-AlliancePandaren-simtest-TalentsEMPrimal-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 354978.03712
-  tps: 287584.2951
+  dps: 358615.57004
+  tps: 289382.46727
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-AlliancePandaren-simtest-TalentsEMPrimal-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 232170.22933
-  tps: 178213.87109
+  dps: 232894.68725
+  tps: 178233.93562
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-AlliancePandaren-simtest-TalentsEMPrimal-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 448592.95621
-  tps: 241674.39943
+  dps: 456078.14685
+  tps: 245514.65958
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-AlliancePandaren-simtest-TalentsEMPrimal-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 273272.61983
-  tps: 226065.51165
+  dps: 273272.49934
+  tps: 226499.15843
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-AlliancePandaren-simtest-TalentsEMPrimal-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 182345.07785
-  tps: 143451.23536
+  dps: 181097.67574
+  tps: 143102.97874
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-AlliancePandaren-simtest-TalentsEMPrimal-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 341633.70573
-  tps: 195135.99739
+  dps: 336217.92832
+  tps: 194054.50998
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-AlliancePandaren-simtest-TalentsEchoUnleashed-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 339514.12926
-  tps: 291277.21735
+  dps: 340514.64522
+  tps: 292901.91922
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-AlliancePandaren-simtest-TalentsEchoUnleashed-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 229952.265
-  tps: 188887.30692
+  dps: 232094.56583
+  tps: 190632.27398
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-AlliancePandaren-simtest-TalentsEchoUnleashed-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 369281.12889
-  tps: 249868.46122
+  dps: 371797.92595
+  tps: 252085.54278
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-AlliancePandaren-simtest-TalentsEchoUnleashed-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 261904.02722
-  tps: 229537.01528
+  dps: 260780.03631
+  tps: 228786.07274
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-AlliancePandaren-simtest-TalentsEchoUnleashed-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 185104.55485
-  tps: 153921.42109
+  dps: 183799.98791
+  tps: 152763.23749
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-AlliancePandaren-simtest-TalentsEchoUnleashed-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 286578.28323
-  tps: 198654.06419
+  dps: 281853.31346
+  tps: 195487.27576
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-simtest-DefaultTalents-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 332539.83073
-  tps: 291873.87589
+  dps: 332969.46134
+  tps: 292703.6416
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-simtest-DefaultTalents-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 232075.04872
-  tps: 196865.54883
+  dps: 232509.22862
+  tps: 197009.01606
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-simtest-DefaultTalents-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 381335.89332
-  tps: 261697.91315
+  dps: 383623.61441
+  tps: 262916.6677
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-simtest-DefaultTalents-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 262443.26788
-  tps: 235764.80407
+  dps: 259315.27035
+  tps: 231850.78847
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-simtest-DefaultTalents-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 183324.35913
-  tps: 157595.57875
+  dps: 183198.1067
+  tps: 157347.88219
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-simtest-DefaultTalents-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 293844.64949
-  tps: 208653.63915
+  dps: 291912.07923
+  tps: 206933.9699
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-simtest-TalentsEMPrimal-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 355403.30612
-  tps: 287366.0052
+  dps: 356262.43184
+  tps: 286045.51256
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-simtest-TalentsEMPrimal-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 233749.32249
-  tps: 179534.87851
+  dps: 234544.00581
+  tps: 180401.67932
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-simtest-TalentsEMPrimal-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 451477.15714
-  tps: 243437.07645
+  dps: 455809.00453
+  tps: 246402.46934
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-simtest-TalentsEMPrimal-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 272881.72492
-  tps: 225616.1196
+  dps: 274450.68005
+  tps: 227821.48253
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-simtest-TalentsEMPrimal-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 183326.11766
-  tps: 144366.82012
+  dps: 183028.03945
+  tps: 144503.09805
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-simtest-TalentsEMPrimal-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 342580.23277
-  tps: 195397.61798
+  dps: 340887.65484
+  tps: 196404.25221
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-simtest-TalentsEchoUnleashed-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 341207.14466
-  tps: 292789.82201
+  dps: 338767.1146
+  tps: 290778.98647
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-simtest-TalentsEchoUnleashed-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 232164.70899
-  tps: 190792.89103
+  dps: 231110.15454
+  tps: 189909.97454
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-simtest-TalentsEchoUnleashed-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 370226.27775
-  tps: 250430.43483
+  dps: 374090.23315
+  tps: 253039.93931
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-simtest-TalentsEchoUnleashed-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 261243.01047
-  tps: 228569.2344
+  dps: 260671.81269
+  tps: 228654.17832
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-simtest-TalentsEchoUnleashed-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 184335.76864
-  tps: 153019.86647
+  dps: 183102.86533
+  tps: 152157.56838
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-simtest-TalentsEchoUnleashed-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 285831.72554
-  tps: 197235.57536
+  dps: 284257.87054
+  tps: 196966.36711
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Dwarf-simtest-DefaultTalents-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 331119.64747
-  tps: 290696.99584
+  dps: 335504.92661
+  tps: 295807.62068
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Dwarf-simtest-DefaultTalents-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 231200.1231
-  tps: 196232.46101
+  dps: 231716.2188
+  tps: 196121.46699
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Dwarf-simtest-DefaultTalents-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 379451.91643
-  tps: 260392.21551
+  dps: 383855.27194
+  tps: 262732.07974
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Dwarf-simtest-DefaultTalents-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 261378.66583
-  tps: 234248.51478
+  dps: 260563.95787
+  tps: 232768.67848
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Dwarf-simtest-DefaultTalents-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 182636.82564
-  tps: 156837.21811
+  dps: 182554.24398
+  tps: 156721.02488
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Dwarf-simtest-DefaultTalents-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 295296.3302
-  tps: 209752.04996
+  dps: 292063.86638
+  tps: 206783.99543
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Dwarf-simtest-TalentsEMPrimal-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 354969.28338
-  tps: 287577.29543
+  dps: 358806.66443
+  tps: 289552.18255
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Dwarf-simtest-TalentsEMPrimal-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 232162.85491
-  tps: 178206.26558
+  dps: 232887.71454
+  tps: 178226.31755
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Dwarf-simtest-TalentsEMPrimal-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 448551.10099
-  tps: 241630.17418
+  dps: 456036.32369
+  tps: 245470.44636
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Dwarf-simtest-TalentsEMPrimal-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 273275.5086
-  tps: 226067.69195
+  dps: 273275.3758
+  tps: 226501.32985
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Dwarf-simtest-TalentsEMPrimal-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 182346.79307
-  tps: 143452.49446
+  dps: 181094.64215
+  tps: 143099.87556
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Dwarf-simtest-TalentsEMPrimal-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 341636.90634
-  tps: 195137.55543
+  dps: 336221.11042
+  tps: 194056.07421
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Dwarf-simtest-TalentsEchoUnleashed-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 339516.95558
-  tps: 291280.17459
+  dps: 340518.36578
+  tps: 292904.89647
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Dwarf-simtest-TalentsEchoUnleashed-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 229953.24239
-  tps: 188889.12004
+  dps: 232090.71444
+  tps: 190628.84832
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Dwarf-simtest-TalentsEchoUnleashed-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 369284.67449
-  tps: 249870.62769
+  dps: 371801.49039
+  tps: 252087.72496
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Dwarf-simtest-TalentsEchoUnleashed-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 261906.79117
-  tps: 229539.23745
+  dps: 260773.09893
+  tps: 228778.59494
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Dwarf-simtest-TalentsEchoUnleashed-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 185106.34697
-  tps: 153922.83816
+  dps: 183801.77772
+  tps: 152764.64862
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Dwarf-simtest-TalentsEchoUnleashed-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 286580.91635
-  tps: 198655.7309
+  dps: 281855.94622
+  tps: 195488.93943
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-simtest-DefaultTalents-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 336116.72241
-  tps: 293792.72466
+  dps: 340378.25046
+  tps: 298808.06179
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-simtest-DefaultTalents-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 234294.34879
-  tps: 198038.19176
+  dps: 234866.61087
+  tps: 197978.14238
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-simtest-DefaultTalents-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 388895.82339
-  tps: 264897.50723
+  dps: 393315.39791
+  tps: 267228.99243
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-simtest-DefaultTalents-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 265142.99845
-  tps: 236591.16624
+  dps: 264313.54647
+  tps: 235072.89463
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-simtest-DefaultTalents-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 185037.50763
-  tps: 158281.24456
+  dps: 184962.26798
+  tps: 158166.42475
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-simtest-DefaultTalents-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 302478.11665
-  tps: 213314.81737
+  dps: 299217.80899
+  tps: 210305.44746
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-simtest-TalentsEMPrimal-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 361257.58322
-  tps: 290531.29232
+  dps: 365305.2165
+  tps: 292681.99232
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-simtest-TalentsEMPrimal-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 235911.83805
-  tps: 179871.67236
+  dps: 236646.278
+  tps: 179895.24604
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-simtest-TalentsEMPrimal-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 461692.77914
-  tps: 245943.69639
+  dps: 469229.60229
+  tps: 249771.37131
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-simtest-TalentsEMPrimal-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 278071.41728
-  tps: 228399.15099
+  dps: 278208.09888
+  tps: 228972.88146
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-simtest-TalentsEMPrimal-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 185238.19241
-  tps: 144818.93546
+  dps: 183972.43542
+  tps: 144474.76252
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-simtest-TalentsEMPrimal-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 351509.56233
-  tps: 198630.75856
+  dps: 346012.09434
+  tps: 197569.16335
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-simtest-TalentsEchoUnleashed-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 344709.21646
-  tps: 294567.47041
+  dps: 345255.18462
+  tps: 295767.08696
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-simtest-TalentsEchoUnleashed-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 233008.73324
-  tps: 190663.94612
+  dps: 235126.99808
+  tps: 192408.1935
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-simtest-TalentsEchoUnleashed-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 378106.57482
-  tps: 254060.61812
+  dps: 380582.03356
+  tps: 256255.36818
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-simtest-TalentsEchoUnleashed-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 265749.4301
-  tps: 231975.06301
+  dps: 264706.42448
+  tps: 231300.57357
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-simtest-TalentsEchoUnleashed-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 187533.61933
-  tps: 155364.77706
+  dps: 186224.80852
+  tps: 154201.40823
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-simtest-TalentsEchoUnleashed-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 293381.05313
-  tps: 201903.16249
+  dps: 288583.16325
+  tps: 198697.28013
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-simtest-DefaultTalents-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 344075.12719
-  tps: 301277.00945
+  dps: 345177.28997
+  tps: 303126.28989
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-simtest-DefaultTalents-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 236838.17293
-  tps: 199633.98769
+  dps: 236834.61927
+  tps: 199472.75507
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-simtest-DefaultTalents-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 404306.92015
-  tps: 275411.03455
+  dps: 403118.78942
+  tps: 272491.63149
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-simtest-DefaultTalents-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 268564.33395
-  tps: 238465.90645
+  dps: 267668.27369
+  tps: 238458.33236
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-simtest-DefaultTalents-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 187523.68299
-  tps: 160020.89786
+  dps: 185515.18514
+  tps: 158347.28794
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-simtest-DefaultTalents-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 308561.25023
-  tps: 215221.93672
+  dps: 305603.63809
+  tps: 213686.67502
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-simtest-TalentsEMPrimal-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 364494.12962
-  tps: 293410.67269
+  dps: 365901.22555
+  tps: 294542.43813
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-simtest-TalentsEMPrimal-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 239646.73766
-  tps: 184448.91463
+  dps: 238718.96426
+  tps: 183454.11443
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-simtest-TalentsEMPrimal-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 477011.87652
-  tps: 263961.64199
+  dps: 472411.93448
+  tps: 259134.4889
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-simtest-TalentsEMPrimal-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 281074.97718
-  tps: 231460.3479
+  dps: 282239.477
+  tps: 232390.38678
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-simtest-TalentsEMPrimal-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 186331.39371
-  tps: 145938.94988
+  dps: 185954.33256
+  tps: 145504.82109
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-simtest-TalentsEMPrimal-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 356520.57406
-  tps: 202602.57868
+  dps: 351947.73008
+  tps: 198597.6848
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-simtest-TalentsEchoUnleashed-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 345988.49113
-  tps: 296127.8817
+  dps: 347272.50256
+  tps: 296814.12918
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-simtest-TalentsEchoUnleashed-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 234979.33118
-  tps: 192088.16764
+  dps: 233645.10904
+  tps: 191557.2849
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-simtest-TalentsEchoUnleashed-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 387820.99772
-  tps: 261031.89165
+  dps: 378540.64796
+  tps: 254904.51694
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-simtest-TalentsEchoUnleashed-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 265606.96234
-  tps: 231763.57159
+  dps: 265109.87733
+  tps: 231817.11543
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-simtest-TalentsEchoUnleashed-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 186536.62143
-  tps: 154384.34186
+  dps: 187229.63389
+  tps: 155335.45115
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-simtest-TalentsEchoUnleashed-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 294941.09873
-  tps: 202183.57288
+  dps: 297645.10043
+  tps: 206286.0888
  }
 }
 dps_results: {
  key: "TestEnhancement-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 220687.67287
-  tps: 185730.94281
+  dps: 220592.48395
+  tps: 186397.95394
  }
 }

--- a/sim/shaman/talents_enhancement.go
+++ b/sim/shaman/talents_enhancement.go
@@ -190,7 +190,10 @@ func (shaman *Shaman) ApplyEnhancementTalents() {
 
 	ppm := core.TernaryFloat64(shaman.S12Enh2pc.IsActive(), 12.0, 10.0)
 
-	dpm := shaman.NewLegacyPPMManager(ppm, core.ProcMaskMeleeOrMeleeProc)
+	// Weapon attacks only — WCL-verified (yaCDjQpWvrkA1FGY fight 15) that melee
+	// procs like Flurry of Xuen and Lightning Strike do not generate Maelstrom
+	// Weapon, unlike Flurry above which they do refresh.
+	dpm := shaman.NewLegacyPPMManager(ppm, core.ProcMaskMelee)
 
 	// This aura is hidden, just applies stacks of the proc aura.
 	shaman.MakeProcTriggerAura(core.ProcTrigger{

--- a/sim/warrior/arms/TestArms.results
+++ b/sim/warrior/arms/TestArms.results
@@ -33,15 +33,15 @@ character_stats_results: {
 dps_results: {
  key: "TestArms-AllItems-AgilePrimalDiamond"
  value: {
-  dps: 434193.90468
-  tps: 317169.452
+  dps: 433811.83136
+  tps: 316653.5298
  }
 }
 dps_results: {
  key: "TestArms-AllItems-AlacrityofXuen-103989"
  value: {
-  dps: 419484.64118
-  tps: 311016.61564
+  dps: 423550.55861
+  tps: 314995.90199
  }
 }
 dps_results: {
@@ -61,50 +61,50 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-AssuranceofConsequence-105472"
  value: {
-  dps: 402101.46151
-  tps: 296861.78702
+  dps: 401942.26812
+  tps: 296840.28163
  }
 }
 dps_results: {
  key: "TestArms-AllItems-AusterePrimalDiamond"
  value: {
-  dps: 425353.70779
-  tps: 310491.8378
+  dps: 424984.64064
+  tps: 309991.34203
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BadJuju-96781"
  value: {
-  dps: 413086.9467
-  tps: 305191.089
+  dps: 411777.191
+  tps: 304716.6834
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BadgeofKypariZar-84079"
  value: {
-  dps: 406701.86526
-  tps: 302191.73958
+  dps: 407303.42146
+  tps: 302329.91066
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BattleplateofResoundingRings"
  value: {
-  dps: 320150.39314
-  tps: 225243.14429
+  dps: 320660.50897
+  tps: 225748.73365
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BattleplateoftheLastMogu"
  value: {
-  dps: 337450.283
-  tps: 240559.71462
+  dps: 338210.5934
+  tps: 241103.31999
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BattleplateofthePrehistoricMarauder"
  value: {
-  dps: 343040.98313
-  tps: 246078.55924
+  dps: 343586.51535
+  tps: 246577.95084
  }
 }
 dps_results: {
@@ -124,15 +124,15 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-BottleofInfiniteStars-87057"
  value: {
-  dps: 410823.38125
-  tps: 302614.54047
+  dps: 410848.97245
+  tps: 302631.72878
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BraidofTenSongs-84072"
  value: {
-  dps: 404389.59201
-  tps: 299760.67071
+  dps: 407804.4257
+  tps: 302223.35993
  }
 }
 dps_results: {
@@ -159,29 +159,29 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-BrutalTalismanoftheShado-PanAssault-94508"
  value: {
-  dps: 413648.17822
-  tps: 305108.41116
+  dps: 413966.58359
+  tps: 305069.25921
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BurningPrimalDiamond"
  value: {
-  dps: 434228.44163
-  tps: 317116.42703
+  dps: 433841.4097
+  tps: 316600.31196
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CapacitivePrimalDiamond"
  value: {
-  dps: 436246.49243
-  tps: 322191.29755
+  dps: 436572.32049
+  tps: 322176.73387
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CarbonicCarbuncle-81138"
  value: {
-  dps: 412428.86278
-  tps: 305320.74585
+  dps: 412511.36643
+  tps: 305380.41883
  }
 }
 dps_results: {
@@ -194,8 +194,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-CharmofTenSongs-84071"
  value: {
-  dps: 407126.09124
-  tps: 299509.96337
+  dps: 407261.86533
+  tps: 300142.04787
  }
 }
 dps_results: {
@@ -208,8 +208,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-CommunalStoneofDestruction-101171"
  value: {
-  dps: 407823.91857
-  tps: 302341.8457
+  dps: 406969.74787
+  tps: 299995.04209
  }
 }
 dps_results: {
@@ -243,8 +243,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-CourageousPrimalDiamond"
  value: {
-  dps: 425353.70779
-  tps: 310491.8378
+  dps: 424984.64064
+  tps: 309991.34203
  }
 }
 dps_results: {
@@ -292,8 +292,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-CraftedDreadfulGladiator'sInsigniaofConquest-93424"
  value: {
-  dps: 402704.24455
-  tps: 297251.49066
+  dps: 402730.03667
+  tps: 297277.28278
  }
 }
 dps_results: {
@@ -306,8 +306,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-CraftedDreadfulGladiator'sInsigniaofVictory-93611"
  value: {
-  dps: 408408.5492
-  tps: 301561.45745
+  dps: 407919.97204
+  tps: 301377.7101
  }
 }
 dps_results: {
@@ -355,8 +355,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-CraftedMalevolentGladiator'sInsigniaofConquest-98760"
  value: {
-  dps: 401771.83558
-  tps: 296966.71082
+  dps: 401752.29834
+  tps: 296947.17358
  }
 }
 dps_results: {
@@ -369,8 +369,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-CraftedMalevolentGladiator'sInsigniaofVictory-98917"
  value: {
-  dps: 408766.49617
-  tps: 300757.44942
+  dps: 408710.42978
+  tps: 301029.13023
  }
 }
 dps_results: {
@@ -397,15 +397,15 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-DarkglowEmbroidery(Rank3)-4893"
  value: {
-  dps: 434600.42321
-  tps: 320684.53577
+  dps: 434974.15965
+  tps: 320739.66971
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmistVortex-87172"
  value: {
-  dps: 417213.78135
-  tps: 309489.45122
+  dps: 415451.70216
+  tps: 308748.09201
  }
 }
 dps_results: {
@@ -425,15 +425,15 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-DestructivePrimalDiamond"
  value: {
-  dps: 427036.50031
-  tps: 311515.41349
+  dps: 427030.89134
+  tps: 311477.03565
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DisciplineofXuen-103986"
  value: {
-  dps: 407772.31592
-  tps: 300823.97578
+  dps: 410376.97125
+  tps: 302727.92183
  }
 }
 dps_results: {
@@ -516,8 +516,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-DreadfulGladiator'sInsigniaofConquest-84349"
  value: {
-  dps: 402710.85786
-  tps: 297258.10397
+  dps: 402707.4332
+  tps: 297254.67932
  }
 }
 dps_results: {
@@ -530,8 +530,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-DreadfulGladiator'sInsigniaofVictory-84495"
  value: {
-  dps: 407846.93012
-  tps: 300518.05657
+  dps: 407908.33527
+  tps: 300694.69496
  }
 }
 dps_results: {
@@ -551,29 +551,29 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-EffulgentPrimalDiamond"
  value: {
-  dps: 425353.70779
-  tps: 310491.8378
+  dps: 424984.64064
+  tps: 309991.34203
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EmberPrimalDiamond"
  value: {
-  dps: 425353.70779
-  tps: 310491.8378
+  dps: 424984.64064
+  tps: 309991.34203
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EmblemofKypariZar-84077"
  value: {
-  dps: 406477.57314
-  tps: 300687.92618
+  dps: 404982.3454
+  tps: 300114.49221
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EmblemoftheCatacombs-83733"
  value: {
-  dps: 407643.09399
-  tps: 301104.23191
+  dps: 406963.53172
+  tps: 302287.7493
  }
 }
 dps_results: {
@@ -586,57 +586,57 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-EnchantWeapon-BloodyDancingSteel-5125"
  value: {
-  dps: 436207.49694
-  tps: 322148.13771
+  dps: 436482.87964
+  tps: 322111.7062
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnchantWeapon-Colossus-4445"
  value: {
-  dps: 431552.27122
-  tps: 318673.19929
+  dps: 431835.35914
+  tps: 318640.2401
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnchantWeapon-ElementalForce-4443"
  value: {
-  dps: 432151.78578
-  tps: 319529.86305
+  dps: 432455.17375
+  tps: 319498.51581
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnchantWeapon-JadeSpirit-4442"
  value: {
-  dps: 431552.27122
-  tps: 318673.19929
+  dps: 431835.35914
+  tps: 318640.2401
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnchantWeapon-River'sSong-4446"
  value: {
-  dps: 431552.27122
-  tps: 318673.19929
+  dps: 431835.35914
+  tps: 318640.2401
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnchantWeapon-SpiritofConquest-5124"
  value: {
-  dps: 431552.27122
-  tps: 318673.19929
+  dps: 431835.35914
+  tps: 318640.2401
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnchantWeapon-Windsong-4441"
  value: {
-  dps: 434045.95422
-  tps: 319396.78261
+  dps: 434989.00354
+  tps: 319598.45125
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticPrimalDiamond"
  value: {
-  dps: 427036.50031
-  tps: 311515.41349
+  dps: 427030.89134
+  tps: 311477.03565
  }
 }
 dps_results: {
@@ -649,22 +649,22 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-EternalPrimalDiamond"
  value: {
-  dps: 425353.70779
-  tps: 310491.8378
+  dps: 424984.64064
+  tps: 309991.34203
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FabledFeatherofJi-Kun-96842"
  value: {
-  dps: 416121.006
-  tps: 306591.13228
+  dps: 416418.23624
+  tps: 306828.38331
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FearwurmBadge-84074"
  value: {
-  dps: 407634.13367
-  tps: 300974.0991
+  dps: 407084.01266
+  tps: 301260.43831
  }
 }
 dps_results: {
@@ -684,15 +684,15 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-FelsoulStoneofDestruction-101266"
  value: {
-  dps: 409475.43458
-  tps: 302353.5522
+  dps: 407376.45062
+  tps: 300503.72432
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Fen-Yu,FuryofXuen-102248"
  value: {
-  dps: 419386.00494
-  tps: 309093.63523
+  dps: 419314.44413
+  tps: 309038.1585
  }
 }
 dps_results: {
@@ -712,15 +712,15 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-FleetPrimalDiamond"
  value: {
-  dps: 428789.33241
-  tps: 312838.16522
+  dps: 429443.87405
+  tps: 313434.678
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForlornPrimalDiamond"
  value: {
-  dps: 425353.70779
-  tps: 310491.8378
+  dps: 424984.64064
+  tps: 309991.34203
  }
 }
 dps_results: {
@@ -740,15 +740,15 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-Fusion-FireCore-105459"
  value: {
-  dps: 420808.83209
-  tps: 309822.70233
+  dps: 421217.05561
+  tps: 310003.19187
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GazeoftheTwins-96915"
  value: {
-  dps: 423139.36208
-  tps: 311319.6098
+  dps: 419261.09804
+  tps: 310292.59791
  }
 }
 dps_results: {
@@ -803,8 +803,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-GrievousGladiator'sInsigniaofConquest-103150"
  value: {
-  dps: 402734.84206
-  tps: 297371.92659
+  dps: 403081.21191
+  tps: 298007.96443
  }
 }
 dps_results: {
@@ -817,15 +817,15 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-GrievousGladiator'sInsigniaofVictory-103319"
  value: {
-  dps: 412659.57391
-  tps: 304274.07267
+  dps: 412859.00085
+  tps: 304869.56031
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Haromm'sTalisman-105527"
  value: {
-  dps: 421865.63114
-  tps: 316551.27887
+  dps: 423495.83201
+  tps: 318022.96721
  }
 }
 dps_results: {
@@ -845,22 +845,22 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-Heart-LesionDefenderStone-101002"
  value: {
-  dps: 404864.40486
-  tps: 299715.3194
+  dps: 406799.61513
+  tps: 300316.07567
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Heart-LesionIdolofBattle-100991"
  value: {
-  dps: 413271.05075
-  tps: 304970.42519
+  dps: 413204.74481
+  tps: 304632.44599
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Heart-LesionStoneofBattle-100990"
  value: {
-  dps: 411251.25258
-  tps: 304141.92781
+  dps: 416255.95859
+  tps: 306084.0465
  }
 }
 dps_results: {
@@ -894,15 +894,15 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-ImpassivePrimalDiamond"
  value: {
-  dps: 427036.50031
-  tps: 311515.41349
+  dps: 427030.89134
+  tps: 311477.03565
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IndomitablePrimalDiamond"
  value: {
-  dps: 425353.70779
-  tps: 310491.8378
+  dps: 424984.64064
+  tps: 309991.34203
  }
 }
 dps_results: {
@@ -986,8 +986,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-Kardris'ToxicTotem-105540"
  value: {
-  dps: 421181.50987
-  tps: 315819.79475
+  dps: 422491.97881
+  tps: 317130.26369
  }
 }
 dps_results: {
@@ -1021,8 +1021,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-LeiShen'sFinalOrders-87072"
  value: {
-  dps: 411507.48923
-  tps: 305609.97957
+  dps: 412015.22607
+  tps: 306165.98259
  }
 }
 dps_results: {
@@ -1035,15 +1035,15 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-LightdrinkerIdolofRage-101200"
  value: {
-  dps: 409715.00899
-  tps: 302578.34006
+  dps: 410479.57028
+  tps: 302780.22635
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LightdrinkerStoneofRage-101203"
  value: {
-  dps: 405738.95746
-  tps: 300069.68078
+  dps: 407020.46627
+  tps: 301024.98587
  }
 }
 dps_results: {
@@ -1056,15 +1056,15 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-LightweaveEmbroidery(Rank3)-4892"
  value: {
-  dps: 434600.42321
-  tps: 320684.53577
+  dps: 434974.15965
+  tps: 320739.66971
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LordBlastington'sScopeofDoom-4699"
  value: {
-  dps: 431552.27122
-  tps: 318673.19929
+  dps: 431835.35914
+  tps: 318640.2401
  }
 }
 dps_results: {
@@ -1112,8 +1112,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-MalevolentGladiator'sInsigniaofConquest-91457"
  value: {
-  dps: 401915.20295
-  tps: 296997.92103
+  dps: 401768.69667
+  tps: 296963.57191
  }
 }
 dps_results: {
@@ -1126,8 +1126,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-MalevolentGladiator'sInsigniaofVictory-91768"
  value: {
-  dps: 408745.04834
-  tps: 300837.37405
+  dps: 408735.65019
+  tps: 300919.98108
  }
 }
 dps_results: {
@@ -1168,8 +1168,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-MirrorScope-4700"
  value: {
-  dps: 431552.27122
-  tps: 318673.19929
+  dps: 431835.35914
+  tps: 318640.2401
  }
 }
 dps_results: {
@@ -1182,22 +1182,22 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-MistdancerDefenderStone-101087"
  value: {
-  dps: 407375.11883
-  tps: 301317.21044
+  dps: 407428.63601
+  tps: 301491.98421
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MistdancerIdolofRage-101113"
  value: {
-  dps: 409597.50801
-  tps: 302536.50401
+  dps: 410338.52803
+  tps: 302777.72148
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MistdancerStoneofRage-101117"
  value: {
-  dps: 408333.53004
-  tps: 301556.34233
+  dps: 408215.29309
+  tps: 301803.88826
  }
 }
 dps_results: {
@@ -1224,8 +1224,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-MountainsageStoneofDestruction-101072"
  value: {
-  dps: 408252.71203
-  tps: 301071.13762
+  dps: 406409.83953
+  tps: 301203.88263
  }
 }
 dps_results: {
@@ -1238,50 +1238,50 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-OathswornDefenderStone-101306"
  value: {
-  dps: 406856.84911
-  tps: 301062.44133
+  dps: 406725.12614
+  tps: 299988.44499
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OathswornIdolofBattle-101295"
  value: {
-  dps: 413930.69189
-  tps: 304896.34237
+  dps: 413529.92464
+  tps: 304596.0624
  }
 }
 dps_results: {
  key: "TestArms-AllItems-OathswornStoneofBattle-101294"
  value: {
-  dps: 414558.06025
-  tps: 305392.47694
+  dps: 413724.86062
+  tps: 306218.95994
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PhaseFingers-4697"
  value: {
-  dps: 435212.80372
-  tps: 321425.32669
+  dps: 435539.05111
+  tps: 321411.2915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PlateofResoundingRings"
  value: {
-  dps: 291322.23745
-  tps: 207808.80176
+  dps: 292030.12407
+  tps: 207727.36587
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PlateoftheLastMogu"
  value: {
-  dps: 303331.75498
-  tps: 217136.15038
+  dps: 304034.05288
+  tps: 217455.16546
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PlateofthePrehistoricMarauder"
  value: {
-  dps: 312945.82871
-  tps: 225551.93276
+  dps: 313331.76641
+  tps: 225693.09502
  }
 }
 dps_results: {
@@ -1294,8 +1294,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-PowerfulPrimalDiamond"
  value: {
-  dps: 425353.70779
-  tps: 310491.8378
+  dps: 424984.64064
+  tps: 309991.34203
  }
 }
 dps_results: {
@@ -1350,8 +1350,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-PridefulGladiator'sInsigniaofConquest-103347"
  value: {
-  dps: 402364.66748
-  tps: 297200.42011
+  dps: 402734.38826
+  tps: 297823.24192
  }
 }
 dps_results: {
@@ -1364,15 +1364,15 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-PridefulGladiator'sInsigniaofVictory-103516"
  value: {
-  dps: 417183.8832
-  tps: 307886.69382
+  dps: 417025.62541
+  tps: 307734.96282
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Primordius'TalismanofRage-96873"
  value: {
-  dps: 421146.82548
-  tps: 310409.25347
+  dps: 421682.4338
+  tps: 310830.25383
  }
 }
 dps_results: {
@@ -1434,15 +1434,15 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-RelicofXuen-79327"
  value: {
-  dps: 412643.35036
-  tps: 304822.46523
+  dps: 412977.42357
+  tps: 305190.28248
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RelicofXuen-79328"
  value: {
-  dps: 401857.95581
-  tps: 297131.07948
+  dps: 401852.2
+  tps: 297125.32367
  }
 }
 dps_results: {
@@ -1455,8 +1455,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-Renataki'sSoulCharm-96741"
  value: {
-  dps: 401366.74826
-  tps: 296595.28562
+  dps: 401390.41585
+  tps: 296456.46821
  }
 }
 dps_results: {
@@ -1469,22 +1469,22 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-ReverberatingPrimalDiamond"
  value: {
-  dps: 435501.24118
-  tps: 318042.8786
+  dps: 435112.60724
+  tps: 317524.96876
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RevitalizingPrimalDiamond"
  value: {
-  dps: 434228.44163
-  tps: 317116.42703
+  dps: 433841.4097
+  tps: 316600.31196
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RuneofRe-Origination-96918"
  value: {
-  dps: 417187.38999
-  tps: 303822.46917
+  dps: 415114.133
+  tps: 304155.14368
  }
 }
 dps_results: {
@@ -1504,8 +1504,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-SearingWords-81267"
  value: {
-  dps: 406928.90786
-  tps: 300204.70435
+  dps: 406771.44022
+  tps: 300128.10235
  }
 }
 dps_results: {
@@ -1525,64 +1525,64 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-SigilofDevotion-83740"
  value: {
-  dps: 407552.01077
-  tps: 301732.15131
+  dps: 407411.55366
+  tps: 301420.46914
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SigilofFidelity-83737"
  value: {
-  dps: 407890.75037
-  tps: 301237.44767
+  dps: 408176.14011
+  tps: 301229.92173
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SigilofGrace-83738"
  value: {
-  dps: 405339.28452
-  tps: 300487.67215
+  dps: 405466.52921
+  tps: 301217.41554
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SigilofKypariZar-84076"
  value: {
-  dps: 410458.8146
-  tps: 303253.48506
+  dps: 410973.81912
+  tps: 303709.00478
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SigilofPatience-83739"
  value: {
-  dps: 405251.70394
-  tps: 299467.46086
+  dps: 403725.9502
+  tps: 298957.63984
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SigilofRampage-105580"
  value: {
-  dps: 402650.70315
-  tps: 297116.10692
+  dps: 402523.63689
+  tps: 297352.32179
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SigiloftheCatacombs-83732"
  value: {
-  dps: 405101.39534
-  tps: 299724.55118
+  dps: 407669.29675
+  tps: 300991.93914
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SinisterPrimalDiamond"
  value: {
-  dps: 426083.58785
-  tps: 310722.65932
+  dps: 426032.69671
+  tps: 310652.31852
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Skeer'sBloodsoakedTalisman-105632"
  value: {
-  dps: 434914.91975
-  tps: 319610.65091
+  dps: 432587.32441
+  tps: 318404.72869
  }
 }
 dps_results: {
@@ -1609,8 +1609,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-SparkofZandalar-96770"
  value: {
-  dps: 417255.33477
-  tps: 310503.53573
+  dps: 417989.76511
+  tps: 310997.89398
  }
 }
 dps_results: {
@@ -1630,22 +1630,22 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-SpringrainIdolofRage-101009"
  value: {
-  dps: 410025.26732
-  tps: 302489.46883
+  dps: 410035.60814
+  tps: 302499.80965
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SpringrainStoneofDestruction-101026"
  value: {
-  dps: 406727.72283
-  tps: 300088.933
+  dps: 406633.72284
+  tps: 302167.49884
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SpringrainStoneofRage-101012"
  value: {
-  dps: 406920.695
-  tps: 301630.06837
+  dps: 408521.13078
+  tps: 303199.10437
  }
 }
 dps_results: {
@@ -1686,22 +1686,22 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-StreamtalkerIdolofRage-101217"
  value: {
-  dps: 411145.39798
-  tps: 302919.8396
+  dps: 410672.7843
+  tps: 302705.80754
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StreamtalkerStoneofDestruction-101225"
  value: {
-  dps: 409037.56029
-  tps: 302090.71157
+  dps: 409302.03366
+  tps: 303025.28369
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StreamtalkerStoneofRage-101220"
  value: {
-  dps: 407896.23378
-  tps: 300455.75781
+  dps: 406094.36941
+  tps: 301747.92048
  }
 }
 dps_results: {
@@ -1728,22 +1728,22 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-SunsoulDefenderStone-101163"
  value: {
-  dps: 409614.34446
-  tps: 301863.27056
+  dps: 406124.30393
+  tps: 300478.89069
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SunsoulIdolofBattle-101152"
  value: {
-  dps: 412905.01293
-  tps: 303749.2347
+  dps: 413797.78527
+  tps: 304930.86384
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SunsoulStoneofBattle-101151"
  value: {
-  dps: 411847.44107
-  tps: 305873.77837
+  dps: 414832.87782
+  tps: 306020.76319
  }
 }
 dps_results: {
@@ -1756,36 +1756,36 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-SwordguardEmbroidery(Rank3)-4894"
  value: {
-  dps: 437805.34593
-  tps: 322990.38702
+  dps: 438200.65389
+  tps: 323050.27393
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SymboloftheCatacombs-83735"
  value: {
-  dps: 408388.3441
-  tps: 302729.6057
+  dps: 408574.65188
+  tps: 302551.83562
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SynapseSprings(MarkII)-4898"
  value: {
-  dps: 436317.41398
-  tps: 322294.21799
+  dps: 436582.64744
+  tps: 322404.42819
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TalismanofBloodlust-96864"
  value: {
-  dps: 406603.4589
-  tps: 301237.69566
+  dps: 407784.27312
+  tps: 302828.98179
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TerrorintheMists-87167"
  value: {
-  dps: 413883.56806
-  tps: 305653.74504
+  dps: 414451.22738
+  tps: 306097.19864
  }
 }
 dps_results: {
@@ -1812,22 +1812,22 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-Time-LostArtifact-103678"
  value: {
-  dps: 413857.26337
-  tps: 307156.82321
+  dps: 414060.85526
+  tps: 307826.43096
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TrailseekerIdolofRage-101054"
  value: {
-  dps: 410580.16026
-  tps: 302708.14391
+  dps: 410185.44212
+  tps: 302468.78204
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TrailseekerStoneofRage-101057"
  value: {
-  dps: 405137.21545
-  tps: 299766.73879
+  dps: 406076.87878
+  tps: 300311.15694
  }
 }
 dps_results: {
@@ -1875,8 +1875,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-TyrannicalGladiator'sInsigniaofConquest-100026"
  value: {
-  dps: 401870.33399
-  tps: 296979.95461
+  dps: 401940.46862
+  tps: 297023.18669
  }
 }
 dps_results: {
@@ -1889,15 +1889,15 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-TyrannicalGladiator'sInsigniaofVictory-100085"
  value: {
-  dps: 411351.75495
-  tps: 302731.54597
+  dps: 410892.90986
+  tps: 302412.59903
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TyrannicalPrimalDiamond"
  value: {
-  dps: 425353.70779
-  tps: 310491.8378
+  dps: 424984.64064
+  tps: 309991.34203
  }
 }
 dps_results: {
@@ -1938,8 +1938,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-ViciousTalismanoftheShado-PanAssault-94511"
  value: {
-  dps: 402475.54572
-  tps: 297031.78449
+  dps: 401598.58239
+  tps: 296717.53585
  }
 }
 dps_results: {
@@ -1959,8 +1959,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-WindsweptPages-81125"
  value: {
-  dps: 409015.09461
-  tps: 304268.2028
+  dps: 406145.26028
+  tps: 301863.7444
  }
 }
 dps_results: {
@@ -1987,8 +1987,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-YaungolFireCarrier-86518"
  value: {
-  dps: 480562.17566
-  tps: 356271.2344
+  dps: 481613.55549
+  tps: 356935.19261
  }
 }
 dps_results: {
@@ -2001,15 +2001,15 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-ZenAlchemistStone-75274"
  value: {
-  dps: 411949.31359
-  tps: 305062.08103
+  dps: 412072.98776
+  tps: 305159.33447
  }
 }
 dps_results: {
  key: "TestArms-Average-Default"
  value: {
-  dps: 439253.17718
-  tps: 323388.04775
+  dps: 439815.32513
+  tps: 323721.97916
  }
 }
 dps_results: {
@@ -2057,43 +2057,43 @@ dps_results: {
 dps_results: {
  key: "TestArms-Settings-Orc-p5_arms_bis-Basic-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 2.59276044288e+06
-  tps: 1.9957157514e+06
+  dps: 2.5902199178e+06
+  tps: 1.99242189018e+06
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p5_arms_bis-Basic-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 437346.66667
-  tps: 323058.0799
+  dps: 437611.90013
+  tps: 323168.29009
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p5_arms_bis-Basic-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 513268.14394
-  tps: 366000.68343
+  dps: 514969.09709
+  tps: 366229.69327
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p5_arms_bis-Basic-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 2.19520546456e+06
-  tps: 1.64671084492e+06
+  dps: 2.20577851803e+06
+  tps: 1.65799309033e+06
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p5_arms_bis-Basic-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 362379.61347
-  tps: 268306.74693
+  dps: 362459.946
+  tps: 268328.74838
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p5_arms_bis-Basic-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 385507.00979
-  tps: 279065.32281
+  dps: 386233.64314
+  tps: 278652.76378
  }
 }
 dps_results: {
@@ -2141,49 +2141,49 @@ dps_results: {
 dps_results: {
  key: "TestArms-Settings-Worgen-p5_arms_bis-Basic-arms-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 2.56170106936e+06
-  tps: 1.96885759991e+06
+  dps: 2.56922803689e+06
+  tps: 1.97250719728e+06
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p5_arms_bis-Basic-arms-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 437415.05471
-  tps: 321656.82886
+  dps: 437967.84626
+  tps: 321881.87642
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p5_arms_bis-Basic-arms-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 508377.71781
-  tps: 364571.54647
+  dps: 510213.3786
+  tps: 364726.36707
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p5_arms_bis-Basic-arms-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 2.18243094296e+06
-  tps: 1.64229429467e+06
+  dps: 2.19376497839e+06
+  tps: 1.65126484057e+06
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p5_arms_bis-Basic-arms-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 358717.52487
-  tps: 265845.6289
+  dps: 359660.12598
+  tps: 266605.21911
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p5_arms_bis-Basic-arms-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 381102.44125
-  tps: 276932.47005
+  dps: 381999.64292
+  tps: 276571.41275
  }
 }
 dps_results: {
  key: "TestArms-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 388438.59771
-  tps: 288840.2152
+  dps: 389466.07779
+  tps: 289407.78318
  }
 }

--- a/sim/warrior/fury/TestFury.results
+++ b/sim/warrior/fury/TestFury.results
@@ -698,8 +698,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-Fen-Yu,FuryofXuen-102248"
  value: {
-  dps: 288910.4408
-  tps: 185435.14378
+  dps: 290976.22068
+  tps: 187457.01049
  }
 }
 dps_results: {
@@ -768,8 +768,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-Gong-Lu,StrengthofXuen-102249"
  value: {
-  dps: 299107.84014
-  tps: 192861.26094
+  dps: 302637.60635
+  tps: 193982.4896
  }
 }
 dps_results: {
@@ -2127,85 +2127,85 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Troll-preraid_fury_tg-DefaultTalents-Basic-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 502079.49941
-  tps: 382353.4149
+  dps: 513379.91115
+  tps: 393020.45677
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-preraid_fury_tg-DefaultTalents-Basic-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 289922.24411
-  tps: 190920.32202
+  dps: 293678.57567
+  tps: 192819.13428
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-preraid_fury_tg-DefaultTalents-Basic-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 362954.47429
-  tps: 235390.53487
+  dps: 368471.48855
+  tps: 236535.26607
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-preraid_fury_tg-DefaultTalents-Basic-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 432358.37452
-  tps: 307245.51648
+  dps: 427773.2557
+  tps: 307011.61816
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-preraid_fury_tg-DefaultTalents-Basic-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 229010.99542
-  tps: 152721.35088
+  dps: 232800.31187
+  tps: 154028.37582
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-preraid_fury_tg-DefaultTalents-Basic-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 265937.3083
-  tps: 172283.71608
+  dps: 270594.03681
+  tps: 173720.90554
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-preraid_fury_tg-Single-Minded Fury-Basic-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 555786.0075
-  tps: 380691.56367
+  dps: 549824.96483
+  tps: 374980.81485
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-preraid_fury_tg-Single-Minded Fury-Basic-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 285583.86326
-  tps: 190794.33519
+  dps: 288095.23108
+  tps: 192551.43408
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-preraid_fury_tg-Single-Minded Fury-Basic-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 365098.90544
-  tps: 240483.03957
+  dps: 363655.38124
+  tps: 241803.87592
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-preraid_fury_tg-Single-Minded Fury-Basic-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 437937.74929
-  tps: 300490.48736
+  dps: 436038.60491
+  tps: 300373.28864
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-preraid_fury_tg-Single-Minded Fury-Basic-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 226361.48384
-  tps: 151614.77497
+  dps: 227085.85684
+  tps: 152265.64531
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-preraid_fury_tg-Single-Minded Fury-Basic-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 267194.79789
-  tps: 175590.45412
+  dps: 266090.17836
+  tps: 175177.55732
  }
 }
 dps_results: {
@@ -2295,85 +2295,85 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Worgen-preraid_fury_tg-DefaultTalents-Basic-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 510505.17062
-  tps: 390364.38985
+  dps: 507479.05458
+  tps: 385083.16656
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-preraid_fury_tg-DefaultTalents-Basic-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 292473.16913
-  tps: 191841.22226
+  dps: 294596.11851
+  tps: 193901.74192
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-preraid_fury_tg-DefaultTalents-Basic-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 367057.34547
-  tps: 237366.29828
+  dps: 369539.16969
+  tps: 238104.99773
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-preraid_fury_tg-DefaultTalents-Basic-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 419440.71378
-  tps: 311941.15869
+  dps: 409639.67938
+  tps: 315845.4774
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-preraid_fury_tg-DefaultTalents-Basic-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 229646.50704
-  tps: 149825.72304
+  dps: 231067.91467
+  tps: 153099.82525
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-preraid_fury_tg-DefaultTalents-Basic-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 270704.00104
-  tps: 171457.90353
+  dps: 269497.91187
+  tps: 171659.48889
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-preraid_fury_tg-Single-Minded Fury-Basic-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 552593.70642
-  tps: 375769.16838
+  dps: 547970.48427
+  tps: 372960.54748
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-preraid_fury_tg-Single-Minded Fury-Basic-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 291448.57065
-  tps: 193851.53337
+  dps: 288696.88163
+  tps: 193171.53953
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-preraid_fury_tg-Single-Minded Fury-Basic-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 367870.62227
-  tps: 242156.34512
+  dps: 362490.13971
+  tps: 238813.35829
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-preraid_fury_tg-Single-Minded Fury-Basic-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 435667.3708
-  tps: 298487.50734
+  dps: 437054.75628
+  tps: 301762.11684
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-preraid_fury_tg-Single-Minded Fury-Basic-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 227580.13618
-  tps: 152536.64955
+  dps: 228473.54324
+  tps: 153117.75763
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-preraid_fury_tg-Single-Minded Fury-Basic-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 267359.57617
-  tps: 172925.7506
+  dps: 265122.03171
+  tps: 174597.94075
  }
 }
 dps_results: {

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -793,9 +793,9 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Fen-Yu,FuryofXuen-102248"
  value: {
-  dps: 419925.77681
-  tps: 2.57889498528e+06
-  dtps: 21754.27561
+  dps: 416595.92352
+  tps: 2.55669007431e+06
+  dtps: 22826.88851
  }
 }
 dps_results: {
@@ -873,9 +873,9 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Gong-Lu,StrengthofXuen-102249"
  value: {
-  dps: 436784.77199
-  tps: 2.68415023278e+06
-  dtps: 20855.62563
+  dps: 434397.07639
+  tps: 2.66848073799e+06
+  dtps: 21064.98696
  }
 }
 dps_results: {


### PR DESCRIPTION
Flurry of Xuen (legendary cloak proc) was registered with `ProcMaskEmpty`, so its hits couldn't feed any proc effects. This gives it a proper proc mask - `ProcMaskRangedProc` for hunters (149276), `ProcMaskMeleeProc` for everyone else (147891) - the same `core.Ternary` pattern the Capacitive Primal Diamond Lightning Strike spell already uses.

Verified against classic log [zNGtmV9dwb6Qg1xR](https://classic.warcraftlogs.com/reports/zNGtmV9dwb6Qg1xR): Flurry of Xuen is the **largest single trigger of Haromm's Talisman Multistrike** - 471 of 1,584 Multistrike procs (~30%) for a BM hunter across 9 boss kills, ~10% for a rogue and ~17% for a feral druid in the same log. Multistrike damage is exactly 1/3 of the triggering hit, which makes attribution unambiguous.

### Example events (Multistrike lands ≤50ms after a FoX hit for exactly 1/3 its damage)

Hunter (Bååge, FoX 149276 -> Multistrike 146069, Iron Juggernaut):
- FoX crit 74,290 -> MS 24,763: [events link](https://classic.warcraftlogs.com/reports/zNGtmV9dwb6Qg1xR?fight=13&type=damage-done&view=events&source=33&start=2410148&end=2412171)
- FoX hit 23,864 -> MS 7,954: [events link](https://classic.warcraftlogs.com/reports/zNGtmV9dwb6Qg1xR?fight=13&type=damage-done&view=events&source=33&start=2420235&end=2422236)
- FoX hit 13,702 -> MS 4,567: [events link](https://classic.warcraftlogs.com/reports/zNGtmV9dwb6Qg1xR?fight=13&type=damage-done&view=events&source=33&start=2429587&end=2431611)

Rogue (Subsloth, melee FoX 147891 -> Multistrike 146061, same fight):
- FoX 50,988 -> MS 16,996: [events link](https://classic.warcraftlogs.com/reports/zNGtmV9dwb6Qg1xR?fight=13&type=damage-done&view=events&source=28&start=2405994&end=2408031)
- FoX 68,628 -> MS 22,876: [events link](https://classic.warcraftlogs.com/reports/zNGtmV9dwb6Qg1xR?fight=13&type=damage-done&view=events&source=28&start=2408085&end=2410106)

Feral Druid (Thüm, melee FoX 147891 -> Multistrike 146061, same fight):
- FoX 67,564 -> MS 22,522: [events link](https://classic.warcraftlogs.com/reports/zNGtmV9dwb6Qg1xR?fight=13&type=damage-done&view=events&source=25&start=2413732&end=2415757)
- FoX 16,974 -> MS 5,658: [events link](https://classic.warcraftlogs.com/reports/zNGtmV9dwb6Qg1xR?fight=13&type=damage-done&view=events&source=25&start=2419999&end=2422048)

The log also shows FoX feeding RPPM/ICD stat procs (Vicious, Dextrous, Capacitance stacks - all with exclusive-window attributions), which the new mask now allows; those are RPPM/ICD-governed so their rates barely move.

