### PR TITLE
Fix gear filter i18n keys and localize fire mage combustion thresholds

### DIFF
--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -2510,5 +2510,31 @@
 		"training_dummy": "Training Dummy",
 		"seek_back": "Rewind {{time}}s",
 		"seek_fwd": "Forward {{time}}s"
+	},
+	"fire_mage": {
+		"combustion_thresholds": {
+			"button": "Calculate Combustion Thresholds",
+			"progress_title": "Calculating Combustion Thresholds",
+			"progress_warning": "Calculating combustion thresholds can be a lengthy process.",
+			"progress_cancel_hint": "You may cancel this operation at any time using the button below.",
+			"modal_title": "Combustion Thresholds",
+			"calculating": "Calculating thresholds",
+			"parsing_logs": "Parsing logs",
+			"table": {
+				"threshold": "Threshold",
+				"current": "Current",
+				"new": "New"
+			},
+			"categories": {
+				"always_send": "Combust Threshold - Always send",
+				"bloodlust": "Combust Threshold - Bloodlust",
+				"alter_time": "Combust Threshold - Alter Time",
+				"no_cds": "Combust Threshold - No CDs",
+				"end_of_combat": "Combust Threshold - End of combat"
+			},
+			"close": "Close",
+			"update": "Update Thresholds",
+			"updated_toast": "Combustion thresholds have been updated"
+		}
 	}
 }

--- a/assets/locales/fr/translation.json
+++ b/assets/locales/fr/translation.json
@@ -2511,5 +2511,31 @@
 		"training_dummy": "Mannequin d'entraînement",
 		"seek_back": "Reculer {{time}}s",
 		"seek_fwd": "Avancer {{time}}s"
+	},
+	"fire_mage": {
+		"combustion_thresholds": {
+			"button": "Calculer les seuils de Combustion",
+			"progress_title": "Calcul des seuils de Combustion",
+			"progress_warning": "Le calcul des seuils de Combustion peut prendre du temps.",
+			"progress_cancel_hint": "Vous pouvez annuler cette opération à tout moment avec le bouton ci-dessous.",
+			"modal_title": "Seuils de Combustion",
+			"calculating": "Calcul des seuils",
+			"parsing_logs": "Analyse des journaux",
+			"table": {
+				"threshold": "Seuil",
+				"current": "Actuel",
+				"new": "Nouveau"
+			},
+			"categories": {
+				"always_send": "Seuil de Combustion - Toujours lancer",
+				"bloodlust": "Seuil de Combustion - Furie sanguinaire",
+				"alter_time": "Seuil de Combustion - Alteration du temps",
+				"no_cds": "Seuil de Combustion - Sans CDs",
+				"end_of_combat": "Seuil de Combustion - Fin de combat"
+			},
+			"close": "Fermer",
+			"update": "Mettre à jour les seuils",
+			"updated_toast": "Les seuils de Combustion ont été mis à jour"
+		}
 	}
 }

--- a/schemas/translation.schema.json
+++ b/schemas/translation.schema.json
@@ -8838,6 +8838,101 @@
 			},
 			"additionalProperties": false,
 			"required": ["empty_title", "empty_desc", "default_player", "training_dummy", "seek_back", "seek_fwd"]
+		},
+		"fire_mage": {
+			"type": "object",
+			"properties": {
+				"combustion_thresholds": {
+					"type": "object",
+					"properties": {
+						"button": {
+							"type": "string"
+						},
+						"progress_title": {
+							"type": "string"
+						},
+						"progress_warning": {
+							"type": "string"
+						},
+						"progress_cancel_hint": {
+							"type": "string"
+						},
+						"modal_title": {
+							"type": "string"
+						},
+						"calculating": {
+							"type": "string"
+						},
+						"parsing_logs": {
+							"type": "string"
+						},
+						"table": {
+							"type": "object",
+							"properties": {
+								"threshold": {
+									"type": "string"
+								},
+								"current": {
+									"type": "string"
+								},
+								"new": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["threshold", "current", "new"]
+						},
+						"categories": {
+							"type": "object",
+							"properties": {
+								"always_send": {
+									"type": "string"
+								},
+								"bloodlust": {
+									"type": "string"
+								},
+								"alter_time": {
+									"type": "string"
+								},
+								"no_cds": {
+									"type": "string"
+								},
+								"end_of_combat": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false,
+							"required": ["always_send", "bloodlust", "alter_time", "no_cds", "end_of_combat"]
+						},
+						"close": {
+							"type": "string"
+						},
+						"update": {
+							"type": "string"
+						},
+						"updated_toast": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false,
+					"required": [
+						"button",
+						"progress_title",
+						"progress_warning",
+						"progress_cancel_hint",
+						"modal_title",
+						"calculating",
+						"parsing_logs",
+						"table",
+						"categories",
+						"close",
+						"update",
+						"updated_toast"
+					]
+				}
+			},
+			"additionalProperties": false,
+			"required": ["combustion_thresholds"]
 		}
 	},
 	"additionalProperties": false,
@@ -8855,7 +8950,8 @@
 		"export",
 		"info",
 		"sidebar",
-		"combat_replay"
+		"combat_replay",
+		"fire_mage"
 	],
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "Generated Schema",

--- a/ui/core/components/gear_picker/filters_menu.tsx
+++ b/ui/core/components/gear_picker/filters_menu.tsx
@@ -239,7 +239,7 @@ export class FiltersMenu extends BaseModal {
 			if (rangedweapontypes.length < 1) {
 				return;
 			}
-			const rangedWeaponTypeSection = this.newSection(i18n.t('gear_tab.gear_picker.filters.ranged_weapon_type'));
+			const rangedWeaponTypeSection = this.newSection(i18n.t('gear_tab.gear_picker.ranged_weapon_type'));
 			rangedWeaponTypeSection.classList.add('filters-menu-section-bool-list');
 
 			rangedweapontypes.forEach(rangedWeaponType => {
@@ -261,11 +261,11 @@ export class FiltersMenu extends BaseModal {
 				});
 			});
 
-			const rangedWeaponSpeedSection = this.newSection(i18n.t('gear_tab.gear_picker.filters.ranged_weapon_speed'));
+			const rangedWeaponSpeedSection = this.newSection(i18n.t('gear_tab.gear_picker.ranged_weapon_speed'));
 			rangedWeaponSpeedSection.classList.add('filters-menu-section-number-list');
 			new NumberPicker<Sim>(rangedWeaponSpeedSection, player.sim, {
 				id: 'filters-min-ranged-weapon-speed',
-				label: i18n.t('gear_tab.gear_picker.filters.min_ranged_speed'),
+				label: i18n.t('gear_tab.gear_picker.min_ranged_speed'),
 				//labelTooltip: 'Maximum speed for the ranged weapon. If 0, no maximum value is applied.',
 				float: true,
 				positive: true,
@@ -279,7 +279,7 @@ export class FiltersMenu extends BaseModal {
 			});
 			new NumberPicker<Sim>(rangedWeaponSpeedSection, player.sim, {
 				id: 'filters-max-ranged-weapon-speed',
-				label: i18n.t('gear_tab.gear_picker.filters.max_ranged_speed'),
+				label: i18n.t('gear_tab.gear_picker.max_ranged_speed'),
 				//labelTooltip: 'Maximum speed for the ranged weapon. If 0, no maximum value is applied.',
 				float: true,
 				positive: true,

--- a/ui/mage/fire/calculate_combustion_thresholds.tsx
+++ b/ui/mage/fire/calculate_combustion_thresholds.tsx
@@ -56,12 +56,12 @@ export class CalculateCombustionThresholds extends Component {
 
 		this.progressTrackerModal = new ProgressTrackerModal(simUI.rootElem, {
 			id: 'combustion-thresholds-progress-tracker',
-			title: 'Calculating Combustion Thresholds',
+			title: i18n.t('fire_mage.combustion_thresholds.progress_title'),
 			hasProgressBar: true,
 			warning: (
 				<>
-					<p>Calculating combustion thresholds can be a lengthy process.</p>
-					<p className="mb-0">You may cancel this operation at any time using the button below.</p>
+					<p>{i18n.t('fire_mage.combustion_thresholds.progress_warning')}</p>
+					<p className="mb-0">{i18n.t('fire_mage.combustion_thresholds.progress_cancel_hint')}</p>
 				</>
 			),
 			onCancel: () => {
@@ -69,7 +69,7 @@ export class CalculateCombustionThresholds extends Component {
 			},
 		});
 
-		this.button = this.simUI.addAction('Calculate Combustion Thresholds', 'mage-calculate-combustion-threshold-group', async () => {
+		this.button = this.simUI.addAction(i18n.t('fire_mage.combustion_thresholds.button'), 'mage-calculate-combustion-threshold-group', async () => {
 			if (this.isRunning) return;
 
 			this.isRunning = true;
@@ -86,7 +86,7 @@ export class CalculateCombustionThresholds extends Component {
 		});
 
 		this.modal = new BaseModal(this.rootElem, clsx('combustion-thresholds-modal'), {
-			title: 'Combustion Thresholds',
+			title: i18n.t('fire_mage.combustion_thresholds.modal_title'),
 			disposeOnClose: false,
 			preventClose: true,
 			size: 'md',
@@ -193,7 +193,7 @@ export class CalculateCombustionThresholds extends Component {
 
 		this.progressTrackerModal.updateProgress({
 			stage: 'calculating',
-			message: 'Calculating thresholds',
+			message: i18n.t('fire_mage.combustion_thresholds.calculating'),
 		});
 
 		const combined = this.toCombustionStats(combinedCategoryValues);
@@ -207,7 +207,7 @@ export class CalculateCombustionThresholds extends Component {
 	private async parseLogs(logs: string[]): Promise<SimLog[]> {
 		this.progressTrackerModal.updateProgress({
 			stage: 'calculating',
-			message: `Parsing logs`,
+			message: i18n.t('fire_mage.combustion_thresholds.parsing_logs'),
 		});
 		await sleep(200);
 		return logs
@@ -422,11 +422,11 @@ export class CalculateCombustionThresholds extends Component {
 
 	private render(data: CombustionAnalysisResult) {
 		const categoryEntries: Record<keyof FireMage_Rotation, string> = {
-			combustAlwaysSend: 'Combust Threshold - Always send',
-			combustBloodlust: 'Combust Threshold - Bloodlust',
-			combustPostAlter: 'Combust Threshold - Alter Time',
-			combustNoAlter: 'Combust Threshold - No CDs',
-			combustEndOfCombat: 'Combust Threshold - End of combat',
+			combustAlwaysSend: i18n.t('fire_mage.combustion_thresholds.categories.always_send'),
+			combustBloodlust: i18n.t('fire_mage.combustion_thresholds.categories.bloodlust'),
+			combustPostAlter: i18n.t('fire_mage.combustion_thresholds.categories.alter_time'),
+			combustNoAlter: i18n.t('fire_mage.combustion_thresholds.categories.no_cds'),
+			combustEndOfCombat: i18n.t('fire_mage.combustion_thresholds.categories.end_of_combat'),
 		};
 
 		const numberFormatter = (value: number) => Math.round(value);
@@ -445,7 +445,7 @@ export class CalculateCombustionThresholds extends Component {
 			this.modal.close();
 			new Toast({
 				variant: 'success',
-				body: 'Combustion thresholds have been updated',
+				body: i18n.t('fire_mage.combustion_thresholds.updated_toast'),
 			});
 		};
 
@@ -456,10 +456,10 @@ export class CalculateCombustionThresholds extends Component {
 						<table>
 							<thead>
 								<tr>
-									<th>Threshold</th>
-									<th>Current</th>
+									<th>{i18n.t('fire_mage.combustion_thresholds.table.threshold')}</th>
+									<th>{i18n.t('fire_mage.combustion_thresholds.table.current')}</th>
 									<th></th>
-									<th>New</th>
+									<th>{i18n.t('fire_mage.combustion_thresholds.table.new')}</th>
 								</tr>
 							</thead>
 							<tbody>
@@ -479,10 +479,10 @@ export class CalculateCombustionThresholds extends Component {
 					</div>
 					<div className="d-flex justify-content-end w-100 gap-3">
 						<button onclick={() => this.modal.close()} className={clsx('btn btn-outline-primary')}>
-							Close
+							{i18n.t('fire_mage.combustion_thresholds.close')}
 						</button>
 						<button onclick={updateValues} className={clsx('btn btn-primary')}>
-							Update Thresholds
+							{i18n.t('fire_mage.combustion_thresholds.update')}
 						</button>
 					</div>
 				</>


### PR DESCRIPTION
## Summary
- Fix ranged weapon filter labels in the gear picker Filters modal: they looked up `gear_tab.gear_picker.filters.ranged_*` keys that do not exist (strings already live at `gear_tab.gear_picker.ranged_*`, matching melee weapon speed keys).
- Localize the Fire Mage **Calculate Combustion Thresholds** action, progress tracker, and results modal (en + fr), and extend `translation.schema.json` accordingly.

## Test plan
- [ ] Open a caster Filters modal (e.g. Mage) and confirm ranged weapon type/speed labels resolve instead of showing raw i18n keys
- [ ] On Fire Mage, click **Calculate Combustion Thresholds** and confirm button/progress/result modal strings are localized in EN and FR
- [ ] `npm run test:locales` / schema validation passes for `en` and `fr`


Made with [Cursor](https://cursor.com)