### PR TITLE
Fix reforger double-counting amplification trinket for Unholy/Frost

### DIFF
--- a/ui/death_knight/frost/sim.ts
+++ b/ui/death_knight/frost/sim.ts
@@ -176,11 +176,16 @@ export class FrostDeathKnightSimUI extends IndividualSimUI<Spec.SpecFrostDeathKn
 			},
 			getEPDefaults: (player: Player<Spec.SpecFrostDeathKnight>) => {
 				const mainHand = player.getEquippedItem(ItemSlot.ItemSlotMainHand);
-				if (mainHand?.item?.handType === HandType.HandTypeTwoHand) {
-					return Presets.TWOHAND_OBLITERATE_EP_PRESET.epWeights;
-				} else {
-					return Presets.MASTERFROST_EP_PRESET.epWeights;
-				}
+				let epWeights =
+					mainHand?.item?.handType === HandType.HandTypeTwoHand
+						? Presets.TWOHAND_OBLITERATE_EP_PRESET.epWeights
+						: Presets.MASTERFROST_EP_PRESET.epWeights;
+
+				const ampModifier = player.getTotalAmplificationTrinketStatModifier();
+				epWeights = epWeights
+					.withStat(Stat.StatHasteRating, epWeights.getStat(Stat.StatHasteRating) / ampModifier)
+					.withStat(Stat.StatMasteryRating, epWeights.getStat(Stat.StatMasteryRating) / ampModifier);
+				return epWeights;
 			},
 		});
 	}

--- a/ui/death_knight/unholy/sim.ts
+++ b/ui/death_knight/unholy/sim.ts
@@ -142,6 +142,16 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecUnholyDeathKnight, {
 export class UnholyDeathKnightSimUI extends IndividualSimUI<Spec.SpecUnholyDeathKnight> {
 	constructor(parentElem: HTMLElement, player: Player<Spec.SpecUnholyDeathKnight>) {
 		super(parentElem, player, SPEC_CONFIG);
-		this.reforger = new ReforgeOptimizer(this);
+		this.reforger = new ReforgeOptimizer(this, {
+			getEPDefaults: player => {
+				let epWeights = player.getEpWeights();
+
+				const ampModifier = player.getTotalAmplificationTrinketStatModifier();
+				epWeights = epWeights
+					.withStat(Stat.StatHasteRating, epWeights.getStat(Stat.StatHasteRating) / ampModifier)
+					.withStat(Stat.StatMasteryRating, epWeights.getStat(Stat.StatMasteryRating) / ampModifier);
+				return epWeights;
+			},
+		});
 	}
 }


### PR DESCRIPTION
The ReforgeOptimizer multiplies haste/mastery EP by the amplification trinket modifier, but Unholy EP weights already include it when sourced from stat weight runs with the trinket equipped (as in the P5 defaults, whose gear set includes Thok's Tail Tip). With haste EP close behind crit, the extra ~8.5% boost made the reforger wrongly prefer haste.

Add the same getEPDefaults normalization Blood and other specs use, dividing haste/mastery EP by the amp modifier so it is counted once.
Also added to Frost.