### PR TITLE
Harden pending-action queue against empty Step() panic

### DIFF
--- a/sim/core/pending_action.go
+++ b/sim/core/pending_action.go
@@ -45,6 +45,11 @@ func (pa *PendingAction) IsConsumed() bool {
 }
 
 func (pa *PendingAction) Cancel(sim *Simulation) {
+	// The event loop keeps a shared sentinel at pendingActions[0]. Cancelling it
+	// empties or corrupts the queue and the next Step() panics with index [-1].
+	if pa == nil || pa == sentinelPendingAction {
+		return
+	}
 	if pa.cancelled {
 		return
 	}

--- a/sim/core/pending_action_test.go
+++ b/sim/core/pending_action_test.go
@@ -1,0 +1,42 @@
+package core
+
+import "testing"
+
+func TestCancelDoesNotRemoveSentinel(t *testing.T) {
+	sim := &Simulation{
+		pendingActions: []*PendingAction{sentinelPendingAction},
+	}
+
+	sentinelPendingAction.Cancel(sim)
+
+	if len(sim.pendingActions) != 1 || sim.pendingActions[0] != sentinelPendingAction {
+		t.Fatalf("Cancel removed the sentinel from pendingActions")
+	}
+	if sentinelPendingAction.cancelled {
+		t.Fatalf("Cancel marked the sentinel cancelled")
+	}
+}
+
+func TestStepEmptyQueueEndsIteration(t *testing.T) {
+	sim := &Simulation{}
+	if !sim.Step() {
+		t.Fatal("Step on an empty pendingActions queue should end the iteration")
+	}
+}
+
+func TestAddPendingActionRestoresSentinel(t *testing.T) {
+	sim := &Simulation{}
+	pa := &PendingAction{OnAction: func(*Simulation) {}}
+
+	sim.AddPendingAction(pa)
+
+	if len(sim.pendingActions) != 2 {
+		t.Fatalf("expected [sentinel, pa], got len=%d", len(sim.pendingActions))
+	}
+	if sim.pendingActions[0] != sentinelPendingAction {
+		t.Fatal("AddPendingAction did not restore the sentinel at index 0")
+	}
+	if sim.pendingActions[1] != pa {
+		t.Fatal("AddPendingAction did not append the new action")
+	}
+}

--- a/sim/core/sim.go
+++ b/sim/core/sim.go
@@ -387,12 +387,14 @@ func (sim *Simulation) runOnce(firstIteration bool) {
 	sim.Cleanup()
 }
 
+func sentinelOnAction(sim *Simulation) {
+	panic("running sentinel pending action")
+}
+
 var (
 	sentinelPendingAction = &PendingAction{
 		NextActionAt: NeverExpires,
-		OnAction: func(sim *Simulation) {
-			panic("running sentinel pending action")
-		},
+		OnAction:     sentinelOnAction,
 	}
 )
 
@@ -409,6 +411,12 @@ func (sim *Simulation) reset(firstIteration bool) {
 		sim.Duration += time.Duration(sim.RandomFloat("sim duration")*float64(variation)) - sim.DurationVariation
 	}
 
+	// The sentinel is a process-wide singleton; reset fields in case a prior
+	// iteration mutated them (shared across concurrent sims as well).
+	sentinelPendingAction.cancelled = false
+	sentinelPendingAction.consumed = false
+	sentinelPendingAction.NextActionAt = NeverExpires
+	sentinelPendingAction.OnAction = sentinelOnAction
 	sim.pendingActions = sim.pendingActions[:0]
 	sim.pendingActions = append(sim.pendingActions, sentinelPendingAction)
 
@@ -511,6 +519,9 @@ func (sim *Simulation) runPendingActions() {
 }
 
 func (sim *Simulation) Step() bool {
+	if len(sim.pendingActions) == 0 {
+		return true
+	}
 	last := len(sim.pendingActions) - 1
 	pa := sim.pendingActions[last]
 
@@ -641,6 +652,9 @@ func (sim *Simulation) AddPendingAction(pa *PendingAction) {
 	//if pa.NextActionAt < sim.CurrentTime {
 	//	panic(fmt.Sprintf("Cant add action in the past: %s", pa.NextActionAt))
 	//}
+	if len(sim.pendingActions) == 0 {
+		sim.pendingActions = append(sim.pendingActions, sentinelPendingAction)
+	}
 	pa.consumed = false
 	for index, v := range sim.pendingActions[1:] {
 		if v.NextActionAt < pa.NextActionAt || (v.NextActionAt == pa.NextActionAt && v.Priority >= pa.Priority) {


### PR DESCRIPTION
## Summary
- Defensive fix for `runtime error: index out of range [-1]` in `Simulation.Step()` when `pendingActions` is empty (see [wowsims/mop#1528](https://github.com/wowsims/mop/issues/1528)).
- `Cancel` no longer removes or marks the shared sentinel; `reset` restores sentinel fields; `Step` ends the iteration instead of panicking on an empty queue; `AddPendingAction` reinserts the sentinel if the queue was emptied.
- Could not deterministically reproduce #1528 (Fury + Gong-Lu / Flurry of Xuen, reported seed, 7/30 APL). This is a guard around the only clean way that panic happens: the process-wide sentinel being cancelled or mutated.

## Test plan
- [x] `go test ./sim/core -run 'TestCancelDoesNotRemoveSentinel|TestStepEmptyQueueEndsIteration|TestAddPendingActionRestoresSentinel'`
- [ ] Colleague review: is ending the iteration on an empty queue acceptable vs. re-adding the sentinel and continuing?
- [ ] Optional: re-run the #1528 share link (Fury, seed `4261074462`) after merge


Made with [Cursor](https://cursor.com)