### PR TITLE
Add hardened production Docker deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,13 @@
 .git
 coverage
 node_modules
+.history
+
+# Build artifacts — must be regenerated inside the image, never copied from host
+dist
+binary_dist
+wowsimmop
+wowsimmop-*
+*.so
+*.dll
+*.wasm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,80 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.25
+##############################################################################
+# build — heavy toolchain (Go + Node + protoc). Compiles the WASM, builds the
+# Vite client, embeds it into the Go binary, and produces a single fully-static
+# `wowsimmop` executable. Used only to feed the `prod` stage below.
+#
+#   docker build --target prod -t wowsimmop .
+##############################################################################
+FROM golang:1.25 AS build
+
+# Several makefile recipes rely on bash features, so make `sh` point at bash.
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+
+# Build the server as a 100% static binary so the runtime image can be scratch.
+ENV CGO_ENABLED=0
+
+# protoc (Go proto gen) — the TS proto gen + Vite build come from node_modules.
+# libprotobuf-dev provides the well-known protos (google/protobuf/descriptor.proto)
+# that common.proto imports; protobuf-compiler only *recommends* it, so with
+# --no-install-recommends it must be named explicitly.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev ca-certificates curl xz-utils \
+ && rm -rf /var/lib/apt/lists/*
+
+# Node, matching .nvmrc, installed from the official static tarball.
+ENV NODE_VERSION=22.17.1
+RUN curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" -o /tmp/node.tar.xz \
+ && tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1 \
+ && rm /tmp/node.tar.xz \
+ && node --version && npm --version
+
+# protoc-gen-go plugin used by `make proto`.
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+ENV PATH="/go/bin:${PATH}"
+
+WORKDIR /src
+
+# Dependency layers first, so they cache across source-only changes.
+COPY go.mod go.sum ./
+RUN go mod download
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Build everything: proto -> wasm + client bundle -> embed -> static server.
+COPY . .
+RUN make wowsimmop
+
+##############################################################################
+# prod — production runtime. Empty base image: only the static binary, no
+# shell, no package manager, nothing to exec into. The app is stateless and
+# serves its client from files embedded in the binary, so no files are read
+# from disk. See docker-compose.yml for the hardened deployment.
+##############################################################################
+FROM scratch AS prod
+
+# Run as an unprivileged numeric UID/GID. scratch has no /etc/passwd, but the
+# kernel only needs the numeric ids — the binary touches no files it must own.
+USER 10001:10001
+
+COPY --from=build /src/wowsimmop /wowsimmop
+
+EXPOSE 8080
+
+ENTRYPOINT ["/wowsimmop"]
+# --usefs=false  serve the embedded client (not from disk)
+# --launch=false don't try to open a browser
+# --nvc          skip the outbound GitHub version check (no egress / no CA certs)
+# --host=:8080   listen on all interfaces inside the container network
+CMD ["--usefs=false", "--launch=false", "--nvc", "--host=:8080"]
+
+##############################################################################
+# dev — local development environment (live reload via air + Vite). This is
+# the DEFAULT target, so the existing `docker build -t wowsims-mop .` workflow
+# is unchanged.
+##############################################################################
+FROM golang:1.25 AS dev
 
 WORKDIR /mop
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+# Production deployment for the MoP sim.
+#
+#   docker compose up -d        # build + start
+#   ./upgrade.sh                # pull, rebuild, restart
+#
+# TLS/HTTPS is expected to be handled by a reverse proxy on the host (e.g.
+# Caddy or nginx) forwarding to 127.0.0.1:18791. This container is bound to
+# localhost only, so nothing reaches the sim except the proxy on the same host.
+#
+# The sim is stateless: no volume needed, runs fully read-only.
+
+services:
+  sim:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: prod
+    image: wowsimmop:local
+    restart: unless-stopped
+    # The server exits cleanly on SIGINT (its only handled signal).
+    stop_signal: SIGINT
+    stop_grace_period: 10s
+
+    # --- hardening ---------------------------------------------------------
+    read_only: true            # no writable layer; app writes nothing to disk
+    tmpfs:
+      - /tmp                   # only scratch space the Go runtime might want
+    cap_drop:
+      - ALL                    # binds 8080 as non-root, needs no capabilities
+    security_opt:
+      - no-new-privileges:true
+    # -----------------------------------------------------------------------
+
+    # Published on the loopback interface only — reachable by the host's
+    # reverse proxy, never on the LAN/VPN/internet directly.
+    ports:
+      - "127.0.0.1:18791:8080"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Upgrade the MoP sim in place: pull latest source, rebuild the sim image, and
+# restart the stack. The app is stateless, so there is nothing to back up.
+#
+# The old container keeps serving while the new image builds; downtime is just
+# the few seconds of the container swap.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+# Check the sim directly on its loopback port (TLS is terminated upstream by
+# the host's reverse proxy, which we don't touch during an app upgrade).
+HEALTH_URL="http://127.0.0.1:18791/version"
+
+echo "==> Pulling latest source..."
+git pull --ff-only
+
+echo "==> Building sim image..."
+docker compose build sim
+
+echo "==> Restarting stack..."
+docker compose up -d
+
+echo "==> Pruning dangling images..."
+docker image prune -f
+
+echo "==> Waiting for the sim to come back..."
+for _ in $(seq 1 30); do
+	if curl -fsS "$HEALTH_URL" >/dev/null 2>&1; then
+		echo "==> Healthy: $(curl -fsS "$HEALTH_URL")"
+		exit 0
+	fi
+	sleep 2
+done
+
+echo "!! Sim did not respond at ${HEALTH_URL} within ~60s." >&2
+echo "   Check logs:  docker compose logs --tail=50" >&2
+exit 1


### PR DESCRIPTION
Port of wowsims/tbc-new#382 (devsecops) to MoP.

- **Multi-stage Dockerfile**: `build` stage compiles a fully static `wowsimmop` binary (CGO disabled, Node from the official tarball matching `.nvmrc`, protoc + protoc-gen-go); `prod` stage is a `scratch` image containing only the binary, running as an unprivileged numeric UID with no shell or package manager. The existing dev image is kept verbatim as the default `dev` target, so the current `docker build` workflow is unchanged.
- **docker-compose.yml**: runs the prod image read-only with all capabilities dropped, `no-new-privileges`, and published on loopback only (`127.0.0.1:18791`) for a host reverse proxy to front.
- **upgrade.sh**: pull → rebuild → restart with a health check against `/version`.
- **.dockerignore**: excludes build artifacts and `.history` from the build context.

Verified: `docker build --target prod` succeeds from a clean context and the resulting container answers `/version`.