### PR TITLE
Fix/apl timeline cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
 				"i18next-http-backend": "^3.0.2",
 				"idb": "^8.0.3",
 				"pako": "^2.0.4",
+				"shallow-equal": "^3.1.0",
 				"tippy.js": "^6.3.7",
 				"tsx-vanilla": "^1.2.0",
 				"uuid": "^11.1.0"
@@ -6112,6 +6113,12 @@
 			"resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
 			"integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/shallow-equal": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-3.1.0.tgz",
+			"integrity": "sha512-pfVOw8QZIXpMbhBWvzBISicvToTiM5WBF1EeAUZDDSb5Dt29yl4AYbyywbJFSEsRUMr7gJaxqCdr4L3tQf9wVg==",
 			"license": "MIT"
 		},
 		"node_modules/shebang-command": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
 		"i18next-http-backend": "^3.0.2",
 		"idb": "^8.0.3",
 		"pako": "^2.0.4",
+		"shallow-equal": "^3.1.0",
 		"tippy.js": "^6.3.7",
 		"tsx-vanilla": "^1.2.0",
 		"uuid": "^11.1.0"

--- a/ui/core/components/component.ts
+++ b/ui/core/components/component.ts
@@ -25,6 +25,13 @@ export abstract class Component {
 		return child;
 	}
 
+	// Disposes a registered child ahead of this component's own disposal.
+	disposeChild(child: Component) {
+		const idx = this.children.indexOf(child);
+		if (idx >= 0) this.children.splice(idx, 1);
+		child.dispose();
+	}
+
 	protected get isDisposed(): boolean {
 		return this.disposed;
 	}

--- a/ui/core/components/component.ts
+++ b/ui/core/components/component.ts
@@ -3,6 +3,8 @@ export abstract class Component {
 
 	private disposeCallbacks: Array<() => void> = [];
 	private disposed = false;
+	// Child components disposed together with this one (cascade before own callbacks).
+	protected readonly children: Array<Component> = [];
 
 	readonly rootElem: HTMLElement;
 
@@ -18,12 +20,22 @@ export abstract class Component {
 		this.disposeCallbacks.push(callback);
 	}
 
+	addChild<C extends Component>(child: C): C {
+		this.children.push(child);
+		return child;
+	}
+
+	protected get isDisposed(): boolean {
+		return this.disposed;
+	}
+
 	dispose() {
 		if (this.disposed) {
 			return;
 		}
 		this.disposed = true;
 
+		this.children.splice(0).forEach(child => child.dispose());
 		this.disposeCallbacks.forEach(callback => callback());
 		this.disposeCallbacks = [];
 	}

--- a/ui/core/components/component.ts
+++ b/ui/core/components/component.ts
@@ -4,7 +4,7 @@ export abstract class Component {
 	private disposeCallbacks: Array<() => void> = [];
 	private disposed = false;
 	// Child components disposed together with this one (cascade before own callbacks).
-	protected readonly children: Array<Component> = [];
+	private readonly children: Array<Component> = [];
 
 	readonly rootElem: HTMLElement;
 
@@ -30,6 +30,12 @@ export abstract class Component {
 		const idx = this.children.indexOf(child);
 		if (idx >= 0) this.children.splice(idx, 1);
 		child.dispose();
+	}
+
+	// Disposes a registered child and removes its root element from the DOM.
+	removeChild(child: Component) {
+		this.disposeChild(child);
+		child.rootElem.remove();
 	}
 
 	protected get isDisposed(): boolean {

--- a/ui/core/components/detailed_results/timeline.tsx
+++ b/ui/core/components/detailed_results/timeline.tsx
@@ -33,6 +33,9 @@ interface TimelineConfig extends ResultComponentConfig {
 
 interface RotationSlot {
 	key: string;
+	// True for a single-player result (rotation chart available); false for a
+	// multi-player one, whose slot only caches the plot options.
+	rotation: boolean;
 	labels: Array<Node>;
 	timeline: Array<Node>;
 	hiddenIdsNodes: Array<Node>;
@@ -61,7 +64,9 @@ export class Timeline extends ResultComponent {
 	// slot's reset callbacks (tooltip destroy, listener removal).
 	private liveSlot: RotationSlot | null = null;
 	private cachedSlots: Array<RotationSlot> = [];
-	private static readonly MAX_CACHED_SLOTS = 2;
+	// One parked slot covers the current <-> reference swap; each parked slot keeps
+	// its full tippy instance set alive, so don't hold more than needed.
+	private static readonly MAX_CACHED_SLOTS = 1;
 
 	private hiddenIds: Array<ActionId>;
 
@@ -199,9 +204,17 @@ export class Timeline extends ResultComponent {
 			return;
 		}
 
-		// Fast path: this (result, filter, chart) was rendered before and its live
-		// subtree is either on screen or parked in the cache.
-		const key = this.resultKey();
+		const players = this.resultData.result.getRaidIndexedPlayers(this.resultData.filter);
+		const singlePlayer = players.length == 1;
+		if (!singlePlayer && this.chartPicker.value == 'rotation') {
+			// Programmatic select changes fire no 'change' event: sync the plot containers by hand.
+			this.chartPicker.value = 'dps';
+			this.onChartPickerSelectHandler();
+		}
+
+		// Fast path: this result was rendered before and its slot is either live
+		// or parked in the cache.
+		const key = this.resultKey(!singlePlayer);
 		const hit = this.liveSlot?.key === key ? this.liveSlot : this.cachedSlots.find(slot => slot.key === key);
 		if (hit?.plotOptions) {
 			if (hit !== this.liveSlot) {
@@ -209,7 +222,7 @@ export class Timeline extends ResultComponent {
 				this.stashLiveSlot();
 				this.attachSlot(hit);
 			}
-			this.setRotationOptionVisible(true);
+			this.setRotationOptionVisible(hit.rotation);
 			this.dpsResourcesPlot.updateOptions(hit.plotOptions);
 			return;
 		}
@@ -263,8 +276,7 @@ export class Timeline extends ResultComponent {
 			},
 		};
 
-		const players = this.resultData!.result.getRaidIndexedPlayers(this.resultData!.filter);
-		if (players.length == 1) {
+		if (singlePlayer) {
 			const player = players[0];
 
 			this.setRotationOptionVisible(true);
@@ -283,16 +295,13 @@ export class Timeline extends ResultComponent {
 			tooltipHandlers = tooltipHandlers.filter(handler => !!handler);
 
 			this.addMajorCooldownAnnotations(player, options);
-			if (this.liveSlot && this.liveSlot.key === key) this.liveSlot.plotOptions = options;
 		} else {
-			if (this.chartPicker.value == 'rotation') {
-				this.chartPicker.value = 'dps';
-				return;
-			}
 			this.setRotationOptionVisible(false);
 
 			this.stashLiveSlot();
 			this.clearRotationChart();
+			// No rotation subtree, but the (expensive) per-player series are worth caching for swaps.
+			this.liveSlot = Timeline.newSlot(key, false);
 
 			if (this.chartPicker.value == 'dps') {
 				let maxDps = 0;
@@ -313,8 +322,8 @@ export class Timeline extends ResultComponent {
 			}
 		}
 
+		if (this.liveSlot?.key === key) this.liveSlot.plotOptions = options;
 		this.dpsResourcesPlot.updateOptions(options);
-
 	}
 
 	private addDpsYAxis(maxDps: number, options: any) {
@@ -526,10 +535,9 @@ export class Timeline extends ResultComponent {
 
 	private clearRotationChart() {
 		this.rotationLabels.replaceChildren(<div className="rotation-label-header"></div>);
-		const canvasRef = ref<HTMLCanvasElement>();
 		this.rotationTimeline.replaceChildren(
 			<div className="rotation-timeline-header">
-				<canvas ref={canvasRef} className="rotation-timeline-canvas" />
+				<canvas className="rotation-timeline-canvas" />
 			</div>,
 		);
 		this.rotationHiddenIdsContainer.replaceChildren();
@@ -545,13 +553,14 @@ export class Timeline extends ResultComponent {
 		if (this.liveSlot?.key === key) {
 			return;
 		}
-		this.stashLiveSlot();
+		// Take before stashing so the stash's eviction can't drop the slot we want.
 		const cached = this.takeCachedSlot(key);
+		this.stashLiveSlot();
 		if (cached) {
 			this.attachSlot(cached);
 			return;
 		}
-		this.liveSlot = { key, labels: [], timeline: [], hiddenIdsNodes: [], emitter: new TypedEvent<void>(), resetCallbacks: [], plotOptions: null };
+		this.liveSlot = Timeline.newSlot(key, true);
 		this.clearRotationChart();
 
 		try {
@@ -610,11 +619,12 @@ export class Timeline extends ResultComponent {
 		}
 
 		// Don't add a row for buffs that were already visualized in a cast row or are prioritized.
-		const buffsToShow = buffsById.filter(auraUptimeLogs =>
-			!playerCastsByAbility.some(casts => {
-				const actionId = auraUptimeLogs[0].actionId;
-				return actionId && (casts[0].actionId!.equalsIgnoringTag(actionId) || auraAsResource.find(auraId => auraId.equals(actionId)));
-			}),
+		const buffsToShow = buffsById.filter(
+			auraUptimeLogs =>
+				!playerCastsByAbility.some(casts => {
+					const actionId = auraUptimeLogs[0].actionId;
+					return actionId && (casts[0].actionId!.equalsIgnoringTag(actionId) || auraAsResource.find(auraId => auraId.equals(actionId)));
+				}),
 		);
 		if (buffsToShow.length > 0) {
 			this.addSeparatorRow(duration);
@@ -1301,15 +1311,21 @@ export class Timeline extends ResultComponent {
 		}
 	}
 
-	private resultKey(): string {
+	// A single player's slot holds the rotation subtree plus every series, so the
+	// chart choice is irrelevant to it; multi-player options depend on the chart.
+	private resultKey(includeChart = false): string {
 		const rd = this.resultData!;
-		return [rd.result.request.requestId, JSON.stringify(rd.filter), this.chartPicker.value].join('|');
+		return [rd.result.request.requestId, JSON.stringify(rd.filter), includeChart ? this.chartPicker.value : ''].join('|');
 	}
 
 	// Single-player results offer the rotation chart; multi-player ones the threat chart.
 	private setRotationOptionVisible(visible: boolean) {
 		this.rootElem.querySelector('.rotation-option')!.classList.toggle('hide', !visible);
 		this.rootElem.querySelector('.threat-option')!.classList.toggle('hide', visible);
+	}
+
+	private static newSlot(key: string, rotation: boolean): RotationSlot {
+		return { key, rotation, labels: [], timeline: [], hiddenIdsNodes: [], emitter: new TypedEvent<void>(), resetCallbacks: [], plotOptions: null };
 	}
 
 	private takeCachedSlot(key: string): RotationSlot | null {

--- a/ui/core/components/detailed_results/timeline.tsx
+++ b/ui/core/components/detailed_results/timeline.tsx
@@ -64,7 +64,9 @@ export class Timeline extends ResultComponent {
 	// swap, and each parked slot keeps its full tippy instance set alive.
 	private parkedSlot: RotationSlot | null = null;
 
-	private hiddenIds: Array<ActionId>;
+	// Hidden rows are keyed by section (player '', pet name, target label) plus
+	// action, so ids shared across sections (e.g. main-hand Attack) hide independently.
+	private hiddenIds: Array<{ scope: string; actionId: ActionId }>;
 
 	private secondaryResource?: SecondaryResource | null;
 
@@ -610,7 +612,7 @@ export class Timeline extends ResultComponent {
 				this.addPetRow(pet.name, duration);
 				orderedResourceTypes.forEach(resourceType => this.addResourceRow(resourceType, pet.groupedResourceLogs[resourceType], duration));
 				const petCastsByAbility = this.getSortedCastsByAbility(pet);
-				petCastsByAbility.forEach(castLogs => this.addCastRow(castLogs, buffsAndDebuffsById, duration));
+				petCastsByAbility.forEach(castLogs => this.addCastRow(castLogs, buffsAndDebuffsById, duration, pet.name));
 			});
 		}
 
@@ -632,7 +634,7 @@ export class Timeline extends ResultComponent {
 			if (targetCastsByAbility.length > 0) {
 				this.addSeparatorRow(duration);
 				this.addTargetRow(target.label, duration);
-				targetCastsByAbility.forEach(castLogs => this.addCastRow(castLogs, buffsAndDebuffsById, duration));
+				targetCastsByAbility.forEach(castLogs => this.addCastRow(castLogs, buffsAndDebuffsById, duration, target.label));
 			}
 		});
 
@@ -641,7 +643,7 @@ export class Timeline extends ResultComponent {
 			if (debuffsToShow.length > 0) {
 				this.addSeparatorRow(duration);
 				this.addTargetRow(targets?.[index]?.label, duration);
-				debuffsToShow.forEach(auraUptimeLogs => this.addAuraRow(auraUptimeLogs, duration));
+				debuffsToShow.forEach(auraUptimeLogs => this.addAuraRow(auraUptimeLogs, duration, targets?.[index]?.label ?? ''));
 			}
 		});
 	}
@@ -687,8 +689,14 @@ export class Timeline extends ResultComponent {
 		return castsByAbility;
 	}
 
-	private makeLabelElem(actionId: ActionId, isHiddenLabel: boolean, isAura?: boolean): JSX.Element {
-		const labelText = idsToGroupForRotation.includes(actionId.spellId) ? actionId.baseName : actionId.name;
+	private hiddenIndex(scope: string, actionId: ActionId): number {
+		return this.hiddenIds.findIndex(hidden => hidden.scope === scope && hidden.actionId.equals(actionId));
+	}
+
+	private makeLabelElem(actionId: ActionId, isHiddenLabel: boolean, isAura: boolean, scope: string): JSX.Element {
+		const baseText = idsToGroupForRotation.includes(actionId.spellId) ? actionId.baseName : actionId.name;
+		// Hidden chips for pet/target rows name their section so two "Attack" chips are telling apart.
+		const labelText = isHiddenLabel && scope ? `${baseText} (${scope})` : baseText;
 		const labelIcon = ref<HTMLAnchorElement>();
 		const hideElem = ref<HTMLElement>();
 		const labelElem = (
@@ -698,18 +706,22 @@ export class Timeline extends ResultComponent {
 				<span className="rotation-label-text">{labelText}</span>
 			</div>
 		);
-		const onClickHandler = () => {
+		// The whole hidden chip un-hides; on the visible label only the eye hides.
+		const clickTarget = isHiddenLabel ? labelElem : hideElem.value!;
+		const onClickHandler = (event: Event) => {
+			// The spell icon keeps its own link + Wowhead tooltip.
+			if (isHiddenLabel && (event.target as Element).closest('.rotation-label-icon')) return;
 			if (isHiddenLabel) {
-				const index = this.hiddenIds.findIndex(hiddenId => hiddenId.equals(actionId));
+				const index = this.hiddenIndex(scope, actionId);
 				if (index != -1) {
 					this.hiddenIds.splice(index, 1);
 				}
 			} else {
-				this.hiddenIds.push(actionId);
+				this.hiddenIds.push({ scope, actionId });
 			}
 			this.liveSlot?.emitter.emit(TypedEvent.nextEventID());
 		};
-		hideElem.value!.addEventListener('click', onClickHandler);
+		clickTarget.addEventListener('click', onClickHandler);
 		const tooltip = tippy(hideElem.value!, {
 			theme: 'timeline-tooltip',
 			placement: 'auto-end',
@@ -717,7 +729,7 @@ export class Timeline extends ResultComponent {
 		});
 
 		const updateHidden = () => {
-			if (isHiddenLabel == Boolean(this.hiddenIds.find(hiddenId => hiddenId.equals(actionId)))) {
+			if (isHiddenLabel == (this.hiddenIndex(scope, actionId) != -1)) {
 				labelElem.classList.remove('hide');
 			} else {
 				labelElem.classList.add('hide');
@@ -729,7 +741,7 @@ export class Timeline extends ResultComponent {
 		actionId.setWowheadDataset(labelIcon.value!, { useBuffAura: isAura });
 
 		this.addOnResetCallback(() => {
-			hideElem.value?.removeEventListener('click', onClickHandler);
+			clickTarget.removeEventListener('click', onClickHandler);
 			tooltip.destroy();
 			event.dispose();
 		});
@@ -748,11 +760,11 @@ export class Timeline extends ResultComponent {
 		);
 	}
 
-	private makeRowElem(actionId: ActionId, duration: number): JSX.Element {
+	private makeRowElem(actionId: ActionId, duration: number, scope: string): JSX.Element {
 		const rowElem = this.makePlainRowElem(duration);
 
 		const updateHidden = () => {
-			if (this.hiddenIds.find(hiddenId => hiddenId.equals(actionId))) {
+			if (this.hiddenIndex(scope, actionId) != -1) {
 				rowElem.classList.add('hide');
 			} else {
 				rowElem.classList.remove('hide');
@@ -889,13 +901,13 @@ export class Timeline extends ResultComponent {
 		this.rotationTimeline.appendChild(rowElem);
 	}
 
-	private addCastRow(castLogs: Array<CastLog>, aurasById: Array<Array<AuraUptimeLog>>, duration: number) {
+	private addCastRow(castLogs: Array<CastLog>, aurasById: Array<Array<AuraUptimeLog>>, duration: number, scope = '') {
 		const actionId = castLogs[0].actionId!;
 
-		this.rotationLabels.appendChild(this.makeLabelElem(actionId, false));
-		this.rotationHiddenIdsContainer.appendChild(this.makeLabelElem(actionId, true));
+		this.rotationLabels.appendChild(this.makeLabelElem(actionId, false, false, scope));
+		this.rotationHiddenIdsContainer.appendChild(this.makeLabelElem(actionId, true, false, scope));
 
-		const rowElem = this.makeRowElem(actionId, duration);
+		const rowElem = this.makeRowElem(actionId, duration, scope);
 		castLogs.forEach(castLog => {
 			const castElem = (
 				<div
@@ -1037,12 +1049,12 @@ export class Timeline extends ResultComponent {
 		this.rotationTimeline.appendChild(rowElem);
 	}
 
-	private addAuraRow(auraUptimeLogs: Array<AuraUptimeLog>, duration: number) {
+	private addAuraRow(auraUptimeLogs: Array<AuraUptimeLog>, duration: number, scope = '') {
 		const actionId = auraUptimeLogs[0].actionId!;
 
-		const rowElem = this.makeRowElem(actionId, duration);
-		this.rotationLabels.appendChild(this.makeLabelElem(actionId, false, true));
-		this.rotationHiddenIdsContainer.appendChild(this.makeLabelElem(actionId, true, true));
+		const rowElem = this.makeRowElem(actionId, duration, scope);
+		this.rotationLabels.appendChild(this.makeLabelElem(actionId, false, true, scope));
+		this.rotationHiddenIdsContainer.appendChild(this.makeLabelElem(actionId, true, true, scope));
 		this.rotationTimeline.appendChild(rowElem);
 
 		this.applyAuraUptimeLogsToRow(auraUptimeLogs, rowElem, false);

--- a/ui/core/components/detailed_results/timeline.tsx
+++ b/ui/core/components/detailed_results/timeline.tsx
@@ -737,14 +737,19 @@ export class Timeline extends ResultComponent {
 		return labelElem;
 	}
 
-	private makeRowElem(actionId: ActionId, duration: number): JSX.Element {
-		const rowElem = (
+	// A timeline row that is never hidden (section headers: pet name, target name).
+	private makePlainRowElem(duration: number): JSX.Element {
+		return (
 			<div
 				className="rotation-timeline-row rotation-row"
 				style={{
 					width: this.timeToPx(duration),
 				}}></div>
 		);
+	}
+
+	private makeRowElem(actionId: ActionId, duration: number): JSX.Element {
+		const rowElem = this.makePlainRowElem(duration);
 
 		const updateHidden = () => {
 			if (this.hiddenIds.find(hiddenId => hiddenId.equals(actionId))) {
@@ -761,7 +766,10 @@ export class Timeline extends ResultComponent {
 
 	private addPetRow(petName: string, duration: number) {
 		const actionId = ActionId.fromPetName(petName);
-		const rowElem = this.makeRowElem(actionId, duration);
+		// Header row: must not follow hiddenIds. fromPetName resolves to the summon
+		// spell's id, so hiding e.g. the "Dire Beast" cast row used to hide this
+		// row but not its label, shifting every row below it.
+		const rowElem = this.makePlainRowElem(duration);
 
 		const iconElem = document.createElement('div');
 		this.rotationLabels.appendChild(iconElem);
@@ -783,7 +791,7 @@ export class Timeline extends ResultComponent {
 	}
 
 	private addTargetRow(targetName: string, duration: number) {
-		const rowElem = this.makeRowElem(ActionId.fromEmpty(), duration);
+		const rowElem = this.makePlainRowElem(duration);
 		this.rotationLabels.appendChild(
 			<div>
 				<div className="rotation-label rotation-row">

--- a/ui/core/components/detailed_results/timeline.tsx
+++ b/ui/core/components/detailed_results/timeline.tsx
@@ -36,7 +36,6 @@ interface RotationSlot {
 	labels: Array<Node>;
 	timeline: Array<Node>;
 	hiddenIdsNodes: Array<Node>;
-	timeRuler: HTMLCanvasElement | null;
 	emitter: TypedEvent<void>;
 	resetCallbacks: Array<() => void>;
 	plotOptions: any | null;
@@ -49,11 +48,9 @@ export class Timeline extends ResultComponent {
 	private readonly rotationPlotElem: HTMLElement;
 	private readonly rotationLabels: HTMLElement;
 	private readonly rotationTimeline: HTMLElement;
-	private rotationTimelineTimeRulerElem: HTMLCanvasElement | null = null;
 	private readonly rotationHiddenIdsContainer: HTMLElement;
 	private readonly chartPicker: HTMLSelectElement;
 
-	private prevResultData: SimResultData | null;
 	private resultData: SimResultData | null;
 	rendered: boolean;
 
@@ -67,7 +64,6 @@ export class Timeline extends ResultComponent {
 	private static readonly MAX_CACHED_SLOTS = 2;
 
 	private hiddenIds: Array<ActionId>;
-	private hiddenIdsChangeEmitter;
 
 	private secondaryResource?: SecondaryResource | null;
 
@@ -75,10 +71,8 @@ export class Timeline extends ResultComponent {
 		config.rootCssClass = 'timeline-root';
 		super(config);
 		this.resultData = null;
-		this.prevResultData = null;
 		this.rendered = false;
 		this.hiddenIds = [];
-		this.hiddenIdsChangeEmitter = new TypedEvent<void>();
 		this.addOnDisposeCallback(() => this.reset());
 		this.secondaryResource = config.secondaryResource;
 
@@ -196,7 +190,6 @@ export class Timeline extends ResultComponent {
 	}
 
 	onSimResult(resultData: SimResultData) {
-		this.prevResultData = this.resultData;
 		this.resultData = resultData;
 		this.update();
 	}
@@ -209,20 +202,16 @@ export class Timeline extends ResultComponent {
 		// Fast path: this (result, filter, chart) was rendered before and its live
 		// subtree is either on screen or parked in the cache.
 		const key = this.resultKey();
-		const hit = this.liveSlot?.key === key ? this.liveSlot : this.takeCachedSlot(key);
-		if (hit && hit.plotOptions) {
+		const hit = this.liveSlot?.key === key ? this.liveSlot : this.cachedSlots.find(slot => slot.key === key);
+		if (hit?.plotOptions) {
 			if (hit !== this.liveSlot) {
+				this.takeCachedSlot(key);
 				this.stashLiveSlot();
 				this.attachSlot(hit);
 			}
-			this.rootElem.querySelector('.rotation-option')!.classList.remove('hide');
-			this.rootElem.querySelector('.threat-option')!.classList.add('hide');
+			this.setRotationOptionVisible(true);
 			this.dpsResourcesPlot.updateOptions(hit.plotOptions);
 			return;
-		}
-		if (hit && hit !== this.liveSlot) {
-			// Rendered subtree without cached chart options: keep it parked.
-			this.cachedSlots.push(hit);
 		}
 
 		const duration = this.resultData!.result.result.firstIterationDuration || 1;
@@ -278,10 +267,7 @@ export class Timeline extends ResultComponent {
 		if (players.length == 1) {
 			const player = players[0];
 
-			const rotationOption = this.rootElem.querySelector('.rotation-option')!;
-			rotationOption.classList.remove('hide');
-			const threatOption = this.rootElem.querySelector('.threat-option')!;
-			threatOption.classList.add('hide');
+			this.setRotationOptionVisible(true);
 
 			try {
 				this.updateRotationChart(player, duration);
@@ -303,10 +289,7 @@ export class Timeline extends ResultComponent {
 				this.chartPicker.value = 'dps';
 				return;
 			}
-			const rotationOption = this.rootElem.querySelector('.rotation-option')!;
-			rotationOption.classList.add('hide');
-			const threatOption = this.rootElem.querySelector('.threat-option')!;
-			threatOption.classList.remove('hide');
+			this.setRotationOptionVisible(false);
 
 			this.stashLiveSlot();
 			this.clearRotationChart();
@@ -549,9 +532,7 @@ export class Timeline extends ResultComponent {
 				<canvas ref={canvasRef} className="rotation-timeline-canvas" />
 			</div>,
 		);
-		this.rotationTimelineTimeRulerElem = canvasRef.value || null;
 		this.rotationHiddenIdsContainer.replaceChildren();
-		this.hiddenIdsChangeEmitter = this.liveSlot ? this.liveSlot.emitter : new TypedEvent<void>();
 	}
 
 	private updateRotationChart(player: UnitMetrics, duration: number) {
@@ -570,7 +551,7 @@ export class Timeline extends ResultComponent {
 			this.attachSlot(cached);
 			return;
 		}
-		this.liveSlot = { key, labels: [], timeline: [], hiddenIdsNodes: [], timeRuler: null, emitter: new TypedEvent<void>(), resetCallbacks: [], plotOptions: null };
+		this.liveSlot = { key, labels: [], timeline: [], hiddenIdsNodes: [], emitter: new TypedEvent<void>(), resetCallbacks: [], plotOptions: null };
 		this.clearRotationChart();
 
 		try {
@@ -720,7 +701,7 @@ export class Timeline extends ResultComponent {
 			} else {
 				this.hiddenIds.push(actionId);
 			}
-			this.hiddenIdsChangeEmitter.emit(TypedEvent.nextEventID());
+			this.liveSlot?.emitter.emit(TypedEvent.nextEventID());
 		};
 		hideElem.value!.addEventListener('click', onClickHandler);
 		const tooltip = tippy(hideElem.value!, {
@@ -736,7 +717,7 @@ export class Timeline extends ResultComponent {
 				labelElem.classList.add('hide');
 			}
 		};
-		const event = this.hiddenIdsChangeEmitter.on(updateHidden);
+		const event = this.liveSlot!.emitter.on(updateHidden);
 		updateHidden();
 		actionId.setBackgroundAndHref(labelIcon.value!);
 		actionId.setWowheadDataset(labelIcon.value!, { useBuffAura: isAura });
@@ -766,7 +747,7 @@ export class Timeline extends ResultComponent {
 				rowElem.classList.remove('hide');
 			}
 		};
-		const event = this.hiddenIdsChangeEmitter.on(updateHidden);
+		const event = this.liveSlot!.emitter.on(updateHidden);
 		updateHidden();
 		this.addOnResetCallback(() => event.dispose());
 		return rowElem;
@@ -1325,6 +1306,12 @@ export class Timeline extends ResultComponent {
 		return [rd.result.request.requestId, JSON.stringify(rd.filter), this.chartPicker.value].join('|');
 	}
 
+	// Single-player results offer the rotation chart; multi-player ones the threat chart.
+	private setRotationOptionVisible(visible: boolean) {
+		this.rootElem.querySelector('.rotation-option')!.classList.toggle('hide', !visible);
+		this.rootElem.querySelector('.threat-option')!.classList.toggle('hide', visible);
+	}
+
 	private takeCachedSlot(key: string): RotationSlot | null {
 		const idx = this.cachedSlots.findIndex(slot => slot.key === key);
 		return idx < 0 ? null : this.cachedSlots.splice(idx, 1)[0];
@@ -1338,7 +1325,6 @@ export class Timeline extends ResultComponent {
 		slot.labels = Array.from(this.rotationLabels.childNodes);
 		slot.timeline = Array.from(this.rotationTimeline.childNodes);
 		slot.hiddenIdsNodes = Array.from(this.rotationHiddenIdsContainer.childNodes);
-		slot.timeRuler = this.rotationTimelineTimeRulerElem;
 		this.rotationLabels.replaceChildren();
 		this.rotationTimeline.replaceChildren();
 		this.rotationHiddenIdsContainer.replaceChildren();
@@ -1353,8 +1339,6 @@ export class Timeline extends ResultComponent {
 		this.rotationLabels.replaceChildren(...slot.labels);
 		this.rotationTimeline.replaceChildren(...slot.timeline);
 		this.rotationHiddenIdsContainer.replaceChildren(...slot.hiddenIdsNodes);
-		this.rotationTimelineTimeRulerElem = slot.timeRuler;
-		this.hiddenIdsChangeEmitter = slot.emitter;
 		this.liveSlot = slot;
 		// hiddenIds is global across results: re-apply it to the restored rows.
 		slot.emitter.emit(TypedEvent.nextEventID());

--- a/ui/core/components/detailed_results/timeline.tsx
+++ b/ui/core/components/detailed_results/timeline.tsx
@@ -31,6 +31,17 @@ interface TimelineConfig extends ResultComponentConfig {
 	secondaryResource?: SecondaryResource | null;
 }
 
+interface RotationSlot {
+	key: string;
+	labels: Array<Node>;
+	timeline: Array<Node>;
+	hiddenIdsNodes: Array<Node>;
+	timeRuler: HTMLCanvasElement | null;
+	emitter: TypedEvent<void>;
+	resetCallbacks: Array<() => void>;
+	plotOptions: any | null;
+}
+
 export class Timeline extends ResultComponent {
 	private readonly dpsResourcesPlotElem: HTMLElement;
 	private dpsResourcesPlot: any;
@@ -46,18 +57,17 @@ export class Timeline extends ResultComponent {
 	private resultData: SimResultData | null;
 	rendered: boolean;
 
+	// A rendered rotation timeline for one (result, filter, chart) key. The DOM
+	// nodes are kept LIVE (moved in and out of the containers, never cloned) so
+	// their tippy instances, click handlers and emitter subscriptions survive a
+	// switch between the current result and a saved reference. Eviction runs the
+	// slot's reset callbacks (tooltip destroy, listener removal).
+	private liveSlot: RotationSlot | null = null;
+	private cachedSlots: Array<RotationSlot> = [];
+	private static readonly MAX_CACHED_SLOTS = 2;
+
 	private hiddenIds: Array<ActionId>;
 	private hiddenIdsChangeEmitter;
-	private cacheHandler = new CacheHandler<{
-		dpsResourcesPlotOptions: any;
-		rotationLabels: Timeline['rotationLabels'];
-		rotationTimeline: Timeline['rotationTimeline'];
-		rotationHiddenIdsContainer: Timeline['rotationHiddenIdsContainer'];
-		rotationTimelineTimeRulerElem: Timeline['rotationTimelineTimeRulerElem'];
-		rotationTimelineTimeRulerImage: ImageData | undefined;
-	}>({
-		keysToKeep: 2,
-	});
 
 	private secondaryResource?: SecondaryResource | null;
 
@@ -69,6 +79,7 @@ export class Timeline extends ResultComponent {
 		this.rendered = false;
 		this.hiddenIds = [];
 		this.hiddenIdsChangeEmitter = new TypedEvent<void>();
+		this.addOnDisposeCallback(() => this.reset());
 		this.secondaryResource = config.secondaryResource;
 
 		this.rootElem.appendChild(
@@ -195,23 +206,23 @@ export class Timeline extends ResultComponent {
 			return;
 		}
 
-		const cachedData = this.cacheHandler.get(this.resultData.result.request.requestId);
-		if (cachedData) {
-			const { dpsResourcesPlotOptions, rotationLabels, rotationTimeline, rotationHiddenIdsContainer, rotationTimelineTimeRulerImage } = cachedData;
-			this.rotationLabels.replaceChildren(...rotationLabels.cloneNode(true).childNodes);
-			this.rotationTimeline.replaceChildren(...rotationTimeline.cloneNode(true).childNodes);
-
-			this.rotationHiddenIdsContainer.replaceChildren(...rotationHiddenIdsContainer.cloneNode(true).childNodes);
-			this.dpsResourcesPlot.updateOptions(dpsResourcesPlotOptions);
-
-			if (rotationTimelineTimeRulerImage)
-				this.rotationTimeline
-					.querySelector<HTMLCanvasElement>('.rotation-timeline-canvas')
-					?.getContext('2d')
-					?.putImageData(rotationTimelineTimeRulerImage, 0, 0);
-
-			this.onChartPickerSelectHandler();
+		// Fast path: this (result, filter, chart) was rendered before and its live
+		// subtree is either on screen or parked in the cache.
+		const key = this.resultKey();
+		const hit = this.liveSlot?.key === key ? this.liveSlot : this.takeCachedSlot(key);
+		if (hit && hit.plotOptions) {
+			if (hit !== this.liveSlot) {
+				this.stashLiveSlot();
+				this.attachSlot(hit);
+			}
+			this.rootElem.querySelector('.rotation-option')!.classList.remove('hide');
+			this.rootElem.querySelector('.threat-option')!.classList.add('hide');
+			this.dpsResourcesPlot.updateOptions(hit.plotOptions);
 			return;
+		}
+		if (hit && hit !== this.liveSlot) {
+			// Rendered subtree without cached chart options: keep it parked.
+			this.cachedSlots.push(hit);
 		}
 
 		const duration = this.resultData!.result.result.firstIterationDuration || 1;
@@ -286,6 +297,7 @@ export class Timeline extends ResultComponent {
 			tooltipHandlers = tooltipHandlers.filter(handler => !!handler);
 
 			this.addMajorCooldownAnnotations(player, options);
+			if (this.liveSlot && this.liveSlot.key === key) this.liveSlot.plotOptions = options;
 		} else {
 			if (this.chartPicker.value == 'rotation') {
 				this.chartPicker.value = 'dps';
@@ -296,6 +308,7 @@ export class Timeline extends ResultComponent {
 			const threatOption = this.rootElem.querySelector('.threat-option')!;
 			threatOption.classList.remove('hide');
 
+			this.stashLiveSlot();
 			this.clearRotationChart();
 
 			if (this.chartPicker.value == 'dps') {
@@ -319,18 +332,6 @@ export class Timeline extends ResultComponent {
 
 		this.dpsResourcesPlot.updateOptions(options);
 
-		this.rotationTimelineTimeRulerElem?.toBlob(() => {
-			this.cacheHandler.set(this.resultData!.result.request.requestId, {
-				dpsResourcesPlotOptions: options,
-				rotationLabels: this.rotationLabels.cloneNode(true) as HTMLElement,
-				rotationTimeline: this.rotationTimeline.cloneNode(true) as HTMLElement,
-				rotationHiddenIdsContainer: this.rotationHiddenIdsContainer.cloneNode(true) as HTMLElement,
-				rotationTimelineTimeRulerElem: this.rotationTimelineTimeRulerElem?.cloneNode(true) as HTMLCanvasElement,
-				rotationTimelineTimeRulerImage: this.rotationTimelineTimeRulerElem
-					?.getContext('2d')
-					?.getImageData(0, 0, this.rotationTimelineTimeRulerElem.width, this.rotationTimelineTimeRulerElem.height),
-			});
-		});
 	}
 
 	private addDpsYAxis(maxDps: number, options: any) {
@@ -550,7 +551,7 @@ export class Timeline extends ResultComponent {
 		);
 		this.rotationTimelineTimeRulerElem = canvasRef.value || null;
 		this.rotationHiddenIdsContainer.replaceChildren();
-		this.hiddenIdsChangeEmitter = new TypedEvent<void>();
+		this.hiddenIdsChangeEmitter = this.liveSlot ? this.liveSlot.emitter : new TypedEvent<void>();
 	}
 
 	private updateRotationChart(player: UnitMetrics, duration: number) {
@@ -559,6 +560,17 @@ export class Timeline extends ResultComponent {
 			return;
 		}
 
+		const key = this.resultKey();
+		if (this.liveSlot?.key === key) {
+			return;
+		}
+		this.stashLiveSlot();
+		const cached = this.takeCachedSlot(key);
+		if (cached) {
+			this.attachSlot(cached);
+			return;
+		}
+		this.liveSlot = { key, labels: [], timeline: [], hiddenIdsNodes: [], timeRuler: null, emitter: new TypedEvent<void>(), resetCallbacks: [], plotOptions: null };
 		this.clearRotationChart();
 
 		try {
@@ -1293,10 +1305,64 @@ export class Timeline extends ResultComponent {
 	}
 
 	update() {
-		this.reset();
 		if (!this.rendered) this.dpsResourcesPlot.render();
 		this.updatePlot();
 		this.rendered = true;
+	}
+
+	// Per-render resources (tooltips, listeners) belong to the slot being
+	// rendered so a parked slot can be destroyed independently.
+	addOnResetCallback(callback: () => void) {
+		if (this.liveSlot) {
+			this.liveSlot.resetCallbacks.push(callback);
+		} else {
+			super.addOnResetCallback(callback);
+		}
+	}
+
+	private resultKey(): string {
+		const rd = this.resultData!;
+		return [rd.result.request.requestId, JSON.stringify(rd.filter), this.chartPicker.value].join('|');
+	}
+
+	private takeCachedSlot(key: string): RotationSlot | null {
+		const idx = this.cachedSlots.findIndex(slot => slot.key === key);
+		return idx < 0 ? null : this.cachedSlots.splice(idx, 1)[0];
+	}
+
+	// Parks the on-screen subtree (nodes moved, tooltips kept alive) and evicts
+	// the least recently used slot beyond the cache size.
+	private stashLiveSlot() {
+		const slot = this.liveSlot;
+		if (!slot) return;
+		slot.labels = Array.from(this.rotationLabels.childNodes);
+		slot.timeline = Array.from(this.rotationTimeline.childNodes);
+		slot.hiddenIdsNodes = Array.from(this.rotationHiddenIdsContainer.childNodes);
+		slot.timeRuler = this.rotationTimelineTimeRulerElem;
+		this.rotationLabels.replaceChildren();
+		this.rotationTimeline.replaceChildren();
+		this.rotationHiddenIdsContainer.replaceChildren();
+		this.liveSlot = null;
+		this.cachedSlots.push(slot);
+		while (this.cachedSlots.length > Timeline.MAX_CACHED_SLOTS) {
+			this.destroySlot(this.cachedSlots.shift()!);
+		}
+	}
+
+	private attachSlot(slot: RotationSlot) {
+		this.rotationLabels.replaceChildren(...slot.labels);
+		this.rotationTimeline.replaceChildren(...slot.timeline);
+		this.rotationHiddenIdsContainer.replaceChildren(...slot.hiddenIdsNodes);
+		this.rotationTimelineTimeRulerElem = slot.timeRuler;
+		this.hiddenIdsChangeEmitter = slot.emitter;
+		this.liveSlot = slot;
+		// hiddenIds is global across results: re-apply it to the restored rows.
+		slot.emitter.emit(TypedEvent.nextEventID());
+	}
+
+	private destroySlot(slot: RotationSlot) {
+		slot.resetCallbacks.forEach(callback => callback());
+		slot.resetCallbacks = [];
 	}
 
 	render() {
@@ -1305,8 +1371,10 @@ export class Timeline extends ResultComponent {
 	}
 
 	reset() {
-		const previousResultRequestId = this.prevResultData?.result.request.requestId;
-		if (previousResultRequestId && !this.cacheHandler.get(previousResultRequestId)) return;
+		if (this.liveSlot) this.destroySlot(this.liveSlot);
+		this.cachedSlots.forEach(slot => this.destroySlot(slot));
+		this.liveSlot = null;
+		this.cachedSlots = [];
 		super.reset();
 	}
 }

--- a/ui/core/components/detailed_results/timeline.tsx
+++ b/ui/core/components/detailed_results/timeline.tsx
@@ -33,15 +33,12 @@ interface TimelineConfig extends ResultComponentConfig {
 
 interface RotationSlot {
 	key: string;
-	// True for a single-player result (rotation chart available); false for a
-	// multi-player one, whose slot only caches the plot options.
-	rotation: boolean;
 	labels: Array<Node>;
 	timeline: Array<Node>;
 	hiddenIdsNodes: Array<Node>;
 	emitter: TypedEvent<void>;
 	resetCallbacks: Array<() => void>;
-	plotOptions: any | null;
+	plotOptions: any;
 }
 
 export class Timeline extends ResultComponent {
@@ -63,10 +60,9 @@ export class Timeline extends ResultComponent {
 	// switch between the current result and a saved reference. Eviction runs the
 	// slot's reset callbacks (tooltip destroy, listener removal).
 	private liveSlot: RotationSlot | null = null;
-	private cachedSlots: Array<RotationSlot> = [];
-	// One parked slot covers the current <-> reference swap; each parked slot keeps
-	// its full tippy instance set alive, so don't hold more than needed.
-	private static readonly MAX_CACHED_SLOTS = 1;
+	// The most recently stashed slot. One is enough for the current <-> reference
+	// swap, and each parked slot keeps its full tippy instance set alive.
+	private parkedSlot: RotationSlot | null = null;
 
 	private hiddenIds: Array<ActionId>;
 
@@ -215,14 +211,14 @@ export class Timeline extends ResultComponent {
 		// Fast path: this result was rendered before and its slot is either live
 		// or parked in the cache.
 		const key = this.resultKey(!singlePlayer);
-		const hit = this.liveSlot?.key === key ? this.liveSlot : this.cachedSlots.find(slot => slot.key === key);
+		const hit = this.liveSlot?.key === key ? this.liveSlot : this.parkedSlot?.key === key ? this.parkedSlot : null;
 		if (hit?.plotOptions) {
 			if (hit !== this.liveSlot) {
-				this.takeCachedSlot(key);
+				this.parkedSlot = null;
 				this.stashLiveSlot();
 				this.attachSlot(hit);
 			}
-			this.setRotationOptionVisible(hit.rotation);
+			this.setRotationOptionVisible(singlePlayer);
 			this.dpsResourcesPlot.updateOptions(hit.plotOptions);
 			return;
 		}
@@ -301,7 +297,7 @@ export class Timeline extends ResultComponent {
 			this.stashLiveSlot();
 			this.clearRotationChart();
 			// No rotation subtree, but the (expensive) per-player series are worth caching for swaps.
-			this.liveSlot = Timeline.newSlot(key, false);
+			this.liveSlot = Timeline.newSlot(key);
 
 			if (this.chartPicker.value == 'dps') {
 				let maxDps = 0;
@@ -553,14 +549,14 @@ export class Timeline extends ResultComponent {
 		if (this.liveSlot?.key === key) {
 			return;
 		}
-		// Take before stashing so the stash's eviction can't drop the slot we want.
-		const cached = this.takeCachedSlot(key);
+		// Take before stashing so the stash can't evict the slot we want.
+		const parked = this.takeParkedSlot(key);
 		this.stashLiveSlot();
-		if (cached) {
-			this.attachSlot(cached);
+		if (parked) {
+			this.attachSlot(parked);
 			return;
 		}
-		this.liveSlot = Timeline.newSlot(key, true);
+		this.liveSlot = Timeline.newSlot(key);
 		this.clearRotationChart();
 
 		try {
@@ -1302,13 +1298,10 @@ export class Timeline extends ResultComponent {
 	}
 
 	// Per-render resources (tooltips, listeners) belong to the slot being
-	// rendered so a parked slot can be destroyed independently.
+	// rendered so a parked slot can be destroyed independently. Rows are only
+	// ever built under a live slot (see updateRotationChart).
 	addOnResetCallback(callback: () => void) {
-		if (this.liveSlot) {
-			this.liveSlot.resetCallbacks.push(callback);
-		} else {
-			super.addOnResetCallback(callback);
-		}
+		this.liveSlot!.resetCallbacks.push(callback);
 	}
 
 	// A single player's slot holds the rotation subtree plus every series, so the
@@ -1324,17 +1317,19 @@ export class Timeline extends ResultComponent {
 		this.rootElem.querySelector('.threat-option')!.classList.toggle('hide', visible);
 	}
 
-	private static newSlot(key: string, rotation: boolean): RotationSlot {
-		return { key, rotation, labels: [], timeline: [], hiddenIdsNodes: [], emitter: new TypedEvent<void>(), resetCallbacks: [], plotOptions: null };
+	private static newSlot(key: string): RotationSlot {
+		return { key, labels: [], timeline: [], hiddenIdsNodes: [], emitter: new TypedEvent<void>(), resetCallbacks: [], plotOptions: null };
 	}
 
-	private takeCachedSlot(key: string): RotationSlot | null {
-		const idx = this.cachedSlots.findIndex(slot => slot.key === key);
-		return idx < 0 ? null : this.cachedSlots.splice(idx, 1)[0];
+	private takeParkedSlot(key: string): RotationSlot | null {
+		if (this.parkedSlot?.key !== key) return null;
+		const slot = this.parkedSlot;
+		this.parkedSlot = null;
+		return slot;
 	}
 
-	// Parks the on-screen subtree (nodes moved, tooltips kept alive) and evicts
-	// the least recently used slot beyond the cache size.
+	// Parks the on-screen subtree (nodes moved, tooltips kept alive), destroying
+	// the previously parked slot.
 	private stashLiveSlot() {
 		const slot = this.liveSlot;
 		if (!slot) return;
@@ -1345,10 +1340,8 @@ export class Timeline extends ResultComponent {
 		this.rotationTimeline.replaceChildren();
 		this.rotationHiddenIdsContainer.replaceChildren();
 		this.liveSlot = null;
-		this.cachedSlots.push(slot);
-		while (this.cachedSlots.length > Timeline.MAX_CACHED_SLOTS) {
-			this.destroySlot(this.cachedSlots.shift()!);
-		}
+		if (this.parkedSlot) this.destroySlot(this.parkedSlot);
+		this.parkedSlot = slot;
 	}
 
 	private attachSlot(slot: RotationSlot) {
@@ -1362,7 +1355,6 @@ export class Timeline extends ResultComponent {
 
 	private destroySlot(slot: RotationSlot) {
 		slot.resetCallbacks.forEach(callback => callback());
-		slot.resetCallbacks = [];
 	}
 
 	render() {
@@ -1372,9 +1364,9 @@ export class Timeline extends ResultComponent {
 
 	reset() {
 		if (this.liveSlot) this.destroySlot(this.liveSlot);
-		this.cachedSlots.forEach(slot => this.destroySlot(slot));
+		if (this.parkedSlot) this.destroySlot(this.parkedSlot);
 		this.liveSlot = null;
-		this.cachedSlots = [];
+		this.parkedSlot = null;
 		super.reset();
 	}
 }

--- a/ui/core/components/individual_sim_ui/apl/apl_group_editor.tsx
+++ b/ui/core/components/individual_sim_ui/apl/apl_group_editor.tsx
@@ -9,7 +9,6 @@ import { Input, InputConfig } from '../../input';
 import { ListItemPickerConfig, ListPicker } from '../../pickers/list_picker';
 import { APLActionPicker } from '../apl_actions';
 import * as AplHelpers from '../apl_helpers';
-import { APL_CHILD_CHANGED_EVENT } from '../apl_helpers';
 import { APLNameModal } from './apl_name_modal';
 import { APLHidePicker } from './hide_picker';
 
@@ -73,7 +72,6 @@ export class APLGroupEditor extends Input<Player<any>, APLGroup> {
 						useIcon: true,
 					},
 				},
-				changedEvent: () => APL_CHILD_CHANGED_EVENT,
 				getValue: () => this.getSourceValue()?.actions || [],
 				setValue: (eventID: EventID, player: Player<any>, newValue: Array<APLListItem>) => {
 					const group = this.getSourceValue();
@@ -176,7 +174,6 @@ class APLGroupActionPicker extends Input<Player<any>, APLListItem> {
 
 		this.hidePicker = this.addChild(
 			new APLHidePicker(itemHeaderElem, player, {
-				changedEvent: () => APL_CHILD_CHANGED_EVENT,
 				getValue: () => this.getItem().hide,
 				setValue: (eventID: EventID, player: Player<any>, newValue: boolean) => {
 					this.getItem().hide = newValue;
@@ -187,7 +184,6 @@ class APLGroupActionPicker extends Input<Player<any>, APLListItem> {
 
 		this.actionPicker = this.addChild(
 			new APLActionPicker(this.rootElem, this.modObject, {
-				changedEvent: () => APL_CHILD_CHANGED_EVENT,
 				getValue: () => this.getItem().action!,
 				setValue: (eventID: EventID, player: Player<any>, newValue: any) => {
 					const item = this.getSourceValue();

--- a/ui/core/components/individual_sim_ui/apl/apl_group_editor.tsx
+++ b/ui/core/components/individual_sim_ui/apl/apl_group_editor.tsx
@@ -44,7 +44,7 @@ export class APLGroupEditor extends Input<Player<any>, APLGroup> {
 		nameContainer.querySelector('.apl-name-rename')!.addEventListener('click', () => {
 			const group = this.getSourceValue();
 			if (!group) return;
-			new APLNameModal(this.rootElem.closest('.individual-sim-ui') as HTMLElement ?? document.body, {
+			new APLNameModal((this.rootElem.closest('.individual-sim-ui') as HTMLElement) ?? document.body, {
 				title: i18n.t('rotation_tab.apl.nameModal.rename', { itemName: i18n.t('rotation_tab.apl.actionGroups.name') }),
 				inputLabel: i18n.t('rotation_tab.apl.actionGroups.attributes.name'),
 				confirmButtonLabel: i18n.t('rotation_tab.apl.nameModal.renameConfirm'),
@@ -62,46 +62,48 @@ export class APLGroupEditor extends Input<Player<any>, APLGroup> {
 		this.actionsContainer = container.appendChild(<div className="apl-group-actions-container" />) as HTMLElement;
 
 		// Create the actions picker in the dedicated container with EXACT same styling as Priority List
-		this.actionsPicker = new ListPicker<Player<any>, APLListItem>(this.actionsContainer, this.modObject, {
-			extraCssClasses: ['apl-list-item-picker'], // Use SAME class as Priority List!
-			title: i18n.t('rotation_tab.apl.actionGroups.attributes.actions'),
-			titleTooltip: i18n.t('rotation_tab.apl.actionGroups.tooltips.actions'),
-			itemLabel: i18n.t('rotation_tab.apl.priorityList.name'),
-			actions: {
-				create: {
-					useIcon: true,
-				},
-			},
-			changedEvent: () => APL_CHILD_CHANGED_EVENT,
-			getValue: () => this.getSourceValue()?.actions || [],
-			setValue: (eventID: EventID, player: Player<any>, newValue: Array<APLListItem>) => {
-				const group = this.getSourceValue();
-				if (group) {
-					group.actions = newValue;
-					player.rotationChangeEmitter.emit(eventID);
-				}
-			},
-			newItem: () =>
-				APLListItem.create({
-					action: {},
-				}),
-			copyItem: (oldItem: APLListItem) => APLListItem.clone(oldItem),
-			newItemPicker: (parent: HTMLElement, _: ListPicker<Player<any>, APLListItem>, index, config: ListItemPickerConfig<Player<any>, APLListItem>) =>
-				new APLGroupActionPicker(parent, this.modObject, { ...config, groupIndex: this.index, index }),
-			inlineMenuBar: true,
-			allowedActions: ['create', 'copy', 'delete', 'move'],
-			dragGroup: 'action-group-actions',
-			extraActions: [
-				AplHelpers.extractToVariableAction(
-					player,
-					actionIndex => this.getSourceValue()?.actions?.[actionIndex]?.action?.condition,
-					(actionIndex, ref) => {
-						this.getSourceValue()!.actions[actionIndex].action!.condition = ref;
+		this.actionsPicker = this.addChild(
+			new ListPicker<Player<any>, APLListItem>(this.actionsContainer, this.modObject, {
+				extraCssClasses: ['apl-list-item-picker'], // Use SAME class as Priority List!
+				title: i18n.t('rotation_tab.apl.actionGroups.attributes.actions'),
+				titleTooltip: i18n.t('rotation_tab.apl.actionGroups.tooltips.actions'),
+				itemLabel: i18n.t('rotation_tab.apl.priorityList.name'),
+				actions: {
+					create: {
+						useIcon: true,
 					},
-					this.rootElem.closest('.individual-sim-ui') as HTMLElement ?? document.body,
-				),
-			],
-		});
+				},
+				changedEvent: () => APL_CHILD_CHANGED_EVENT,
+				getValue: () => this.getSourceValue()?.actions || [],
+				setValue: (eventID: EventID, player: Player<any>, newValue: Array<APLListItem>) => {
+					const group = this.getSourceValue();
+					if (group) {
+						group.actions = newValue;
+						player.rotationChangeEmitter.emit(eventID);
+					}
+				},
+				newItem: () =>
+					APLListItem.create({
+						action: {},
+					}),
+				copyItem: (oldItem: APLListItem) => APLListItem.clone(oldItem),
+				newItemPicker: (parent: HTMLElement, _: ListPicker<Player<any>, APLListItem>, index, config: ListItemPickerConfig<Player<any>, APLListItem>) =>
+					new APLGroupActionPicker(parent, this.modObject, { ...config, groupIndex: this.index, index }),
+				inlineMenuBar: true,
+				allowedActions: ['create', 'copy', 'delete', 'move'],
+				dragGroup: 'action-group-actions',
+				extraActions: [
+					AplHelpers.extractToVariableAction(
+						player,
+						actionIndex => this.getSourceValue()?.actions?.[actionIndex]?.action?.condition,
+						(actionIndex, ref) => {
+							this.getSourceValue()!.actions[actionIndex].action!.condition = ref;
+						},
+						(this.rootElem.closest('.individual-sim-ui') as HTMLElement) ?? document.body,
+					),
+				],
+			}),
+		);
 
 		this.init();
 	}
@@ -172,26 +174,30 @@ class APLGroupActionPicker extends Input<Player<any>, APLListItem> {
 			return validations;
 		});
 
-		this.hidePicker = new APLHidePicker(itemHeaderElem, player, {
-			changedEvent: () => APL_CHILD_CHANGED_EVENT,
-			getValue: () => this.getItem().hide,
-			setValue: (eventID: EventID, player: Player<any>, newValue: boolean) => {
-				this.getItem().hide = newValue;
-				this.player.rotationChangeEmitter.emit(eventID);
-			},
-		});
+		this.hidePicker = this.addChild(
+			new APLHidePicker(itemHeaderElem, player, {
+				changedEvent: () => APL_CHILD_CHANGED_EVENT,
+				getValue: () => this.getItem().hide,
+				setValue: (eventID: EventID, player: Player<any>, newValue: boolean) => {
+					this.getItem().hide = newValue;
+					this.player.rotationChangeEmitter.emit(eventID);
+				},
+			}),
+		);
 
-		this.actionPicker = new APLActionPicker(this.rootElem, this.modObject, {
-			changedEvent: () => APL_CHILD_CHANGED_EVENT,
-			getValue: () => this.getItem().action!,
-			setValue: (eventID: EventID, player: Player<any>, newValue: any) => {
-				const item = this.getSourceValue();
-				if (item) {
-					this.getItem().action = newValue;
-					player.rotationChangeEmitter.emit(eventID);
-				}
-			},
-		});
+		this.actionPicker = this.addChild(
+			new APLActionPicker(this.rootElem, this.modObject, {
+				changedEvent: () => APL_CHILD_CHANGED_EVENT,
+				getValue: () => this.getItem().action!,
+				setValue: (eventID: EventID, player: Player<any>, newValue: any) => {
+					const item = this.getSourceValue();
+					if (item) {
+						this.getItem().action = newValue;
+						player.rotationChangeEmitter.emit(eventID);
+					}
+				},
+			}),
+		);
 
 		this.init();
 	}
@@ -210,6 +216,7 @@ class APLGroupActionPicker extends Input<Player<any>, APLListItem> {
 		if (!newValue) {
 			return;
 		}
+		this.hidePicker.setInputValue(newValue.hide);
 		this.actionPicker.setInputValue(newValue.action || APLAction.create());
 		if (newValue.action?.condition) {
 			if (!newValue.action.condition?.uuid?.value || newValue.action.condition.uuid.value == '') {

--- a/ui/core/components/individual_sim_ui/apl/apl_group_editor.tsx
+++ b/ui/core/components/individual_sim_ui/apl/apl_group_editor.tsx
@@ -9,6 +9,7 @@ import { Input, InputConfig } from '../../input';
 import { ListItemPickerConfig, ListPicker } from '../../pickers/list_picker';
 import { APLActionPicker } from '../apl_actions';
 import * as AplHelpers from '../apl_helpers';
+import { APL_CHILD_CHANGED_EVENT } from '../apl_helpers';
 import { APLNameModal } from './apl_name_modal';
 import { APLHidePicker } from './hide_picker';
 
@@ -71,7 +72,7 @@ export class APLGroupEditor extends Input<Player<any>, APLGroup> {
 					useIcon: true,
 				},
 			},
-			changedEvent: (player: Player<any>) => player.rotationChangeEmitter,
+			changedEvent: () => APL_CHILD_CHANGED_EVENT,
 			getValue: () => this.getSourceValue()?.actions || [],
 			setValue: (eventID: EventID, player: Player<any>, newValue: Array<APLListItem>) => {
 				const group = this.getSourceValue();
@@ -172,7 +173,7 @@ class APLGroupActionPicker extends Input<Player<any>, APLListItem> {
 		});
 
 		this.hidePicker = new APLHidePicker(itemHeaderElem, player, {
-			changedEvent: () => this.player.rotationChangeEmitter,
+			changedEvent: () => APL_CHILD_CHANGED_EVENT,
 			getValue: () => this.getItem().hide,
 			setValue: (eventID: EventID, player: Player<any>, newValue: boolean) => {
 				this.getItem().hide = newValue;
@@ -181,7 +182,7 @@ class APLGroupActionPicker extends Input<Player<any>, APLListItem> {
 		});
 
 		this.actionPicker = new APLActionPicker(this.rootElem, this.modObject, {
-			changedEvent: () => this.modObject.rotationChangeEmitter,
+			changedEvent: () => APL_CHILD_CHANGED_EVENT,
 			getValue: () => this.getItem().action!,
 			setValue: (eventID: EventID, player: Player<any>, newValue: any) => {
 				const item = this.getSourceValue();

--- a/ui/core/components/individual_sim_ui/apl/apl_variables_list_picker.tsx
+++ b/ui/core/components/individual_sim_ui/apl/apl_variables_list_picker.tsx
@@ -9,6 +9,7 @@ import { randomUUID } from '../../../utils';
 import { Component } from '../../component';
 import { Input } from '../../input';
 import { ListItemPickerConfig, ListPicker } from '../../pickers/list_picker';
+import { APL_CHILD_CHANGED_EVENT } from '../apl_helpers';
 import { APLValuePicker } from '../apl_values';
 import { AplFloatingActionBar } from './apl_floating_action_bar';
 import { APLNameModal } from './apl_name_modal';
@@ -134,7 +135,7 @@ class APLValueVariablePicker extends Input<Player<any>, APLValueVariable> {
 			id: randomUUID(),
 			label: i18n.t('rotation_tab.apl.variables.attributes.value'),
 			labelTooltip: i18n.t('rotation_tab.apl.variables.attributes.valueTooltip'),
-			changedEvent: (player: Player<any>) => player.rotationChangeEmitter,
+			changedEvent: () => APL_CHILD_CHANGED_EVENT,
 			getValue: () => this.getSourceValue().value,
 			setValue: (eventID: EventID, player: Player<any>, newValue: any) => {
 				const sourceValue = this.getSourceValue();

--- a/ui/core/components/individual_sim_ui/apl/apl_variables_list_picker.tsx
+++ b/ui/core/components/individual_sim_ui/apl/apl_variables_list_picker.tsx
@@ -9,7 +9,6 @@ import { randomUUID } from '../../../utils';
 import { Component } from '../../component';
 import { Input } from '../../input';
 import { ListItemPickerConfig, ListPicker } from '../../pickers/list_picker';
-import { APL_CHILD_CHANGED_EVENT } from '../apl_helpers';
 import { APLValuePicker } from '../apl_values';
 import { AplFloatingActionBar } from './apl_floating_action_bar';
 import { APLNameModal } from './apl_name_modal';
@@ -135,7 +134,6 @@ class APLValueVariablePicker extends Input<Player<any>, APLValueVariable> {
 				id: randomUUID(),
 				label: i18n.t('rotation_tab.apl.variables.attributes.value'),
 				labelTooltip: i18n.t('rotation_tab.apl.variables.attributes.valueTooltip'),
-				changedEvent: () => APL_CHILD_CHANGED_EVENT,
 				getValue: () => this.getSourceValue().value,
 				setValue: (eventID: EventID, player: Player<any>, newValue: any) => {
 					const sourceValue = this.getSourceValue();

--- a/ui/core/components/individual_sim_ui/apl/apl_variables_list_picker.tsx
+++ b/ui/core/components/individual_sim_ui/apl/apl_variables_list_picker.tsx
@@ -76,7 +76,6 @@ export class APLVariablesListPicker extends Component {
 			value: undefined,
 		});
 	}
-
 }
 
 class APLValueVariablePicker extends Input<Player<any>, APLValueVariable> {
@@ -117,7 +116,7 @@ class APLValueVariablePicker extends Input<Player<any>, APLValueVariable> {
 		nameContainer.querySelector('.apl-name-rename')!.addEventListener('click', () => {
 			const sourceValue = this.getSourceValue();
 			if (!sourceValue) return;
-			new APLNameModal(this.rootElem.closest('.individual-sim-ui') as HTMLElement ?? document.body, {
+			new APLNameModal((this.rootElem.closest('.individual-sim-ui') as HTMLElement) ?? document.body, {
 				title: i18n.t('rotation_tab.apl.nameModal.rename', { itemName: i18n.t('rotation_tab.apl.variables.name') }),
 				inputLabel: i18n.t('rotation_tab.apl.variables.attributes.name'),
 				confirmButtonLabel: i18n.t('rotation_tab.apl.nameModal.renameConfirm'),
@@ -131,18 +130,20 @@ class APLValueVariablePicker extends Input<Player<any>, APLValueVariable> {
 			});
 		});
 
-		this.valuePicker = new APLValuePicker(container, player, {
-			id: randomUUID(),
-			label: i18n.t('rotation_tab.apl.variables.attributes.value'),
-			labelTooltip: i18n.t('rotation_tab.apl.variables.attributes.valueTooltip'),
-			changedEvent: () => APL_CHILD_CHANGED_EVENT,
-			getValue: () => this.getSourceValue().value,
-			setValue: (eventID: EventID, player: Player<any>, newValue: any) => {
-				const sourceValue = this.getSourceValue();
-				sourceValue.value = newValue;
-				this.config.setValue(eventID, player, this.config.getValue(player));
-			},
-		});
+		this.valuePicker = this.addChild(
+			new APLValuePicker(container, player, {
+				id: randomUUID(),
+				label: i18n.t('rotation_tab.apl.variables.attributes.value'),
+				labelTooltip: i18n.t('rotation_tab.apl.variables.attributes.valueTooltip'),
+				changedEvent: () => APL_CHILD_CHANGED_EVENT,
+				getValue: () => this.getSourceValue().value,
+				setValue: (eventID: EventID, player: Player<any>, newValue: any) => {
+					const sourceValue = this.getSourceValue();
+					sourceValue.value = newValue;
+					this.config.setValue(eventID, player, this.config.getValue(player));
+				},
+			}),
+		);
 
 		this.init();
 	}

--- a/ui/core/components/individual_sim_ui/apl/pre_pull_list_picker.tsx
+++ b/ui/core/components/individual_sim_ui/apl/pre_pull_list_picker.tsx
@@ -9,7 +9,6 @@ import { Input } from '../../input';
 import { ListItemPickerConfig, ListPicker } from '../../pickers/list_picker';
 import { AdaptiveStringPicker } from '../../pickers/string_picker';
 import { APLActionPicker } from '../apl_actions';
-import { APL_CHILD_CHANGED_EVENT } from '../apl_helpers';
 import { APLValueImplStruct, APLValuePicker } from '../apl_values';
 import { APLHidePicker } from './hide_picker';
 
@@ -64,7 +63,6 @@ class APLPrepullActionPicker extends Input<Player<any>, APLPrepullAction> {
 
 		this.hidePicker = this.addChild(
 			new APLHidePicker(itemHeaderElem, player, {
-				changedEvent: () => APL_CHILD_CHANGED_EVENT,
 				getValue: () => this.getItem().hide,
 				setValue: (eventID: EventID, player: Player<any>, newValue: boolean) => {
 					this.getItem().hide = newValue;
@@ -79,7 +77,6 @@ class APLPrepullActionPicker extends Input<Player<any>, APLPrepullAction> {
 				label: i18n.t('rotation_tab.apl.prepull_actions.do_at.label'),
 				labelTooltip: i18n.t('rotation_tab.apl.prepull_actions.do_at.tooltip'),
 				extraCssClasses: ['apl-prepull-actions-doat'],
-				changedEvent: () => APL_CHILD_CHANGED_EVENT,
 				getValue: () => this.getItem().doAtValue,
 				setValue: (eventID: EventID, player: Player<any>, newValue: APLValue | undefined) => {
 					if (newValue) {
@@ -98,7 +95,6 @@ class APLPrepullActionPicker extends Input<Player<any>, APLPrepullAction> {
 
 		this.actionPicker = this.addChild(
 			new APLActionPicker(this.rootElem, this.player, {
-				changedEvent: () => APL_CHILD_CHANGED_EVENT,
 				getValue: () => this.getItem().action!,
 				setValue: (eventID: EventID, player: Player<any>, newValue: APLAction) => {
 					this.getItem().action = newValue;

--- a/ui/core/components/individual_sim_ui/apl/pre_pull_list_picker.tsx
+++ b/ui/core/components/individual_sim_ui/apl/pre_pull_list_picker.tsx
@@ -62,44 +62,50 @@ class APLPrepullActionPicker extends Input<Player<any>, APLPrepullAction> {
 		const itemHeaderElem = ListPicker.getItemHeaderElem(this);
 		ListPicker.makeListItemValidations(itemHeaderElem, player, player => player.getCurrentStats().rotationStats?.prepullActions[index]?.validations || []);
 
-		this.hidePicker = new APLHidePicker(itemHeaderElem, player, {
-			changedEvent: () => APL_CHILD_CHANGED_EVENT,
-			getValue: () => this.getItem().hide,
-			setValue: (eventID: EventID, player: Player<any>, newValue: boolean) => {
-				this.getItem().hide = newValue;
-				this.player.rotationChangeEmitter.emit(eventID);
-			},
-		});
+		this.hidePicker = this.addChild(
+			new APLHidePicker(itemHeaderElem, player, {
+				changedEvent: () => APL_CHILD_CHANGED_EVENT,
+				getValue: () => this.getItem().hide,
+				setValue: (eventID: EventID, player: Player<any>, newValue: boolean) => {
+					this.getItem().hide = newValue;
+					this.player.rotationChangeEmitter.emit(eventID);
+				},
+			}),
+		);
 
-		this.doAtPicker = new APLValuePicker(this.rootElem, this.player, {
-			id: randomUUID(),
-			label: i18n.t('rotation_tab.apl.prepull_actions.do_at.label'),
-			labelTooltip: i18n.t('rotation_tab.apl.prepull_actions.do_at.tooltip'),
-			extraCssClasses: ['apl-prepull-actions-doat'],
-			changedEvent: () => APL_CHILD_CHANGED_EVENT,
-			getValue: () => this.getItem().doAtValue,
-			setValue: (eventID: EventID, player: Player<any>, newValue: APLValue | undefined) => {
-				if (newValue) {
-					this.getItem().doAtValue = newValue;
-				} else {
-					this.getItem().doAtValue = APLValue.create({
-						value: { oneofKind: 'const', const: { val: '-1s' } },
-						uuid: { value: randomUUID() },
-					});
-				}
-				this.player.rotationChangeEmitter.emit(eventID);
-			},
-			inline: true,
-		});
+		this.doAtPicker = this.addChild(
+			new APLValuePicker(this.rootElem, this.player, {
+				id: randomUUID(),
+				label: i18n.t('rotation_tab.apl.prepull_actions.do_at.label'),
+				labelTooltip: i18n.t('rotation_tab.apl.prepull_actions.do_at.tooltip'),
+				extraCssClasses: ['apl-prepull-actions-doat'],
+				changedEvent: () => APL_CHILD_CHANGED_EVENT,
+				getValue: () => this.getItem().doAtValue,
+				setValue: (eventID: EventID, player: Player<any>, newValue: APLValue | undefined) => {
+					if (newValue) {
+						this.getItem().doAtValue = newValue;
+					} else {
+						this.getItem().doAtValue = APLValue.create({
+							value: { oneofKind: 'const', const: { val: '-1s' } },
+							uuid: { value: randomUUID() },
+						});
+					}
+					this.player.rotationChangeEmitter.emit(eventID);
+				},
+				inline: true,
+			}),
+		);
 
-		this.actionPicker = new APLActionPicker(this.rootElem, this.player, {
-			changedEvent: () => APL_CHILD_CHANGED_EVENT,
-			getValue: () => this.getItem().action!,
-			setValue: (eventID: EventID, player: Player<any>, newValue: APLAction) => {
-				this.getItem().action = newValue;
-				this.player.rotationChangeEmitter.emit(eventID);
-			},
-		});
+		this.actionPicker = this.addChild(
+			new APLActionPicker(this.rootElem, this.player, {
+				changedEvent: () => APL_CHILD_CHANGED_EVENT,
+				getValue: () => this.getItem().action!,
+				setValue: (eventID: EventID, player: Player<any>, newValue: APLAction) => {
+					this.getItem().action = newValue;
+					this.player.rotationChangeEmitter.emit(eventID);
+				},
+			}),
+		);
 		this.init();
 	}
 

--- a/ui/core/components/individual_sim_ui/apl/pre_pull_list_picker.tsx
+++ b/ui/core/components/individual_sim_ui/apl/pre_pull_list_picker.tsx
@@ -9,6 +9,7 @@ import { Input } from '../../input';
 import { ListItemPickerConfig, ListPicker } from '../../pickers/list_picker';
 import { AdaptiveStringPicker } from '../../pickers/string_picker';
 import { APLActionPicker } from '../apl_actions';
+import { APL_CHILD_CHANGED_EVENT } from '../apl_helpers';
 import { APLValueImplStruct, APLValuePicker } from '../apl_values';
 import { APLHidePicker } from './hide_picker';
 
@@ -62,7 +63,7 @@ class APLPrepullActionPicker extends Input<Player<any>, APLPrepullAction> {
 		ListPicker.makeListItemValidations(itemHeaderElem, player, player => player.getCurrentStats().rotationStats?.prepullActions[index]?.validations || []);
 
 		this.hidePicker = new APLHidePicker(itemHeaderElem, player, {
-			changedEvent: () => this.player.rotationChangeEmitter,
+			changedEvent: () => APL_CHILD_CHANGED_EVENT,
 			getValue: () => this.getItem().hide,
 			setValue: (eventID: EventID, player: Player<any>, newValue: boolean) => {
 				this.getItem().hide = newValue;
@@ -75,7 +76,7 @@ class APLPrepullActionPicker extends Input<Player<any>, APLPrepullAction> {
 			label: i18n.t('rotation_tab.apl.prepull_actions.do_at.label'),
 			labelTooltip: i18n.t('rotation_tab.apl.prepull_actions.do_at.tooltip'),
 			extraCssClasses: ['apl-prepull-actions-doat'],
-			changedEvent: () => this.player.rotationChangeEmitter,
+			changedEvent: () => APL_CHILD_CHANGED_EVENT,
 			getValue: () => this.getItem().doAtValue,
 			setValue: (eventID: EventID, player: Player<any>, newValue: APLValue | undefined) => {
 				if (newValue) {
@@ -92,7 +93,7 @@ class APLPrepullActionPicker extends Input<Player<any>, APLPrepullAction> {
 		});
 
 		this.actionPicker = new APLActionPicker(this.rootElem, this.player, {
-			changedEvent: () => this.player.rotationChangeEmitter,
+			changedEvent: () => APL_CHILD_CHANGED_EVENT,
 			getValue: () => this.getItem().action!,
 			setValue: (eventID: EventID, player: Player<any>, newValue: APLAction) => {
 				this.getItem().action = newValue;

--- a/ui/core/components/individual_sim_ui/apl/priority_list_picker.tsx
+++ b/ui/core/components/individual_sim_ui/apl/priority_list_picker.tsx
@@ -8,6 +8,7 @@ import { Input } from '../../input';
 import { ListItemPickerConfig, ListPicker } from '../../pickers/list_picker';
 import { APLActionPicker } from '../apl_actions';
 import * as AplHelpers from '../apl_helpers';
+import { APL_CHILD_CHANGED_EVENT } from '../apl_helpers';
 import { AplFloatingActionBar } from './apl_floating_action_bar';
 import { APLHidePicker } from './hide_picker';
 
@@ -81,7 +82,7 @@ class APLListItemPicker extends Input<Player<any>, APLListItem> {
 		});
 
 		this.hidePicker = new APLHidePicker(itemHeaderElem, player, {
-			changedEvent: () => this.player.rotationChangeEmitter,
+			changedEvent: () => APL_CHILD_CHANGED_EVENT,
 			getValue: () => this.getItem().hide,
 			setValue: (eventID: EventID, player: Player<any>, newValue: boolean) => {
 				this.getItem().hide = newValue;
@@ -90,7 +91,7 @@ class APLListItemPicker extends Input<Player<any>, APLListItem> {
 		});
 
 		this.actionPicker = new APLActionPicker(this.rootElem, this.player, {
-			changedEvent: () => this.player.rotationChangeEmitter,
+			changedEvent: () => APL_CHILD_CHANGED_EVENT,
 			getValue: () => this.getItem().action!,
 			setValue: (eventID: EventID, player: Player<any>, newValue: APLAction) => {
 				this.getItem().action = newValue;

--- a/ui/core/components/individual_sim_ui/apl/priority_list_picker.tsx
+++ b/ui/core/components/individual_sim_ui/apl/priority_list_picker.tsx
@@ -81,23 +81,27 @@ class APLListItemPicker extends Input<Player<any>, APLListItem> {
 			return validations;
 		});
 
-		this.hidePicker = new APLHidePicker(itemHeaderElem, player, {
-			changedEvent: () => APL_CHILD_CHANGED_EVENT,
-			getValue: () => this.getItem().hide,
-			setValue: (eventID: EventID, player: Player<any>, newValue: boolean) => {
-				this.getItem().hide = newValue;
-				this.player.rotationChangeEmitter.emit(eventID);
-			},
-		});
+		this.hidePicker = this.addChild(
+			new APLHidePicker(itemHeaderElem, player, {
+				changedEvent: () => APL_CHILD_CHANGED_EVENT,
+				getValue: () => this.getItem().hide,
+				setValue: (eventID: EventID, player: Player<any>, newValue: boolean) => {
+					this.getItem().hide = newValue;
+					this.player.rotationChangeEmitter.emit(eventID);
+				},
+			}),
+		);
 
-		this.actionPicker = new APLActionPicker(this.rootElem, this.player, {
-			changedEvent: () => APL_CHILD_CHANGED_EVENT,
-			getValue: () => this.getItem().action!,
-			setValue: (eventID: EventID, player: Player<any>, newValue: APLAction) => {
-				this.getItem().action = newValue;
-				this.player.rotationChangeEmitter.emit(eventID);
-			},
-		});
+		this.actionPicker = this.addChild(
+			new APLActionPicker(this.rootElem, this.player, {
+				changedEvent: () => APL_CHILD_CHANGED_EVENT,
+				getValue: () => this.getItem().action!,
+				setValue: (eventID: EventID, player: Player<any>, newValue: APLAction) => {
+					this.getItem().action = newValue;
+					this.player.rotationChangeEmitter.emit(eventID);
+				},
+			}),
+		);
 		this.init();
 	}
 

--- a/ui/core/components/individual_sim_ui/apl/priority_list_picker.tsx
+++ b/ui/core/components/individual_sim_ui/apl/priority_list_picker.tsx
@@ -8,7 +8,6 @@ import { Input } from '../../input';
 import { ListItemPickerConfig, ListPicker } from '../../pickers/list_picker';
 import { APLActionPicker } from '../apl_actions';
 import * as AplHelpers from '../apl_helpers';
-import { APL_CHILD_CHANGED_EVENT } from '../apl_helpers';
 import { AplFloatingActionBar } from './apl_floating_action_bar';
 import { APLHidePicker } from './hide_picker';
 
@@ -83,7 +82,6 @@ class APLListItemPicker extends Input<Player<any>, APLListItem> {
 
 		this.hidePicker = this.addChild(
 			new APLHidePicker(itemHeaderElem, player, {
-				changedEvent: () => APL_CHILD_CHANGED_EVENT,
 				getValue: () => this.getItem().hide,
 				setValue: (eventID: EventID, player: Player<any>, newValue: boolean) => {
 					this.getItem().hide = newValue;
@@ -94,7 +92,6 @@ class APLListItemPicker extends Input<Player<any>, APLListItem> {
 
 		this.actionPicker = this.addChild(
 			new APLActionPicker(this.rootElem, this.player, {
-				changedEvent: () => APL_CHILD_CHANGED_EVENT,
 				getValue: () => this.getItem().action!,
 				setValue: (eventID: EventID, player: Player<any>, newValue: APLAction) => {
 					this.getItem().action = newValue;

--- a/ui/core/components/individual_sim_ui/apl_actions.ts
+++ b/ui/core/components/individual_sim_ui/apl_actions.ts
@@ -70,25 +70,27 @@ export class APLActionPicker extends Input<Player<any>, APLAction> {
 	constructor(parent: HTMLElement, player: Player<any>, config: APLActionPickerConfig) {
 		super(parent, 'apl-action-picker-root', player, config);
 
-		this.conditionPicker = new AplValues.APLValuePicker(this.rootElem, this.modObject, {
-			label: i18n.t('rotation_tab.apl.priority_list.if_label'),
-			changedEvent: () => APL_CHILD_CHANGED_EVENT,
-			getValue: (_player: Player<any>) => this.getSourceValue()?.condition,
-			setValue: (eventID: EventID, player: Player<any>, newValue: APLValue | undefined) => {
-				const srcVal = this.getSourceValue();
-				if (srcVal) {
-					srcVal.condition = newValue;
-					player.rotationChangeEmitter.emit(eventID);
-				} else {
-					this.setSourceValue(
-						eventID,
-						APLAction.create({
-							condition: newValue,
-						}),
-					);
-				}
-			},
-		});
+		this.conditionPicker = this.addChild(
+			new AplValues.APLValuePicker(this.rootElem, this.modObject, {
+				label: i18n.t('rotation_tab.apl.priority_list.if_label'),
+				changedEvent: () => APL_CHILD_CHANGED_EVENT,
+				getValue: (_player: Player<any>) => this.getSourceValue()?.condition,
+				setValue: (eventID: EventID, player: Player<any>, newValue: APLValue | undefined) => {
+					const srcVal = this.getSourceValue();
+					if (srcVal) {
+						srcVal.condition = newValue;
+						player.rotationChangeEmitter.emit(eventID);
+					} else {
+						this.setSourceValue(
+							eventID,
+							APLAction.create({
+								condition: newValue,
+							}),
+						);
+					}
+				},
+			}),
+		);
 		this.conditionPicker.rootElem.classList.add('apl-action-condition', 'apl-priority-list-only');
 
 		this.actionDiv = document.createElement('div');
@@ -101,74 +103,79 @@ export class APLActionPicker extends Input<Player<any>, APLAction> {
 			actionKind => actionKindFactories[actionKind].includeIf?.(player, isPrepull) ?? true,
 		);
 
-		this.kindPicker = new TextDropdownPicker(this.actionDiv, player, {
-			id: randomUUID(),
-			defaultLabel: i18n.t('rotation_tab.apl.priority_list.item_label'),
-			values: allActionKinds.map(actionKind => {
-				const factory = actionKindFactories[actionKind];
-				return {
-					value: actionKind,
-					label: factory.label,
-					submenu: factory.submenu,
-					tooltip: factory.fullDescription ? `<p>${factory.shortDescription}</p> ${factory.fullDescription}` : factory.shortDescription,
-				};
-			}),
-			equals: (a, b) => a == b,
-			changedEvent: () => APL_CHILD_CHANGED_EVENT,
-			getValue: (_player: Player<any>) => this.getSourceValue()?.action.oneofKind,
-			setValue: (eventID: EventID, player: Player<any>, newKind: APLActionKind) => {
-				const sourceValue = this.getSourceValue();
-				const oldKind = sourceValue?.action.oneofKind;
-				if (oldKind == newKind) {
-					return;
-				}
+		this.kindPicker = this.addChild(
+			new TextDropdownPicker(this.actionDiv, player, {
+				id: randomUUID(),
+				defaultLabel: i18n.t('rotation_tab.apl.priority_list.item_label'),
+				values: allActionKinds.map(actionKind => {
+					const factory = actionKindFactories[actionKind];
+					return {
+						value: actionKind,
+						label: factory.label,
+						submenu: factory.submenu,
+						tooltip: factory.fullDescription ? `<p>${factory.shortDescription}</p> ${factory.fullDescription}` : factory.shortDescription,
+					};
+				}),
+				equals: (a, b) => a == b,
+				changedEvent: () => APL_CHILD_CHANGED_EVENT,
+				getValue: (_player: Player<any>) => this.getSourceValue()?.action.oneofKind,
+				setValue: (eventID: EventID, player: Player<any>, newKind: APLActionKind) => {
+					const sourceValue = this.getSourceValue();
+					const oldKind = sourceValue?.action.oneofKind;
+					if (oldKind == newKind) {
+						return;
+					}
 
-				if (newKind) {
-					const factory = actionKindFactories[newKind];
-					let newSourceValue = this.makeAPLAction(newKind, factory.newValue());
-					if (sourceValue) {
-						// Some pre-fill logic when swapping kinds.
-						if (oldKind && this.actionPicker) {
-							if (newKind == 'sequence') {
-								if (sourceValue.action.oneofKind == 'strictSequence') {
-									(newSourceValue.action as APLActionImplStruct<'sequence'>).sequence.actions = sourceValue.action.strictSequence.actions;
-								} else {
-									(newSourceValue.action as APLActionImplStruct<'sequence'>).sequence.actions = [
-										this.makeAPLAction(oldKind, this.actionPicker.getInputValue()),
-									];
+					if (newKind) {
+						const factory = actionKindFactories[newKind];
+						let newSourceValue = this.makeAPLAction(newKind, factory.newValue());
+						if (sourceValue) {
+							// Some pre-fill logic when swapping kinds.
+							if (oldKind && this.actionPicker) {
+								if (newKind == 'sequence') {
+									if (sourceValue.action.oneofKind == 'strictSequence') {
+										(newSourceValue.action as APLActionImplStruct<'sequence'>).sequence.actions = sourceValue.action.strictSequence.actions;
+									} else {
+										(newSourceValue.action as APLActionImplStruct<'sequence'>).sequence.actions = [
+											this.makeAPLAction(oldKind, this.actionPicker.getInputValue()),
+										];
+									}
+								} else if (newKind == 'strictSequence') {
+									if (sourceValue.action.oneofKind == 'sequence') {
+										(newSourceValue.action as APLActionImplStruct<'strictSequence'>).strictSequence.actions =
+											sourceValue.action.sequence.actions;
+									} else {
+										(newSourceValue.action as APLActionImplStruct<'strictSequence'>).strictSequence.actions = [
+											this.makeAPLAction(oldKind, this.actionPicker.getInputValue()),
+										];
+									}
+								} else if (
+									sourceValue.action.oneofKind == 'sequence' &&
+									sourceValue.action.sequence.actions?.[0]?.action.oneofKind == newKind
+								) {
+									newSourceValue = sourceValue.action.sequence.actions[0];
+								} else if (
+									sourceValue.action.oneofKind == 'strictSequence' &&
+									sourceValue.action.strictSequence.actions?.[0]?.action.oneofKind == newKind
+								) {
+									newSourceValue = sourceValue.action.strictSequence.actions[0];
 								}
-							} else if (newKind == 'strictSequence') {
-								if (sourceValue.action.oneofKind == 'sequence') {
-									(newSourceValue.action as APLActionImplStruct<'strictSequence'>).strictSequence.actions =
-										sourceValue.action.sequence.actions;
-								} else {
-									(newSourceValue.action as APLActionImplStruct<'strictSequence'>).strictSequence.actions = [
-										this.makeAPLAction(oldKind, this.actionPicker.getInputValue()),
-									];
-								}
-							} else if (sourceValue.action.oneofKind == 'sequence' && sourceValue.action.sequence.actions?.[0]?.action.oneofKind == newKind) {
-								newSourceValue = sourceValue.action.sequence.actions[0];
-							} else if (
-								sourceValue.action.oneofKind == 'strictSequence' &&
-								sourceValue.action.strictSequence.actions?.[0]?.action.oneofKind == newKind
-							) {
-								newSourceValue = sourceValue.action.strictSequence.actions[0];
 							}
 						}
-					}
-					if (sourceValue) {
-						sourceValue.action = newSourceValue.action;
+						if (sourceValue) {
+							sourceValue.action = newSourceValue.action;
+						} else {
+							this.setSourceValue(eventID, newSourceValue);
+						}
 					} else {
-						this.setSourceValue(eventID, newSourceValue);
+						sourceValue.action = {
+							oneofKind: newKind,
+						};
 					}
-				} else {
-					sourceValue.action = {
-						oneofKind: newKind,
-					};
-				}
-				player.rotationChangeEmitter.emit(eventID);
-			},
-		});
+					player.rotationChangeEmitter.emit(eventID);
+				},
+			}),
+		);
 
 		this.currentKind = undefined;
 		this.actionPicker = null;
@@ -232,6 +239,7 @@ export class APLActionPicker extends Input<Player<any>, APLAction> {
 			return;
 		}
 		this.currentKind = newActionKind;
+		this.kindPicker.setInputValue(newActionKind);
 
 		if (this.actionPicker) {
 			this.disposeChild(this.actionPicker);
@@ -242,8 +250,6 @@ export class APLActionPicker extends Input<Player<any>, APLAction> {
 		if (!newActionKind) {
 			return;
 		}
-
-		this.kindPicker.setInputValue(newActionKind);
 
 		const factory = actionKindFactories[newActionKind];
 		this.actionPicker = factory.factory(this.actionDiv, this.modObject, {
@@ -641,7 +647,7 @@ const actionKindFactories: { [f in NonNullable<APLActionKind>]: ActionKindConfig
 			AplHelpers.numberFieldConfig('amount', false, {
 				label: i18n.t('rotation_tab.apl.actions.damage_amplification.amount.label'),
 			}),
-			AplHelpers.damageAmpTypeFieldConfig('ampType')
+			AplHelpers.damageAmpTypeFieldConfig('ampType'),
 		],
 	}),
 	['itemSwap']: inputBuilder({

--- a/ui/core/components/individual_sim_ui/apl_actions.ts
+++ b/ui/core/components/individual_sim_ui/apl_actions.ts
@@ -234,9 +234,7 @@ export class APLActionPicker extends Input<Player<any>, APLAction> {
 		this.currentKind = newActionKind;
 
 		if (this.actionPicker) {
-			const childIdx = this.children.indexOf(this.actionPicker);
-			if (childIdx >= 0) this.children.splice(childIdx, 1);
-			this.actionPicker.dispose();
+			this.disposeChild(this.actionPicker);
 			this.actionPicker.rootElem.remove();
 			this.actionPicker = null;
 		}

--- a/ui/core/components/individual_sim_ui/apl_actions.ts
+++ b/ui/core/components/individual_sim_ui/apl_actions.ts
@@ -44,7 +44,6 @@ import { randomUUID } from '../../utils';
 import { Input, InputConfig } from '../input.js';
 import { TextDropdownPicker } from '../pickers/dropdown_picker.jsx';
 import { ListItemPickerConfig, ListPicker } from '../pickers/list_picker.jsx';
-import { APL_CHILD_CHANGED_EVENT } from './apl_helpers';
 import * as AplHelpers from './apl_helpers.js';
 import { itemSwapSetFieldConfig } from './apl_helpers.js';
 import * as AplValues from './apl_values.js';
@@ -73,7 +72,6 @@ export class APLActionPicker extends Input<Player<any>, APLAction> {
 		this.conditionPicker = this.addChild(
 			new AplValues.APLValuePicker(this.rootElem, this.modObject, {
 				label: i18n.t('rotation_tab.apl.priority_list.if_label'),
-				changedEvent: () => APL_CHILD_CHANGED_EVENT,
 				getValue: (_player: Player<any>) => this.getSourceValue()?.condition,
 				setValue: (eventID: EventID, player: Player<any>, newValue: APLValue | undefined) => {
 					const srcVal = this.getSourceValue();
@@ -117,7 +115,6 @@ export class APLActionPicker extends Input<Player<any>, APLAction> {
 					};
 				}),
 				equals: (a, b) => a == b,
-				changedEvent: () => APL_CHILD_CHANGED_EVENT,
 				getValue: (_player: Player<any>) => this.getSourceValue()?.action.oneofKind,
 				setValue: (eventID: EventID, player: Player<any>, newKind: APLActionKind) => {
 					const sourceValue = this.getSourceValue();
@@ -242,8 +239,7 @@ export class APLActionPicker extends Input<Player<any>, APLAction> {
 		this.kindPicker.setInputValue(newActionKind);
 
 		if (this.actionPicker) {
-			this.disposeChild(this.actionPicker);
-			this.actionPicker.rootElem.remove();
+			this.removeChild(this.actionPicker);
 			this.actionPicker = null;
 		}
 
@@ -253,7 +249,6 @@ export class APLActionPicker extends Input<Player<any>, APLAction> {
 
 		const factory = actionKindFactories[newActionKind];
 		this.actionPicker = factory.factory(this.actionDiv, this.modObject, {
-			changedEvent: () => APL_CHILD_CHANGED_EVENT,
 			getValue: () => (this.getSourceValue()?.action as any)?.[newActionKind] || factory.newValue(),
 			setValue: (eventID: EventID, player: Player<any>, newValue: any) => {
 				const sourceValue = this.getSourceValue();

--- a/ui/core/components/individual_sim_ui/apl_actions.ts
+++ b/ui/core/components/individual_sim_ui/apl_actions.ts
@@ -1,3 +1,4 @@
+import i18n from '../../../i18n/config';
 import { itemSwapEnabledSpecs } from '../../individual_sim_ui.js';
 import { Player } from '../../player.js';
 import {
@@ -7,6 +8,7 @@ import {
 	APLActionActivateAuraWithStacks,
 	APLActionAutocastOtherCooldowns,
 	APLActionCancelAura,
+	APLActionCancelSpellCast,
 	APLActionCastAllStatBuffCooldowns,
 	APLActionCastFriendlySpell,
 	APLActionCastSpell,
@@ -14,6 +16,7 @@ import {
 	APLActionChangeTarget,
 	APLActionChannelSpell,
 	APLActionCustomRotation,
+	APLActionDamageAmplifier,
 	APLActionGroupReference,
 	APLActionGuardianHotwDpsRotation,
 	APLActionGuardianHotwDpsRotation_Strategy as HotwStrategy,
@@ -29,21 +32,19 @@ import {
 	APLActionStrictMultidot,
 	APLActionStrictSequence,
 	APLActionTriggerICD,
-	APLActionDamageAmplifier,
 	APLActionWait,
 	APLActionWaitUntil,
-	APLValue,
 	APLActionWarlockNextExhaleTarget,
-	APLActionCancelSpellCast,
+	APLValue,
 } from '../../proto/apl.js';
 import { Spec } from '../../proto/common.js';
 import { FeralDruid_Rotation_AplType } from '../../proto/druid.js';
 import { EventID } from '../../typed_event.js';
 import { randomUUID } from '../../utils';
 import { Input, InputConfig } from '../input.js';
-import i18n from '../../../i18n/config';
 import { TextDropdownPicker } from '../pickers/dropdown_picker.jsx';
 import { ListItemPickerConfig, ListPicker } from '../pickers/list_picker.jsx';
+import { APL_CHILD_CHANGED_EVENT } from './apl_helpers';
 import * as AplHelpers from './apl_helpers.js';
 import { itemSwapSetFieldConfig } from './apl_helpers.js';
 import * as AplValues from './apl_values.js';
@@ -71,7 +72,7 @@ export class APLActionPicker extends Input<Player<any>, APLAction> {
 
 		this.conditionPicker = new AplValues.APLValuePicker(this.rootElem, this.modObject, {
 			label: i18n.t('rotation_tab.apl.priority_list.if_label'),
-			changedEvent: (player: Player<any>) => player.rotationChangeEmitter,
+			changedEvent: () => APL_CHILD_CHANGED_EVENT,
 			getValue: (_player: Player<any>) => this.getSourceValue()?.condition,
 			setValue: (eventID: EventID, player: Player<any>, newValue: APLValue | undefined) => {
 				const srcVal = this.getSourceValue();
@@ -113,7 +114,7 @@ export class APLActionPicker extends Input<Player<any>, APLAction> {
 				};
 			}),
 			equals: (a, b) => a == b,
-			changedEvent: (player: Player<any>) => player.rotationChangeEmitter,
+			changedEvent: () => APL_CHILD_CHANGED_EVENT,
 			getValue: (_player: Player<any>) => this.getSourceValue()?.action.oneofKind,
 			setValue: (eventID: EventID, player: Player<any>, newKind: APLActionKind) => {
 				const sourceValue = this.getSourceValue();
@@ -233,6 +234,9 @@ export class APLActionPicker extends Input<Player<any>, APLAction> {
 		this.currentKind = newActionKind;
 
 		if (this.actionPicker) {
+			const childIdx = this.children.indexOf(this.actionPicker);
+			if (childIdx >= 0) this.children.splice(childIdx, 1);
+			this.actionPicker.dispose();
 			this.actionPicker.rootElem.remove();
 			this.actionPicker = null;
 		}
@@ -245,7 +249,7 @@ export class APLActionPicker extends Input<Player<any>, APLAction> {
 
 		const factory = actionKindFactories[newActionKind];
 		this.actionPicker = factory.factory(this.actionDiv, this.modObject, {
-			changedEvent: (player: Player<any>) => player.rotationChangeEmitter,
+			changedEvent: () => APL_CHILD_CHANGED_EVENT,
 			getValue: () => (this.getSourceValue()?.action as any)?.[newActionKind] || factory.newValue(),
 			setValue: (eventID: EventID, player: Player<any>, newValue: any) => {
 				const sourceValue = this.getSourceValue();
@@ -255,6 +259,7 @@ export class APLActionPicker extends Input<Player<any>, APLAction> {
 				player.rotationChangeEmitter.emit(eventID);
 			},
 		});
+		this.addChild(this.actionPicker);
 		this.actionPicker.rootElem.classList.add('apl-action-' + newActionKind);
 	}
 }

--- a/ui/core/components/individual_sim_ui/apl_helpers.tsx
+++ b/ui/core/components/individual_sim_ui/apl_helpers.tsx
@@ -30,11 +30,6 @@ import { AdaptiveStringPicker } from '../pickers/string_picker.js';
 import { UnitPicker, UnitPickerConfig, UnitValue } from '../pickers/unit_picker.jsx';
 import { APLNameModal } from './apl/apl_name_modal';
 
-// Nested APL pickers are re-synced by their parent's setInputValue cascade;
-// they must not subscribe to the rotation themselves (that made every edit
-// O(n·depth) twice over). This event is never emitted.
-export const APL_CHILD_CHANGED_EVENT = new TypedEvent<void>('APLChild');
-
 export type ACTION_ID_SET =
 	| 'auras'
 	| 'stackable_auras'
@@ -653,7 +648,6 @@ export class APLPickerBuilder<T> extends Input<Player<any>, T> {
 					label: fieldConfig.label,
 					labelTooltip: fieldConfig.labelTooltip,
 					id: randomUUID(),
-					changedEvent: () => APL_CHILD_CHANGED_EVENT,
 					getValue: () => {
 						const source = builder.getSourceValue();
 						if (!source[field]) {
@@ -797,7 +791,6 @@ export function variableNameFieldConfig(field: string, options?: Partial<APLPick
 				defaultLabel: i18n.t('rotation_tab.apl.helpers.select_variable'),
 				equals: (a, b) => a === b,
 				values: [],
-				changedEvent: () => APL_CHILD_CHANGED_EVENT,
 			});
 
 			const updateValues = () => {
@@ -991,7 +984,6 @@ export function groupNameFieldConfig(field: string, options?: Partial<APLPickerB
 				defaultLabel: i18n.t('rotation_tab.apl.helpers.select_group'),
 				equals: (a, b) => a === b,
 				values: [],
-				changedEvent: () => APL_CHILD_CHANGED_EVENT,
 			});
 
 			const updateValues = () => {
@@ -1037,12 +1029,10 @@ export function groupReferenceVariablesFieldConfig(
 }
 
 // Auto-populated list of the variables a group reference passes to its group.
-// Rebuilds its item pickers only when the set of placeholder names changes.
 class APLGroupVariablesPicker extends Input<Player<any>, any[]> {
 	private readonly listPicker: ListPicker<Player<any>, any>;
 	private readonly getParentValue: () => any;
 	private readonly groupNameField: string;
-	private lastPlaceholderKey = '';
 
 	constructor(parent: HTMLElement, player: Player<any>, config: any, getParentValue: () => any, groupNameField: string) {
 		// The inner ListPicker renders the title; don't let Input render a second label.
@@ -1052,16 +1042,15 @@ class APLGroupVariablesPicker extends Input<Player<any>, any[]> {
 		this.groupNameField = groupNameField;
 
 		// Reconcile once up front so the ListPicker's init() builds the final item set.
-		this.lastPlaceholderKey = APLGroupVariablesPicker.placeholderKey(this.reconcile());
+		this.reconcile();
 
 		this.listPicker = this.addChild(
 			new ListPicker(this.rootElem, player, {
 				title: 'Group Variables',
 				titleTooltip: "Variables to pass to the group. These will override the group's internal variables.",
 				itemLabel: 'Variable',
-				changedEvent: () => APL_CHILD_CHANGED_EVENT,
 				// Copy: ListPicker splices its input in place before calling setValue.
-				getValue: () => (this.getParentValue()?.variables ?? []).slice(),
+				getValue: () => this.getInputValue(),
 				setValue: (eventID: EventID, player: Player<any>, newValue: any[]) => {
 					const parentValue = this.getParentValue();
 					if (parentValue) parentValue.variables = newValue;
@@ -1088,10 +1077,6 @@ class APLGroupVariablesPicker extends Input<Player<any>, any[]> {
 				allowedActions: ['delete', 'copy'], // Only allow delete and copy, not create
 			}),
 		);
-	}
-
-	private static placeholderKey(parentValue: any | null): string {
-		return parentValue ? (parentValue.variables || []).map((v: any) => v.__uiVarName || v.name).join('\u0000') : '';
 	}
 
 	// Scans the selected group for variable placeholders and syncs
@@ -1150,8 +1135,7 @@ class APLGroupVariablesPicker extends Input<Player<any>, any[]> {
 			variableItem.__uiVarName = varName;
 			return variableItem;
 		});
-		const changed = reconciled.length !== existing.length || reconciled.some((v, i) => v !== existing[i]);
-		if (changed) parentValue.variables = reconciled;
+		parentValue.variables = reconciled;
 		return parentValue;
 	}
 
@@ -1166,16 +1150,9 @@ class APLGroupVariablesPicker extends Input<Player<any>, any[]> {
 	setInputValue(newValue: any[]) {
 		const parentValue = this.getParentValue();
 		if (parentValue) parentValue.variables = newValue;
-		const reconciled = this.reconcile();
-		const key = APLGroupVariablesPicker.placeholderKey(reconciled);
-		if (key !== this.lastPlaceholderKey) {
-			this.lastPlaceholderKey = key;
-			// Clear first to force picker recreation — labels are set in the
-			// constructor and won't update on reuse.
-			this.listPicker.setInputValue([]);
-		}
+		this.reconcile();
 		// Cascade to the nested list (its items no longer self-subscribe).
-		this.listPicker.setInputValue((reconciled?.variables ?? []).slice());
+		this.listPicker.setInputValue(this.getInputValue());
 	}
 }
 
@@ -1184,7 +1161,8 @@ class APLGroupVariablePicker extends Input<Player<any>, any> {
 	private readonly valuePicker: TextDropdownPicker<Player<any>, string>;
 	private readonly getParentValue: () => any;
 	private readonly groupNameField: string;
-	private readonly variableName: string;
+	private readonly nameLabel: HTMLElement;
+	private variableName: string;
 
 	constructor(
 		parent: HTMLElement,
@@ -1199,11 +1177,10 @@ class APLGroupVariablePicker extends Input<Player<any>, any> {
 		this.groupNameField = groupNameField;
 		this.variableName = variableName;
 
-		// Create label for the variable name
-		const label = document.createElement('label');
-		label.textContent = `${this.variableName}:`;
-		label.classList.add('group-variable-label', 'fw-bold', 'd-block');
-		this.rootElem.appendChild(label);
+		// Label for the variable name (kept current by setInputValue when the row is reused).
+		this.nameLabel = document.createElement('label');
+		this.nameLabel.classList.add('group-variable-label', 'fw-bold', 'd-block');
+		this.rootElem.appendChild(this.nameLabel);
 
 		// Variable value picker
 		this.valuePicker = this.addChild(
@@ -1214,7 +1191,6 @@ class APLGroupVariablePicker extends Input<Player<any>, any> {
 				defaultLabel: i18n.t('rotation_tab.apl.helpers.select_variable'),
 				equals: (a, b) => a === b,
 				values: [],
-				changedEvent: () => APL_CHILD_CHANGED_EVENT,
 				getValue: () => {
 					const item = this.getSourceValue();
 					if (item?.value?.value?.variableRef?.name) {
@@ -1279,6 +1255,8 @@ class APLGroupVariablePicker extends Input<Player<any>, any> {
 
 	setInputValue(newValue: any) {
 		if (!newValue) return;
+		this.variableName = newValue.__uiVarName || newValue.name || this.variableName;
+		this.nameLabel.textContent = `${this.variableName}:`;
 		this.valuePicker.setInputValue(newValue.value?.value?.variableRef?.name || '');
 	}
 }

--- a/ui/core/components/individual_sim_ui/apl_helpers.tsx
+++ b/ui/core/components/individual_sim_ui/apl_helpers.tsx
@@ -321,8 +321,10 @@ const actionIdSets: Record<
 
 export type DEFAULT_UNIT_REF = 'self' | 'currentTarget';
 
-export interface APLActionIDPickerConfig<ModObject>
-	extends Omit<DropdownPickerConfig<ModObject, ActionID, ActionId>, 'defaultLabel' | 'equals' | 'setOptionContent' | 'values' | 'getValue' | 'setValue'> {
+export interface APLActionIDPickerConfig<ModObject> extends Omit<
+	DropdownPickerConfig<ModObject, ActionID, ActionId>,
+	'defaultLabel' | 'equals' | 'setOptionContent' | 'values' | 'getValue' | 'setValue'
+> {
 	actionIdSet: ACTION_ID_SET;
 	getUnitRef: (player: Player<any>) => UnitReference;
 	defaultUnitRef: DEFAULT_UNIT_REF;
@@ -389,20 +391,24 @@ export class APLActionIDPicker extends DropdownPicker<Player<any>, ActionID, Act
 			config.defaultUnitRef == 'self' ? UnitReference.create({ type: UnitType.Self }) : UnitReference.create({ type: UnitType.CurrentTarget });
 		const getActionIDs = actionIdSet.getActionIDs;
 		let updateSeq = 0;
-		const updateValues = async () => {
+		let lastMetadata: UnitMetadata | undefined;
+		const updateValues = async (force: boolean) => {
 			const seq = ++updateSeq;
 			const unitRef = getUnitRef(player);
 			const metadata = player.sim.getUnitMetadata(unitRef, player, defaultRef);
-			if (metadata) {
-				const values = await getActionIDs(metadata);
-				// A newer update (or disposal) happened while awaiting: drop this one.
-				if (seq !== updateSeq || this.isDisposed) return;
-				this.setOptions(values);
-			}
+			if (!metadata) return;
+			// The option list depends only on which metadata instance backs the
+			// unit; a rotation edit that leaves the unit alone has nothing to do.
+			if (!force && metadata === lastMetadata) return;
+			lastMetadata = metadata;
+			const values = await getActionIDs(metadata);
+			// A newer update (or disposal) happened while awaiting: drop this one.
+			if (seq !== updateSeq || this.isDisposed) return;
+			this.setOptions(values);
 		};
-		updateValues();
-		const unitMetaEvent = player.sim.unitMetadataEmitter.on(updateValues);
-		const rotationChangeEvent = player.rotationChangeEmitter.on(updateValues);
+		updateValues(true);
+		const unitMetaEvent = player.sim.unitMetadataEmitter.on(() => updateValues(true));
+		const rotationChangeEvent = player.rotationChangeEmitter.on(() => updateValues(false));
 		this.addOnDisposeCallback(() => {
 			unitMetaEvent.dispose();
 			rotationChangeEvent.dispose();
@@ -639,27 +645,29 @@ export class APLPickerBuilder<T> extends Input<Player<any>, T> {
 		fieldConfig: APLPickerBuilderFieldConfig<T, F>,
 	): APLPickerBuilderField<T, F> {
 		const field: F = fieldConfig.field;
-		const picker = fieldConfig.factory(
-			builder.rootElem,
-			builder.modObject,
-			{
-				label: fieldConfig.label,
-				labelTooltip: fieldConfig.labelTooltip,
-				id: randomUUID(),
-				changedEvent: () => APL_CHILD_CHANGED_EVENT,
-				getValue: () => {
-					const source = builder.getSourceValue();
-					if (!source[field]) {
-						source[field] = fieldConfig.newValue();
-					}
-					return source[field];
+		const picker = builder.addChild(
+			fieldConfig.factory(
+				builder.rootElem,
+				builder.modObject,
+				{
+					label: fieldConfig.label,
+					labelTooltip: fieldConfig.labelTooltip,
+					id: randomUUID(),
+					changedEvent: () => APL_CHILD_CHANGED_EVENT,
+					getValue: () => {
+						const source = builder.getSourceValue();
+						if (!source[field]) {
+							source[field] = fieldConfig.newValue();
+						}
+						return source[field];
+					},
+					setValue: (eventID: EventID, player: Player<any>, newValue: any) => {
+						builder.getSourceValue()[field] = newValue;
+						player.rotationChangeEmitter.emit(eventID);
+					},
 				},
-				setValue: (eventID: EventID, player: Player<any>, newValue: any) => {
-					builder.getSourceValue()[field] = newValue;
-					player.rotationChangeEmitter.emit(eventID);
-				},
-			},
-			() => builder.getSourceValue(),
+				() => builder.getSourceValue(),
+			),
 		);
 
 		if (field === 'vals' || field === 'actions') {
@@ -1034,12 +1042,17 @@ class APLGroupVariablesPicker extends Input<Player<any>, any[]> {
 	private readonly listPicker: ListPicker<Player<any>, any>;
 	private readonly getParentValue: () => any;
 	private readonly groupNameField: string;
-	private lastPlaceholderKey: string | null = null;
+	private lastPlaceholderKey = '';
 
 	constructor(parent: HTMLElement, player: Player<any>, config: any, getParentValue: () => any, groupNameField: string) {
-		super(parent, 'group-reference-variables-container', player, config);
+		// The inner ListPicker renders the title; don't let Input render a second label.
+		const { label: _label, labelTooltip: _labelTooltip, ...inputConfig } = config;
+		super(parent, 'group-reference-variables-container', player, inputConfig);
 		this.getParentValue = getParentValue;
 		this.groupNameField = groupNameField;
+
+		// Reconcile once up front so the ListPicker's init() builds the final item set.
+		this.lastPlaceholderKey = APLGroupVariablesPicker.placeholderKey(this.reconcile());
 
 		this.listPicker = this.addChild(
 			new ListPicker(this.rootElem, player, {
@@ -1048,7 +1061,7 @@ class APLGroupVariablesPicker extends Input<Player<any>, any[]> {
 				itemLabel: 'Variable',
 				changedEvent: () => APL_CHILD_CHANGED_EVENT,
 				// Copy: ListPicker splices its input in place before calling setValue.
-				getValue: () => (this.reconcile()?.variables ?? []).slice(),
+				getValue: () => (this.getParentValue()?.variables ?? []).slice(),
 				setValue: (eventID: EventID, player: Player<any>, newValue: any[]) => {
 					const parentValue = this.getParentValue();
 					if (parentValue) parentValue.variables = newValue;
@@ -1075,23 +1088,10 @@ class APLGroupVariablesPicker extends Input<Player<any>, any[]> {
 				allowedActions: ['delete', 'copy'], // Only allow delete and copy, not create
 			}),
 		);
+	}
 
-		const updateVariableList = () => {
-			const parentValue = this.reconcile();
-			const key = parentValue ? (parentValue.variables || []).map((v: any) => v.__uiVarName || v.name).join('\u0000') : '';
-			if (key === this.lastPlaceholderKey) {
-				// Same placeholders: the existing item pickers refresh themselves.
-				return;
-			}
-			this.lastPlaceholderKey = key;
-			// Clear first to force picker recreation — labels are set in the
-			// constructor and won't update on reuse.
-			this.listPicker.setInputValue([]);
-			this.listPicker.setInputValue(parentValue?.variables ?? []);
-		};
-		const rotationEvent = player.rotationChangeEmitter.on(updateVariableList);
-		this.addOnDisposeCallback(() => rotationEvent.dispose());
-		updateVariableList();
+	private static placeholderKey(parentValue: any | null): string {
+		return parentValue ? (parentValue.variables || []).map((v: any) => v.__uiVarName || v.name).join('\u0000') : '';
 	}
 
 	// Scans the selected group for variable placeholders and syncs
@@ -1166,8 +1166,16 @@ class APLGroupVariablesPicker extends Input<Player<any>, any[]> {
 	setInputValue(newValue: any[]) {
 		const parentValue = this.getParentValue();
 		if (parentValue) parentValue.variables = newValue;
+		const reconciled = this.reconcile();
+		const key = APLGroupVariablesPicker.placeholderKey(reconciled);
+		if (key !== this.lastPlaceholderKey) {
+			this.lastPlaceholderKey = key;
+			// Clear first to force picker recreation — labels are set in the
+			// constructor and won't update on reuse.
+			this.listPicker.setInputValue([]);
+		}
 		// Cascade to the nested list (its items no longer self-subscribe).
-		this.listPicker.setInputValue((this.reconcile()?.variables ?? []).slice());
+		this.listPicker.setInputValue((reconciled?.variables ?? []).slice());
 	}
 }
 
@@ -1198,35 +1206,37 @@ class APLGroupVariablePicker extends Input<Player<any>, any> {
 		this.rootElem.appendChild(label);
 
 		// Variable value picker
-		this.valuePicker = new TextDropdownPicker(this.rootElem, this.modObject, {
-			id: randomUUID(),
-			label: '',
-			labelTooltip: i18n.t('rotation_tab.apl.helpers.field_configs.variable_assignment_tooltip', { variableName: this.variableName }),
-			defaultLabel: i18n.t('rotation_tab.apl.helpers.select_variable'),
-			equals: (a, b) => a === b,
-			values: [],
-			changedEvent: () => APL_CHILD_CHANGED_EVENT,
-			getValue: () => {
-				const item = this.getSourceValue();
-				if (item?.value?.value?.variableRef?.name) {
-					return item.value.value.variableRef.name;
-				}
-				return '';
-			},
-			setValue: (eventID: EventID, player: Player<any>, newValue: string) => {
-				const item = this.getSourceValue();
-				if (item && newValue) {
-					item.value = {
-						uuid: { value: randomUUID() },
-						value: {
-							oneofKind: 'variableRef',
-							variableRef: { name: newValue },
-						},
-					};
-					player.rotationChangeEmitter.emit(eventID);
-				}
-			},
-		});
+		this.valuePicker = this.addChild(
+			new TextDropdownPicker(this.rootElem, this.modObject, {
+				id: randomUUID(),
+				label: '',
+				labelTooltip: i18n.t('rotation_tab.apl.helpers.field_configs.variable_assignment_tooltip', { variableName: this.variableName }),
+				defaultLabel: i18n.t('rotation_tab.apl.helpers.select_variable'),
+				equals: (a, b) => a === b,
+				values: [],
+				changedEvent: () => APL_CHILD_CHANGED_EVENT,
+				getValue: () => {
+					const item = this.getSourceValue();
+					if (item?.value?.value?.variableRef?.name) {
+						return item.value.value.variableRef.name;
+					}
+					return '';
+				},
+				setValue: (eventID: EventID, player: Player<any>, newValue: string) => {
+					const item = this.getSourceValue();
+					if (item && newValue) {
+						item.value = {
+							uuid: { value: randomUUID() },
+							value: {
+								oneofKind: 'variableRef',
+								variableRef: { name: newValue },
+							},
+						};
+						player.rotationChangeEmitter.emit(eventID);
+					}
+				},
+			}),
+		);
 
 		// Update available variables when group changes
 		const updateAvailableVariables = () => {
@@ -1269,7 +1279,7 @@ class APLGroupVariablePicker extends Input<Player<any>, any> {
 
 	setInputValue(newValue: any) {
 		if (!newValue) return;
-		// The value picker will be updated via the change event
+		this.valuePicker.setInputValue(newValue.value?.value?.variableRef?.name || '');
 	}
 }
 

--- a/ui/core/components/individual_sim_ui/apl_helpers.tsx
+++ b/ui/core/components/individual_sim_ui/apl_helpers.tsx
@@ -1,9 +1,11 @@
 import { ref } from 'tsx-vanilla';
 
-import { CacheHandler } from '../../cache_handler';
 import i18n from '../../../i18n/config';
+import { translateStat } from '../../../i18n/localization.js';
+import { CacheHandler } from '../../cache_handler';
 import { Player, UnitMetadata } from '../../player.js';
 import {
+	APLActionDamageAmplifier_AmplificationType,
 	APLActionGuardianHotwDpsRotation_Strategy as HotwStrategy,
 	APLActionItemSwap_SwapSet as ItemSwapSet,
 	APLValue,
@@ -11,14 +13,12 @@ import {
 	APLValueRuneSlot,
 	APLValueRuneType,
 	APLValueVariable,
-	APLActionDamageAmplifier_AmplificationType,
 } from '../../proto/apl.js';
 import { ActionID, OtherAction, Stat, UnitReference, UnitReference_Type as UnitType } from '../../proto/common.js';
 import { FeralDruid_Rotation_AplType } from '../../proto/druid.js';
 import { ActionId, defaultTargetIcon, getPetIconFromName } from '../../proto_utils/action_id.js';
 import { renameAPLReference } from '../../proto_utils/apl_utils.js';
 import { getStatName } from '../../proto_utils/names.js';
-import { translateStat } from '../../../i18n/localization.js';
 import { EventID, TypedEvent } from '../../typed_event.js';
 import { bucket, getEnumValues, randomUUID } from '../../utils.js';
 import { Input, InputConfig } from '../input.jsx';
@@ -29,6 +29,11 @@ import { NumberPicker, NumberPickerConfig } from '../pickers/number_picker.js';
 import { AdaptiveStringPicker } from '../pickers/string_picker.js';
 import { UnitPicker, UnitPickerConfig, UnitValue } from '../pickers/unit_picker.jsx';
 import { APLNameModal } from './apl/apl_name_modal';
+
+// Nested APL pickers are re-synced by their parent's setInputValue cascade;
+// they must not subscribe to the rotation themselves (that made every edit
+// O(n·depth) twice over). This event is never emitted.
+export const APL_CHILD_CHANGED_EVENT = new TypedEvent<void>('APLChild');
 
 export type ACTION_ID_SET =
 	| 'auras'
@@ -383,11 +388,15 @@ export class APLActionIDPicker extends DropdownPicker<Player<any>, ActionID, Act
 		const defaultRef =
 			config.defaultUnitRef == 'self' ? UnitReference.create({ type: UnitType.Self }) : UnitReference.create({ type: UnitType.CurrentTarget });
 		const getActionIDs = actionIdSet.getActionIDs;
+		let updateSeq = 0;
 		const updateValues = async () => {
+			const seq = ++updateSeq;
 			const unitRef = getUnitRef(player);
 			const metadata = player.sim.getUnitMetadata(unitRef, player, defaultRef);
 			if (metadata) {
 				const values = await getActionIDs(metadata);
+				// A newer update (or disposal) happened while awaiting: drop this one.
+				if (seq !== updateSeq || this.isDisposed) return;
 				this.setOptions(values);
 			}
 		};
@@ -637,7 +646,7 @@ export class APLPickerBuilder<T> extends Input<Player<any>, T> {
 				label: fieldConfig.label,
 				labelTooltip: fieldConfig.labelTooltip,
 				id: randomUUID(),
-				changedEvent: (player: Player<any>) => player.rotationChangeEmitter,
+				changedEvent: () => APL_CHILD_CHANGED_EVENT,
 				getValue: () => {
 					const source = builder.getSourceValue();
 					if (!source[field]) {
@@ -780,7 +789,7 @@ export function variableNameFieldConfig(field: string, options?: Partial<APLPick
 				defaultLabel: i18n.t('rotation_tab.apl.helpers.select_variable'),
 				equals: (a, b) => a === b,
 				values: [],
-				changedEvent: (player: Player<any>) => player.rotationChangeEmitter,
+				changedEvent: () => APL_CHILD_CHANGED_EVENT,
 			});
 
 			const updateValues = () => {
@@ -803,7 +812,8 @@ export function variableNameFieldConfig(field: string, options?: Partial<APLPick
 
 			// Update values initially and when rotation changes
 			updateValues();
-			player.rotationChangeEmitter.on(updateValues);
+			const rotationEvent = player.rotationChangeEmitter.on(updateValues);
+			picker.addOnDisposeCallback(() => rotationEvent.dispose());
 
 			return picker;
 		},
@@ -973,7 +983,7 @@ export function groupNameFieldConfig(field: string, options?: Partial<APLPickerB
 				defaultLabel: i18n.t('rotation_tab.apl.helpers.select_group'),
 				equals: (a, b) => a === b,
 				values: [],
-				changedEvent: (player: Player<any>) => player.rotationChangeEmitter,
+				changedEvent: () => APL_CHILD_CHANGED_EVENT,
 			});
 
 			const updateValues = () => {
@@ -996,7 +1006,8 @@ export function groupNameFieldConfig(field: string, options?: Partial<APLPickerB
 
 			// Update values initially and when rotation changes
 			updateValues();
-			player.rotationChangeEmitter.on(updateValues);
+			const rotationEvent = player.rotationChangeEmitter.on(updateValues);
+			picker.addOnDisposeCallback(() => rotationEvent.dispose());
 
 			return picker;
 		},
@@ -1012,25 +1023,35 @@ export function groupReferenceVariablesFieldConfig(
 	return {
 		field: field,
 		newValue: () => [],
-		factory: (parent, player, config, getParentValue) => {
-			// Create a simple container
-			const container = document.createElement('div');
-			container.classList.add('group-reference-variables-container');
-			parent.appendChild(container);
+		factory: (parent, player, config, getParentValue) => new APLGroupVariablesPicker(parent, player, config, getParentValue, groupNameField),
+		...(options || {}),
+	};
+}
 
-			// Create a ListPicker for the variables
-			const listPicker = new ListPicker(container, player, {
+// Auto-populated list of the variables a group reference passes to its group.
+// Rebuilds its item pickers only when the set of placeholder names changes.
+class APLGroupVariablesPicker extends Input<Player<any>, any[]> {
+	private readonly listPicker: ListPicker<Player<any>, any>;
+	private readonly getParentValue: () => any;
+	private readonly groupNameField: string;
+	private lastPlaceholderKey: string | null = null;
+
+	constructor(parent: HTMLElement, player: Player<any>, config: any, getParentValue: () => any, groupNameField: string) {
+		super(parent, 'group-reference-variables-container', player, config);
+		this.getParentValue = getParentValue;
+		this.groupNameField = groupNameField;
+
+		this.listPicker = this.addChild(
+			new ListPicker(this.rootElem, player, {
 				title: 'Group Variables',
 				titleTooltip: "Variables to pass to the group. These will override the group's internal variables.",
 				itemLabel: 'Variable',
-				changedEvent: (player: Player<any>) => player.rotationChangeEmitter,
-				getValue: () => {
-					const parentValue = getParentValue();
-					return parentValue?.variables || [];
-				},
+				changedEvent: () => APL_CHILD_CHANGED_EVENT,
+				// Copy: ListPicker splices its input in place before calling setValue.
+				getValue: () => (this.reconcile()?.variables ?? []).slice(),
 				setValue: (eventID: EventID, player: Player<any>, newValue: any[]) => {
-					const parentValue = getParentValue();
-					parentValue.variables = newValue;
+					const parentValue = this.getParentValue();
+					if (parentValue) parentValue.variables = newValue;
 					config.setValue(eventID, player, newValue);
 				},
 				newItem: () => {
@@ -1042,115 +1063,112 @@ export function groupReferenceVariablesFieldConfig(
 				}),
 				newItemPicker: (
 					parent: HTMLElement,
-					listPicker: ListPicker<Player<any>, any>,
+					_listPicker: ListPicker<Player<any>, any>,
 					index: number,
 					itemConfig: ListItemPickerConfig<Player<any>, any>,
 				) => {
-					const currentVariables = getParentValue()?.variables || [];
+					const currentVariables = this.getParentValue()?.variables || [];
 					const variableName = currentVariables[index]?.__uiVarName || currentVariables[index]?.name || '';
-					return new APLGroupVariablePicker(parent, player, itemConfig, getParentValue, groupNameField, variableName);
+					return new APLGroupVariablePicker(parent, player, itemConfig, this.getParentValue, this.groupNameField, variableName);
 				},
 				inlineMenuBar: false, // Hide the add/remove buttons since we auto-populate
 				allowedActions: ['delete', 'copy'], // Only allow delete and copy, not create
-			});
+			}),
+		);
 
-			// Function to update the list based on the selected group
-			const updateVariableList = () => {
-				const parentValue = getParentValue();
-				const selectedGroupName = parentValue[groupNameField];
+		const updateVariableList = () => {
+			const parentValue = this.reconcile();
+			const key = parentValue ? (parentValue.variables || []).map((v: any) => v.__uiVarName || v.name).join('\u0000') : '';
+			if (key === this.lastPlaceholderKey) {
+				// Same placeholders: the existing item pickers refresh themselves.
+				return;
+			}
+			this.lastPlaceholderKey = key;
+			// Clear first to force picker recreation — labels are set in the
+			// constructor and won't update on reuse.
+			this.listPicker.setInputValue([]);
+			this.listPicker.setInputValue(parentValue?.variables ?? []);
+		};
+		const rotationEvent = player.rotationChangeEmitter.on(updateVariableList);
+		this.addOnDisposeCallback(() => rotationEvent.dispose());
+		updateVariableList();
+	}
 
-				if (!selectedGroupName) {
-					listPicker.setInputValue([]);
-					container.classList.add('d-none');
-					return;
-				}
+	// Scans the selected group for variable placeholders and syncs
+	// parentValue.variables to that set (keeping existing assignments). Returns
+	// the parent value, or null when there is nothing to show.
+	private reconcile(): any | null {
+		const parentValue = this.getParentValue();
+		const selectedGroupName = parentValue?.[this.groupNameField];
+		if (!selectedGroupName) {
+			this.rootElem.classList.add('d-none');
+			return null;
+		}
+		const groups = this.modObject.aplRotation?.groups || [];
+		const selectedGroup = groups.find((group: any) => group.name === selectedGroupName);
+		if (!selectedGroup) {
+			this.rootElem.classList.add('d-none');
+			return null;
+		}
 
-				// Find the selected group
-				const groups = player.aplRotation?.groups || [];
-				const selectedGroup = groups.find((group: any) => group.name === selectedGroupName);
+		const placeholderVariables = new Set<string>();
+		const scanForPlaceholders = (obj: any) => {
+			if (!obj || typeof obj !== 'object') return;
+			if (obj?.value?.oneofKind === 'variablePlaceholder') {
+				const name = obj.value.variablePlaceholder?.name;
+				if (name) placeholderVariables.add(name);
+			}
+			if (Array.isArray(obj)) {
+				obj.forEach(child => scanForPlaceholders(child));
+			} else {
+				Object.values(obj).forEach(child => scanForPlaceholders(child));
+			}
+		};
+		selectedGroup.actions?.forEach((actionItem: any) => scanForPlaceholders(actionItem));
 
-				if (!selectedGroup) {
-					listPicker.setInputValue([]);
-					container.classList.add('d-none');
-					return;
-				}
+		if (placeholderVariables.size === 0) {
+			this.rootElem.classList.add('d-none');
+			return null;
+		}
+		this.rootElem.classList.remove('d-none');
 
-				// Prepare a set and recursive scanner for VariablePlaceholder values.
-				const placeholderVariables = new Set<string>();
-				const scanForPlaceholders = (obj: any) => {
-					if (!obj || typeof obj !== 'object') return;
-					// Detect a variable placeholder APLValue.
-					if (obj?.value?.oneofKind === 'variablePlaceholder') {
-						const name = obj.value.variablePlaceholder?.name;
-						if (name) placeholderVariables.add(name);
-					}
-					// Recurse through arrays and object properties.
-					if (Array.isArray(obj)) {
-						obj.forEach(child => scanForPlaceholders(child));
-					} else {
-						Object.values(obj).forEach(child => scanForPlaceholders(child));
-					}
+		const existing: any[] = parentValue.variables || [];
+		const reconciled = Array.from(placeholderVariables).map(varName => {
+			let variableItem = existing.find((v: any) => v.name === varName);
+			if (!variableItem) {
+				variableItem = {
+					name: varName,
+					value: {
+						uuid: { value: randomUUID() },
+						value: {
+							oneofKind: 'variableRef',
+							variableRef: { name: '' },
+						},
+					},
 				};
+			}
+			variableItem.__uiVarName = varName;
+			return variableItem;
+		});
+		const changed = reconciled.length !== existing.length || reconciled.some((v, i) => v !== existing[i]);
+		if (changed) parentValue.variables = reconciled;
+		return parentValue;
+	}
 
-				// Perform a full recursive scan on every action in the group.
-				selectedGroup.actions?.forEach((actionItem: any) => {
-					scanForPlaceholders(actionItem);
-				});
+	getInputElem(): HTMLElement | null {
+		return this.rootElem;
+	}
 
-				// Hide the container if no placeholder variables found
-				if (placeholderVariables.size === 0) {
-					container.classList.add('d-none');
-					listPicker.setInputValue([]);
-					return;
-				}
+	getInputValue(): any[] {
+		return (this.getParentValue()?.variables || []).slice();
+	}
 
-				// Show the container and populate variables
-				container.classList.remove('d-none');
-
-				parentValue.variables = Array.from(placeholderVariables).map(varName => {
-					// Find existing variable or create new one
-					let variableItem = parentValue?.variables.find((v: any) => v.name === varName);
-					if (!variableItem) {
-						variableItem = {
-							name: varName,
-							value: {
-								uuid: { value: randomUUID() },
-								value: {
-									oneofKind: 'variableRef',
-									variableRef: { name: '' },
-								},
-							},
-						};
-					}
-					// Attach UI variable name for label
-					variableItem.__uiVarName = varName;
-					return variableItem;
-				});
-
-				// Clear first to force picker recreation — labels are set in
-				// the constructor and won't update on reuse.
-				listPicker.setInputValue([]);
-				listPicker.setInputValue(parentValue.variables);
-			};
-
-			// Listen for group name changes and rotation changes
-			player.rotationChangeEmitter.on(updateVariableList);
-			updateVariableList();
-
-			return {
-				rootElem: container,
-				getInputValue: () => {
-					const parentValue = getParentValue();
-					return parentValue?.variables || [];
-				},
-				setInputValue: (newValue: any[]) => {
-					const parentValue = getParentValue();
-					parentValue.variables = newValue;
-				},
-			} as any;
-		},
-		...(options || {}),
-	};
+	setInputValue(newValue: any[]) {
+		const parentValue = this.getParentValue();
+		if (parentValue) parentValue.variables = newValue;
+		// Cascade to the nested list (its items no longer self-subscribe).
+		this.listPicker.setInputValue((this.reconcile()?.variables ?? []).slice());
+	}
 }
 
 // Simple picker for individual group variables
@@ -1187,7 +1205,7 @@ class APLGroupVariablePicker extends Input<Player<any>, any> {
 			defaultLabel: i18n.t('rotation_tab.apl.helpers.select_variable'),
 			equals: (a, b) => a === b,
 			values: [],
-			changedEvent: (player: Player<any>) => player.rotationChangeEmitter,
+			changedEvent: () => APL_CHILD_CHANGED_EVENT,
 			getValue: () => {
 				const item = this.getSourceValue();
 				if (item?.value?.value?.variableRef?.name) {
@@ -1231,7 +1249,8 @@ class APLGroupVariablePicker extends Input<Player<any>, any> {
 		};
 
 		// Listen for group name changes
-		this.modObject.rotationChangeEmitter.on(updateAvailableVariables);
+		const rotationEvent = this.modObject.rotationChangeEmitter.on(updateAvailableVariables);
+		this.addOnDisposeCallback(() => rotationEvent.dispose());
 		updateAvailableVariables();
 
 		this.init();

--- a/ui/core/components/individual_sim_ui/apl_values.ts
+++ b/ui/core/components/individual_sim_ui/apl_values.ts
@@ -347,9 +347,7 @@ export class APLValuePicker extends Input<Player<any>, APLValue | undefined> {
 		this.currentKind = newKind;
 
 		if (this.valuePicker) {
-			const childIdx = this.children.indexOf(this.valuePicker);
-			if (childIdx >= 0) this.children.splice(childIdx, 1);
-			this.valuePicker.dispose();
+			this.disposeChild(this.valuePicker);
 			this.valuePicker.rootElem.remove();
 			this.valuePicker = null;
 		}

--- a/ui/core/components/individual_sim_ui/apl_values.ts
+++ b/ui/core/components/individual_sim_ui/apl_values.ts
@@ -179,102 +179,106 @@ export class APLValuePicker extends Input<Player<any>, APLValue | undefined> {
 			);
 		}
 
-		this.kindPicker = new TextDropdownPicker(this.rootElem, player, {
-			defaultLabel: i18n.t('rotation_tab.apl.values.no_condition'),
-			id: randomUUID(),
-			values: [
-				{
-					value: undefined,
-					label: i18n.t('rotation_tab.apl.values.none'),
-				} as TextDropdownValueConfig<APLValueKind>,
-			].concat(
-				allValueKinds.map(kind => {
-					const factory = valueKindFactories[kind];
-					const resolveString = factory.dynamicStringResolver || ((value: string) => value);
-					return {
-						value: kind,
-						label: resolveString(factory.label, player),
-						submenu: factory.submenu,
-						tooltip: factory.fullDescription
-							? `<p>${resolveString(factory.shortDescription, player)}</p> ${resolveString(factory.fullDescription, player)}`
-							: resolveString(factory.shortDescription, player),
-					};
-				}),
-			),
-			equals: (a, b) => a == b,
-			changedEvent: () => APL_CHILD_CHANGED_EVENT,
-			getValue: (_player: Player<any>) => this.getSourceValue()?.value.oneofKind,
-			setValue: (eventID: EventID, player: Player<any>, newKind: APLValueKind) => {
-				const sourceValue = this.getSourceValue();
-				const oldKind = sourceValue?.value.oneofKind;
-				if (oldKind == newKind) {
-					return;
-				}
+		this.kindPicker = this.addChild(
+			new TextDropdownPicker(this.rootElem, player, {
+				defaultLabel: i18n.t('rotation_tab.apl.values.no_condition'),
+				id: randomUUID(),
+				values: [
+					{
+						value: undefined,
+						label: i18n.t('rotation_tab.apl.values.none'),
+					} as TextDropdownValueConfig<APLValueKind>,
+				].concat(
+					allValueKinds.map(kind => {
+						const factory = valueKindFactories[kind];
+						const resolveString = factory.dynamicStringResolver || ((value: string) => value);
+						return {
+							value: kind,
+							label: resolveString(factory.label, player),
+							submenu: factory.submenu,
+							tooltip: factory.fullDescription
+								? `<p>${resolveString(factory.shortDescription, player)}</p> ${resolveString(factory.fullDescription, player)}`
+								: resolveString(factory.shortDescription, player),
+						};
+					}),
+				),
+				equals: (a, b) => a == b,
+				changedEvent: () => APL_CHILD_CHANGED_EVENT,
+				getValue: (_player: Player<any>) => this.getSourceValue()?.value.oneofKind,
+				setValue: (eventID: EventID, player: Player<any>, newKind: APLValueKind) => {
+					const sourceValue = this.getSourceValue();
+					const oldKind = sourceValue?.value.oneofKind;
+					if (oldKind == newKind) {
+						return;
+					}
 
-				if (newKind) {
-					const factory = valueKindFactories[newKind];
-					let newSourceValue = this.makeAPLValue(newKind, factory.newValue());
-					if (sourceValue) {
-						// Some pre-fill logic when swapping kinds.
-						if (oldKind && this.valuePicker) {
-							if (newKind == 'not') {
-								(newSourceValue.value as APLValueImplStruct<'not'>).not.val = this.makeAPLValue(oldKind, this.valuePicker.getInputValue());
-							} else if (sourceValue.value.oneofKind == 'not' && sourceValue.value.not.val?.value.oneofKind == newKind) {
-								newSourceValue = sourceValue.value.not.val;
-							} else if (newKind == 'and') {
-								if (sourceValue.value.oneofKind == 'or') {
-									(newSourceValue.value as APLValueImplStruct<'and'>).and.vals = sourceValue.value.or.vals;
-								} else {
-									(newSourceValue.value as APLValueImplStruct<'and'>).and.vals = [
-										this.makeAPLValue(oldKind, this.valuePicker.getInputValue()),
-									];
+					if (newKind) {
+						const factory = valueKindFactories[newKind];
+						let newSourceValue = this.makeAPLValue(newKind, factory.newValue());
+						if (sourceValue) {
+							// Some pre-fill logic when swapping kinds.
+							if (oldKind && this.valuePicker) {
+								if (newKind == 'not') {
+									(newSourceValue.value as APLValueImplStruct<'not'>).not.val = this.makeAPLValue(oldKind, this.valuePicker.getInputValue());
+								} else if (sourceValue.value.oneofKind == 'not' && sourceValue.value.not.val?.value.oneofKind == newKind) {
+									newSourceValue = sourceValue.value.not.val;
+								} else if (newKind == 'and') {
+									if (sourceValue.value.oneofKind == 'or') {
+										(newSourceValue.value as APLValueImplStruct<'and'>).and.vals = sourceValue.value.or.vals;
+									} else {
+										(newSourceValue.value as APLValueImplStruct<'and'>).and.vals = [
+											this.makeAPLValue(oldKind, this.valuePicker.getInputValue()),
+										];
+									}
+								} else if (newKind == 'or') {
+									if (sourceValue.value.oneofKind == 'and') {
+										(newSourceValue.value as APLValueImplStruct<'or'>).or.vals = sourceValue.value.and.vals;
+									} else {
+										(newSourceValue.value as APLValueImplStruct<'or'>).or.vals = [
+											this.makeAPLValue(oldKind, this.valuePicker.getInputValue()),
+										];
+									}
+								} else if (newKind == 'min') {
+									if (sourceValue.value.oneofKind == 'max') {
+										(newSourceValue.value as APLValueImplStruct<'min'>).min.vals = sourceValue.value.max.vals;
+									} else {
+										(newSourceValue.value as APLValueImplStruct<'min'>).min.vals = [
+											this.makeAPLValue(oldKind, this.valuePicker.getInputValue()),
+										];
+									}
+								} else if (newKind == 'max') {
+									if (sourceValue.value.oneofKind == 'min') {
+										(newSourceValue.value as APLValueImplStruct<'max'>).max.vals = sourceValue.value.min.vals;
+									} else {
+										(newSourceValue.value as APLValueImplStruct<'max'>).max.vals = [
+											this.makeAPLValue(oldKind, this.valuePicker.getInputValue()),
+										];
+									}
+								} else if (sourceValue.value.oneofKind == 'and' && sourceValue.value.and.vals?.[0]?.value.oneofKind == newKind) {
+									newSourceValue = sourceValue.value.and.vals[0];
+								} else if (sourceValue.value.oneofKind == 'or' && sourceValue.value.or.vals?.[0]?.value.oneofKind == newKind) {
+									newSourceValue = sourceValue.value.or.vals[0];
+								} else if (sourceValue.value.oneofKind == 'min' && sourceValue.value.min.vals?.[0]?.value.oneofKind == newKind) {
+									newSourceValue = sourceValue.value.min.vals[0];
+								} else if (sourceValue.value.oneofKind == 'max' && sourceValue.value.max.vals?.[0]?.value.oneofKind == newKind) {
+									newSourceValue = sourceValue.value.max.vals[0];
+								} else if (newKind == 'cmp') {
+									(newSourceValue.value as APLValueImplStruct<'cmp'>).cmp.lhs = this.makeAPLValue(oldKind, this.valuePicker.getInputValue());
 								}
-							} else if (newKind == 'or') {
-								if (sourceValue.value.oneofKind == 'and') {
-									(newSourceValue.value as APLValueImplStruct<'or'>).or.vals = sourceValue.value.and.vals;
-								} else {
-									(newSourceValue.value as APLValueImplStruct<'or'>).or.vals = [this.makeAPLValue(oldKind, this.valuePicker.getInputValue())];
-								}
-							} else if (newKind == 'min') {
-								if (sourceValue.value.oneofKind == 'max') {
-									(newSourceValue.value as APLValueImplStruct<'min'>).min.vals = sourceValue.value.max.vals;
-								} else {
-									(newSourceValue.value as APLValueImplStruct<'min'>).min.vals = [
-										this.makeAPLValue(oldKind, this.valuePicker.getInputValue()),
-									];
-								}
-							} else if (newKind == 'max') {
-								if (sourceValue.value.oneofKind == 'min') {
-									(newSourceValue.value as APLValueImplStruct<'max'>).max.vals = sourceValue.value.min.vals;
-								} else {
-									(newSourceValue.value as APLValueImplStruct<'max'>).max.vals = [
-										this.makeAPLValue(oldKind, this.valuePicker.getInputValue()),
-									];
-								}
-							} else if (sourceValue.value.oneofKind == 'and' && sourceValue.value.and.vals?.[0]?.value.oneofKind == newKind) {
-								newSourceValue = sourceValue.value.and.vals[0];
-							} else if (sourceValue.value.oneofKind == 'or' && sourceValue.value.or.vals?.[0]?.value.oneofKind == newKind) {
-								newSourceValue = sourceValue.value.or.vals[0];
-							} else if (sourceValue.value.oneofKind == 'min' && sourceValue.value.min.vals?.[0]?.value.oneofKind == newKind) {
-								newSourceValue = sourceValue.value.min.vals[0];
-							} else if (sourceValue.value.oneofKind == 'max' && sourceValue.value.max.vals?.[0]?.value.oneofKind == newKind) {
-								newSourceValue = sourceValue.value.max.vals[0];
-							} else if (newKind == 'cmp') {
-								(newSourceValue.value as APLValueImplStruct<'cmp'>).cmp.lhs = this.makeAPLValue(oldKind, this.valuePicker.getInputValue());
 							}
 						}
-					}
-					if (sourceValue) {
-						sourceValue.value = newSourceValue.value;
+						if (sourceValue) {
+							sourceValue.value = newSourceValue.value;
+						} else {
+							this.setSourceValue(eventID, newSourceValue);
+						}
 					} else {
-						this.setSourceValue(eventID, newSourceValue);
+						this.setSourceValue(eventID, undefined);
 					}
-				} else {
-					this.setSourceValue(eventID, undefined);
-				}
-				player.rotationChangeEmitter.emit(eventID);
-			},
-		});
+					player.rotationChangeEmitter.emit(eventID);
+				},
+			}),
+		);
 
 		this.currentKind = undefined;
 		this.valuePicker = null;
@@ -345,6 +349,7 @@ export class APLValuePicker extends Input<Player<any>, APLValue | undefined> {
 			return;
 		}
 		this.currentKind = newKind;
+		this.kindPicker.setInputValue(newKind);
 
 		if (this.valuePicker) {
 			this.disposeChild(this.valuePicker);
@@ -355,8 +360,6 @@ export class APLValuePicker extends Input<Player<any>, APLValue | undefined> {
 		if (!newKind) {
 			return;
 		}
-
-		this.kindPicker.setInputValue(newKind);
 
 		const factory = valueKindFactories[newKind];
 		this.valuePicker = factory.factory(this.rootElem, this.modObject, {
@@ -958,7 +961,7 @@ const valueKindFactories: { [f in ValidAPLValueKind]: ValueKindConfig<APLValueIm
 		submenu: ['resources', 'eclipse'],
 		shortDescription: i18n.t('rotation_tab.apl.values.solar_energy.tooltip'),
 		newValue: APLValueCurrentSolarEnergy.create,
-		includeIf: (player: Player<any>, _isPrepull: boolean) =>  player.getSpec() == Spec.SpecBalanceDruid,
+		includeIf: (player: Player<any>, _isPrepull: boolean) => player.getSpec() == Spec.SpecBalanceDruid,
 		fields: [],
 	}),
 	currentLunarEnergy: inputBuilder({
@@ -966,7 +969,7 @@ const valueKindFactories: { [f in ValidAPLValueKind]: ValueKindConfig<APLValueIm
 		submenu: ['resources', 'eclipse'],
 		shortDescription: i18n.t('rotation_tab.apl.values.lunar_energy.tooltip'),
 		newValue: APLValueCurrentLunarEnergy.create,
-		includeIf: (player: Player<any>, _isPrepull: boolean) =>  player.getSpec() == Spec.SpecBalanceDruid,
+		includeIf: (player: Player<any>, _isPrepull: boolean) => player.getSpec() == Spec.SpecBalanceDruid,
 		fields: [],
 	}),
 	druidCurrentEclipsePhase: inputBuilder({
@@ -974,7 +977,7 @@ const valueKindFactories: { [f in ValidAPLValueKind]: ValueKindConfig<APLValueIm
 		submenu: ['resources', 'eclipse'],
 		shortDescription: i18n.t('rotation_tab.apl.values.current_eclipse_phase.tooltip'),
 		newValue: APLValueCurrentEclipsePhase.create,
-		includeIf: (player: Player<any>, _isPrepull: boolean) =>  player.getSpec() == Spec.SpecBalanceDruid,
+		includeIf: (player: Player<any>, _isPrepull: boolean) => player.getSpec() == Spec.SpecBalanceDruid,
 		fields: [AplHelpers.eclipseTypeFieldConfig('eclipsePhase')],
 	}),
 	currentGenericResource: inputBuilder({

--- a/ui/core/components/individual_sim_ui/apl_values.ts
+++ b/ui/core/components/individual_sim_ui/apl_values.ts
@@ -133,7 +133,6 @@ import { randomUUID } from '../../utils';
 import { Input, InputConfig } from '../input.js';
 import { TextDropdownPicker, TextDropdownValueConfig } from '../pickers/dropdown_picker.jsx';
 import { ListItemPickerConfig, ListPicker } from '../pickers/list_picker.jsx';
-import { APL_CHILD_CHANGED_EVENT } from './apl_helpers';
 import * as AplHelpers from './apl_helpers.js';
 
 export interface APLValuePickerConfig extends InputConfig<Player<any>, APLValue | undefined> {}
@@ -203,7 +202,6 @@ export class APLValuePicker extends Input<Player<any>, APLValue | undefined> {
 					}),
 				),
 				equals: (a, b) => a == b,
-				changedEvent: () => APL_CHILD_CHANGED_EVENT,
 				getValue: (_player: Player<any>) => this.getSourceValue()?.value.oneofKind,
 				setValue: (eventID: EventID, player: Player<any>, newKind: APLValueKind) => {
 					const sourceValue = this.getSourceValue();
@@ -352,8 +350,7 @@ export class APLValuePicker extends Input<Player<any>, APLValue | undefined> {
 		this.kindPicker.setInputValue(newKind);
 
 		if (this.valuePicker) {
-			this.disposeChild(this.valuePicker);
-			this.valuePicker.rootElem.remove();
+			this.removeChild(this.valuePicker);
 			this.valuePicker = null;
 		}
 
@@ -364,7 +361,6 @@ export class APLValuePicker extends Input<Player<any>, APLValue | undefined> {
 		const factory = valueKindFactories[newKind];
 		this.valuePicker = factory.factory(this.rootElem, this.modObject, {
 			id: randomUUID(),
-			changedEvent: () => APL_CHILD_CHANGED_EVENT,
 			getValue: () => {
 				const sourceVal = this.getSourceValue();
 				return sourceVal ? (sourceVal.value as any)[newKind] || factory.newValue() : factory.newValue();

--- a/ui/core/components/individual_sim_ui/apl_values.ts
+++ b/ui/core/components/individual_sim_ui/apl_values.ts
@@ -1,21 +1,31 @@
-import { Player } from '../../player.js';
+import i18n from '../../../i18n/config';
 import { itemSwapEnabledSpecs } from '../../individual_sim_ui.js';
+import { Player } from '../../player.js';
 import {
 	APLValue,
+	APLValueActionGroupUsed,
+	APLValueActiveItemSwapSet,
+	APLValueAfflictionCurrentSnapshot,
+	APLValueAfflictionExhaleWindow,
 	APLValueAllTrinketStatProcsActive,
-	APLValueAnyTrinketStatProcsAvailable,
 	APLValueAnd,
 	APLValueAnyStatBuffCooldownsActive,
 	APLValueAnyStatBuffCooldownsMinDuration,
 	APLValueAnyTrinketStatProcsActive,
+	APLValueAnyTrinketStatProcsAvailable,
+	APLValueAuraICDIsReady,
 	APLValueAuraInternalCooldown,
 	APLValueAuraIsActive,
+	APLValueAuraIsInactive,
 	APLValueAuraIsKnown,
 	APLValueAuraNumStacks,
 	APLValueAuraRemainingTime,
 	APLValueAuraShouldRefresh,
 	APLValueAutoTimeToNext,
+	APLValueBossCurrentTarget,
+	APLValueBossSpellCastTimeRemaining,
 	APLValueBossSpellIsCasting,
+	APLValueBossSpellIsKnown,
 	APLValueBossSpellTimeToReady,
 	APLValueCatExcessEnergy,
 	APLValueCatNewSavageRoarDuration,
@@ -42,18 +52,20 @@ import {
 	APLValueCurrentSolarEnergy,
 	APLValueCurrentTime,
 	APLValueCurrentTimePercent,
+	APLValueDotBaseDuration,
 	APLValueDotIsActive,
 	APLValueDotIsActiveOnAllTargets,
 	APLValueDotLowestRemainingTime,
 	APLValueDotPercentIncrease,
 	APLValueDotRemainingTime,
 	APLValueDotTickFrequency,
-	APLValueAfflictionCurrentSnapshot,
+	APLValueDotTimeToNextTick,
 	APLValueEnergyRegenPerSecond,
 	APLValueEnergyTimeToTarget,
 	APLValueFocusRegenPerSecond,
 	APLValueFocusTimeToTarget,
 	APLValueFrontOfTarget,
+	APLValueFullRuneCooldown,
 	APLValueGCDIsReady,
 	APLValueGCDTimeToReady,
 	APLValueInputDelay,
@@ -73,13 +85,13 @@ import {
 	APLValueMonkCurrentChi,
 	APLValueMonkMaxChi,
 	APLValueNextRuneCooldown,
-	APLValueFullRuneCooldown,
 	APLValueNot,
 	APLValueNumberTargets,
 	APLValueNumEquippedStatProcTrinkets,
 	APLValueNumStatBuffCooldowns,
 	APLValueOr,
 	APLValueProtectionPaladinDamageTakenLastGlobal,
+	APLValueRemainingCastTime,
 	APLValueRemainingTime,
 	APLValueRemainingTimePercent,
 	APLValueRuneCooldown,
@@ -93,6 +105,10 @@ import {
 	APLValueSpellChanneledTicks,
 	APLValueSpellCPM,
 	APLValueSpellCurrentCost,
+	APLValueSpellFullCooldown,
+	APLValueSpellGCDHastedDuration,
+	APLValueSpellInFlight,
+	APLValueSpellIsCasting,
 	APLValueSpellIsChanneling,
 	APLValueSpellIsKnown,
 	APLValueSpellIsReady,
@@ -108,21 +124,6 @@ import {
 	APLValueVariablePlaceholder,
 	APLValueWarlockHandOfGuldanInFlight,
 	APLValueWarlockHauntInFlight,
-	APLValueAfflictionExhaleWindow,
-	APLValueAuraIsInactive,
-	APLValueAuraICDIsReady,
-	APLValueActiveItemSwapSet,
-	APLValueDotBaseDuration,
-	APLValueSpellGCDHastedDuration,
-	APLValueSpellFullCooldown,
-	APLValueDotTimeToNextTick,
-	APLValueSpellInFlight,
-	APLValueBossCurrentTarget,
-	APLValueBossSpellIsKnown,
-	APLValueBossSpellCastTimeRemaining,
-	APLValueSpellIsCasting,
-	APLValueRemainingCastTime,
-	APLValueActionGroupUsed,
 } from '../../proto/apl.js';
 import { Class, Spec } from '../../proto/common.js';
 import { ShamanTotems_TotemType as TotemType } from '../../proto/shaman.js';
@@ -132,7 +133,7 @@ import { randomUUID } from '../../utils';
 import { Input, InputConfig } from '../input.js';
 import { TextDropdownPicker, TextDropdownValueConfig } from '../pickers/dropdown_picker.jsx';
 import { ListItemPickerConfig, ListPicker } from '../pickers/list_picker.jsx';
-import i18n from '../../../i18n/config';
+import { APL_CHILD_CHANGED_EVENT } from './apl_helpers';
 import * as AplHelpers from './apl_helpers.js';
 
 export interface APLValuePickerConfig extends InputConfig<Player<any>, APLValue | undefined> {}
@@ -201,7 +202,7 @@ export class APLValuePicker extends Input<Player<any>, APLValue | undefined> {
 				}),
 			),
 			equals: (a, b) => a == b,
-			changedEvent: (player: Player<any>) => player.rotationChangeEmitter,
+			changedEvent: () => APL_CHILD_CHANGED_EVENT,
 			getValue: (_player: Player<any>) => this.getSourceValue()?.value.oneofKind,
 			setValue: (eventID: EventID, player: Player<any>, newKind: APLValueKind) => {
 				const sourceValue = this.getSourceValue();
@@ -346,6 +347,9 @@ export class APLValuePicker extends Input<Player<any>, APLValue | undefined> {
 		this.currentKind = newKind;
 
 		if (this.valuePicker) {
+			const childIdx = this.children.indexOf(this.valuePicker);
+			if (childIdx >= 0) this.children.splice(childIdx, 1);
+			this.valuePicker.dispose();
 			this.valuePicker.rootElem.remove();
 			this.valuePicker = null;
 		}
@@ -359,7 +363,7 @@ export class APLValuePicker extends Input<Player<any>, APLValue | undefined> {
 		const factory = valueKindFactories[newKind];
 		this.valuePicker = factory.factory(this.rootElem, this.modObject, {
 			id: randomUUID(),
-			changedEvent: (player: Player<any>) => player.rotationChangeEmitter,
+			changedEvent: () => APL_CHILD_CHANGED_EVENT,
 			getValue: () => {
 				const sourceVal = this.getSourceValue();
 				return sourceVal ? (sourceVal.value as any)[newKind] || factory.newValue() : factory.newValue();
@@ -372,6 +376,7 @@ export class APLValuePicker extends Input<Player<any>, APLValue | undefined> {
 				player.rotationChangeEmitter.emit(eventID);
 			},
 		});
+		this.addChild(this.valuePicker);
 	}
 }
 

--- a/ui/core/components/individual_sim_ui/gear_tab.ts
+++ b/ui/core/components/individual_sim_ui/gear_tab.ts
@@ -80,7 +80,6 @@ export class GearTab extends SimTab {
 				});
 			},
 			changeEmitters: [this.simUI.player.changeEmitter],
-			equals: (a: SavedGearSet, b: SavedGearSet) => SavedGearSet.equals(a, b),
 			toJson: (a: SavedGearSet) => SavedGearSet.toJson(a),
 			fromJson: (obj: any) => SavedGearSet.fromJson(obj),
 		});

--- a/ui/core/components/individual_sim_ui/rotation_tab.tsx
+++ b/ui/core/components/individual_sim_ui/rotation_tab.tsx
@@ -1,3 +1,5 @@
+import clsx from 'clsx';
+
 import i18n from '../../../i18n/config';
 import { IndividualSimUI, InputSection } from '../../individual_sim_ui';
 import { Player } from '../../player';
@@ -10,6 +12,7 @@ import { ContentBlock } from '../content_block';
 import * as IconInputs from '../icon_inputs';
 import { Input } from '../input';
 import { BooleanPicker } from '../pickers/boolean_picker';
+import { TextDropdownPicker } from '../pickers/dropdown_picker';
 import { EnumPicker } from '../pickers/enum_picker';
 import { NumberPicker } from '../pickers/number_picker';
 import { SavedDataManager } from '../saved_data_manager';
@@ -21,8 +24,6 @@ import { APLPrePullListPicker } from './apl/pre_pull_list_picker';
 import { APLPriorityListPicker } from './apl/priority_list_picker';
 import { CooldownsPicker } from './cooldowns_picker';
 import { PresetConfigurationCategory, PresetConfigurationPicker } from './preset_configuration_picker';
-import { TextDropdownPicker } from '../pickers/dropdown_picker';
-import clsx from 'clsx';
 
 export class RotationTab extends SimTab {
 	protected simUI: IndividualSimUI<any>;
@@ -278,6 +279,7 @@ export class RotationTab extends SimTab {
 		});
 
 		this.simUI.sim.waitForInit().then(() => {
+			if (this.isDisposed) return;
 			savedRotationsManager.loadUserData();
 			(this.simUI.individualConfig.presets.rotations || []).forEach(presetRotation => {
 				const rotData = presetRotation.rotation;

--- a/ui/core/components/individual_sim_ui/rotation_tab.tsx
+++ b/ui/core/components/individual_sim_ui/rotation_tab.tsx
@@ -1,3 +1,4 @@
+import { isEqualAPLRotation } from '../../proto_utils/apl_utils';
 import clsx from 'clsx';
 
 import i18n from '../../../i18n/config';
@@ -5,7 +6,6 @@ import { IndividualSimUI, InputSection } from '../../individual_sim_ui';
 import { Player } from '../../player';
 import { APLRotation, APLRotation_Type as APLRotationType } from '../../proto/apl';
 import { SavedRotation } from '../../proto/ui';
-import { isEqualAPLRotation } from '../../proto_utils/apl_utils';
 import { EventID, TypedEvent } from '../../typed_event';
 import { omitDeep } from '../../utils';
 import { ContentBlock } from '../content_block';
@@ -263,11 +263,8 @@ export class RotationTab extends SimTab {
 					player.setAplRotation(eventID, newRotation.rotation || APLRotation.create());
 				}),
 			changeEmitters: [this.simUI.player.rotationChangeEmitter, this.simUI.player.talentsChangeEmitter],
-			equals: (a: SavedRotation, b: SavedRotation) => {
-				// Uncomment this to debug equivalence checks with preset rotations (e.g. the chip doesn't highlight)
-				// console.log(`Rot A: ${SavedRotation.toJsonString(a, { prettySpaces: 2 })}\n\nRot B: ${SavedRotation.toJsonString(b, { prettySpaces: 2 })}`);
-				return isEqualAPLRotation(this.simUI.player, a.rotation, b.rotation);
-			},
+			// Semantic: Auto and APL types match, simple rotations compare by content.
+			equals: (a: SavedRotation, b: SavedRotation) => isEqualAPLRotation(this.simUI.player, a.rotation, b.rotation),
 			toJson: (a: SavedRotation) => SavedRotation.toJson(a),
 			fromJson: (obj: any) => omitDeep(SavedRotation.fromJson(obj), ['uuid']),
 			nameLabel: i18n.t('rotation_tab.saved_rotations.name_label'),

--- a/ui/core/components/individual_sim_ui/settings_tab.tsx
+++ b/ui/core/components/individual_sim_ui/settings_tab.tsx
@@ -299,7 +299,6 @@ export class SettingsTab extends SimTab {
 			getData: (encounter: Encounter) => SavedEncounter.create({ encounter: encounter.toProto() }),
 			setData: (eventID: EventID, encounter: Encounter, newEncounter: SavedEncounter) => encounter.fromProto(eventID, newEncounter.encounter!),
 			changeEmitters: [this.simUI.sim.encounter.changeEmitter],
-			equals: (a: SavedEncounter, b: SavedEncounter) => SavedEncounter.equals(a, b),
 			toJson: (a: SavedEncounter) => SavedEncounter.toJson(a),
 			fromJson: (obj: any) => SavedEncounter.fromJson(obj),
 		});
@@ -355,7 +354,6 @@ export class SettingsTab extends SimTab {
 				this.simUI.player.distanceFromTargetChangeEmitter,
 				this.simUI.player.healingModelChangeEmitter,
 			],
-			equals: (a: SavedSettings, b: SavedSettings) => SavedSettings.equals(a, b),
 			toJson: (a: SavedSettings) => SavedSettings.toJson(a),
 			fromJson: (obj: any) => SavedSettings.fromJson(obj),
 		});

--- a/ui/core/components/individual_sim_ui/talents_tab.tsx
+++ b/ui/core/components/individual_sim_ui/talents_tab.tsx
@@ -83,7 +83,6 @@ export class TalentsTab<SpecType extends Spec> extends SimTab {
 				});
 			},
 			changeEmitters: [this.simUI.player.talentsChangeEmitter, this.simUI.player.glyphsChangeEmitter],
-			equals: (a: SavedTalents, b: SavedTalents) => SavedTalents.equals(a, b),
 			toJson: (a: SavedTalents) => SavedTalents.toJson(a),
 			fromJson: (obj: any) => SavedTalents.fromJson(obj),
 			nameLabel: i18n.t('talents_tab.saved_talents.name_label'),

--- a/ui/core/components/input.tsx
+++ b/ui/core/components/input.tsx
@@ -18,8 +18,9 @@ export interface InputConfig<ModObject, T, V = T> {
 
 	defaultValue?: T;
 
-	// Returns the event indicating the mapped value has changed.
-	changedEvent: (obj: ModObject) => TypedEvent<any>;
+	// Returns the event indicating the mapped value has changed. Omit for inputs
+	// whose parent keeps them in sync via refresh() (e.g. nested APL pickers).
+	changedEvent?: (obj: ModObject) => TypedEvent<any>;
 
 	// Get and set the mapped value.
 	getValue: (obj: ModObject) => T;
@@ -65,19 +66,18 @@ export abstract class Input<ModObject, T, V = T> extends Component {
 		if (config.label) this.rootElem.appendChild(this.buildLabel(config));
 		if (config.description) this.rootElem.appendChild(this.buildDescription(config));
 
-		const event = config.changedEvent(this.modObject).on(() => {
+		const event = config.changedEvent?.(this.modObject).on(() => {
 			const element = this.getInputElem();
 			if (!existsInDOM(element) || !existsInDOM(this.rootElem)) {
 				this.dispose();
 				return;
 			}
-			this.setInputValue(this.getSourceValue());
-			this.update();
+			this.refresh();
 		});
 
 		this.addOnDisposeCallback(() => {
 			this.abortController?.abort();
-			event.dispose();
+			event?.dispose();
 		});
 	}
 
@@ -120,6 +120,12 @@ export abstract class Input<ModObject, T, V = T> extends Component {
 		} else {
 			this.rootElem.classList.add('hide');
 		}
+	}
+
+	// Re-reads the mapped value from the source and re-applies enable/show state.
+	refresh() {
+		this.setInputValue(this.getSourceValue());
+		this.update();
 	}
 
 	// Can't call abstract functions in constructor, so need an init() call.

--- a/ui/core/components/input_helpers.ts
+++ b/ui/core/components/input_helpers.ts
@@ -53,7 +53,7 @@ export function makeWrappedBooleanInput<SpecType extends Spec, ModObject>(
 		label: config.label,
 		labelTooltip: config.labelTooltip,
 		description: config.description,
-		changedEvent: (player: Player<SpecType>) => config.changedEvent(getModObject(player)),
+		changedEvent: (player: Player<SpecType>) => config.changedEvent!(getModObject(player)),
 		getValue: (player: Player<SpecType>) => config.getValue(getModObject(player)),
 		setValue: (eventID: EventID, player: Player<SpecType>, newValue: boolean) => config.setValue(eventID, getModObject(player), newValue),
 		enableWhen: config.enableWhen ? (player: Player<SpecType>) => config.enableWhen!(getModObject(player)) : undefined,
@@ -163,7 +163,7 @@ function makeWrappedNumberInput<SpecType extends Spec, ModObject>(
 		showZeroes: config.showZeroes,
 		maxDecimalDigits: config.maxDecimalDigits,
 		positive: config.positive,
-		changedEvent: (player: Player<SpecType>) => config.changedEvent(getModObject(player)),
+		changedEvent: (player: Player<SpecType>) => config.changedEvent!(getModObject(player)),
 		getValue: (player: Player<SpecType>) => config.getValue(getModObject(player)),
 		setValue: (eventID: EventID, player: Player<SpecType>, newValue: number) => config.setValue(eventID, getModObject(player), newValue),
 		enableWhen: config.enableWhen ? (player: Player<SpecType>) => config.enableWhen!(getModObject(player)) : undefined,
@@ -172,7 +172,8 @@ function makeWrappedNumberInput<SpecType extends Spec, ModObject>(
 	};
 }
 export interface PlayerNumberInputConfig<SpecType extends Spec, Message>
-	extends BasePlayerConfig<SpecType, number>,
+	extends
+		BasePlayerConfig<SpecType, number>,
 		Pick<NumberPickerConfig<Player<SpecType>>, 'labelTooltip' | 'description' | 'showZeroes' | 'maxDecimalDigits' | 'float' | 'positive'> {
 	fieldName: keyof Message;
 	label: string;
@@ -323,7 +324,7 @@ function makeWrappedEnumInput<SpecType extends Spec, ModObject>(config: WrappedE
 		labelTooltip: config.labelTooltip,
 		description: config.description,
 		values: config.values,
-		changedEvent: (player: Player<SpecType>) => config.changedEvent(getModObject(player)),
+		changedEvent: (player: Player<SpecType>) => config.changedEvent!(getModObject(player)),
 		getValue: (player: Player<SpecType>) => config.getValue(getModObject(player)),
 		setValue: (eventID: EventID, player: Player<SpecType>, newValue: number) => config.setValue(eventID, getModObject(player), newValue),
 		enableWhen: config.enableWhen ? (player: Player<SpecType>) => config.enableWhen!(getModObject(player)) : undefined,
@@ -435,7 +436,7 @@ function makeWrappedIconInput<SpecType extends Spec, ModObject, T>(
 		actionId: config.actionId,
 		label: config.label,
 		states: config.states,
-		changedEvent: (player: Player<SpecType>) => config.changedEvent(getModObject(player)),
+		changedEvent: (player: Player<SpecType>) => config.changedEvent!(getModObject(player)),
 		showWhen: (player: Player<SpecType>) => !config.showWhen || (config.showWhen(getModObject(player)) as any),
 		getValue: (player: Player<SpecType>) => config.getValue(getModObject(player)),
 		setValue: (eventID: EventID, player: Player<SpecType>, newValue: T) => config.setValue(eventID, getModObject(player), newValue),
@@ -626,7 +627,7 @@ function makeWrappedEnumIconInput<SpecType extends Spec, ModObject, T>(
 		equals: config.equals,
 		showWhen: (player: Player<SpecType>): boolean => !config.showWhen || (config.showWhen(getModObject(player)) as any),
 		zeroValue: config.zeroValue,
-		changedEvent: (player: Player<SpecType>) => config.changedEvent(getModObject(player)),
+		changedEvent: (player: Player<SpecType>) => config.changedEvent!(getModObject(player)),
 		getValue: (player: Player<SpecType>) => config.getValue(getModObject(player)),
 		setValue: (eventID: EventID, player: Player<SpecType>, newValue: T) => config.setValue(eventID, getModObject(player), newValue),
 		extraCssClasses: config.extraCssClasses,

--- a/ui/core/components/pickers/dropdown_picker.tsx
+++ b/ui/core/components/pickers/dropdown_picker.tsx
@@ -5,7 +5,7 @@ import tippy from 'tippy.js';
 import { ref } from 'tsx-vanilla';
 
 import { TypedEvent } from '../../typed_event.js';
-import { existsInDOM } from '../../utils.js';
+import { arrayEquals, existsInDOM } from '../../utils.js';
 import { Input, InputConfig } from '../input.js';
 import i18n from '../../../i18n/config';
 
@@ -111,7 +111,7 @@ export class DropdownPicker<ModObject, T, V = T> extends Input<ModObject, T, V> 
 		// Keep the existing config objects when nothing changed: every APL
 		// action-id picker refreshes its options on each rotation change, and a
 		// fresh-but-equal list would force a button re-render per picker.
-		if (filtered.length === this.valueConfigs.length && filtered.every((vc, i) => this.isSameOption(vc, this.valueConfigs[i]))) {
+		if (arrayEquals(filtered, this.valueConfigs, (a, b) => this.isSameOption(a, b))) {
 			return;
 		}
 		this.valueConfigs = filtered;

--- a/ui/core/components/pickers/dropdown_picker.tsx
+++ b/ui/core/components/pickers/dropdown_picker.tsx
@@ -1,5 +1,6 @@
 import { Dropdown } from 'bootstrap';
 import clsx from 'clsx';
+import { shallowEqualArrays, shallowEqualObjects } from 'shallow-equal';
 import tippy from 'tippy.js';
 import { ref } from 'tsx-vanilla';
 
@@ -110,12 +111,25 @@ export class DropdownPicker<ModObject, T, V = T> extends Input<ModObject, T, V> 
 		// Keep the existing config objects when nothing changed: every APL
 		// action-id picker refreshes its options on each rotation change, and a
 		// fresh-but-equal list would force a button re-render per picker.
-		if (filtered.length === this.valueConfigs.length && filtered.every((vc, i) => this.config.equals(vc.value, this.valueConfigs[i].value))) {
+		if (filtered.length === this.valueConfigs.length && filtered.every((vc, i) => this.isSameOption(vc, this.valueConfigs[i]))) {
 			return;
 		}
 		this.valueConfigs = filtered;
 		this.setInputValue(this.getSourceValue());
 		return;
+	}
+
+	// True when two option configs would render identically: equal values plus
+	// identical display fields, including those of an object value (e.g. a
+	// UnitValue's text/icon/color, which `equals` deliberately ignores).
+	private isSameOption(a: DropdownValueConfig<V>, b: DropdownValueConfig<V>): boolean {
+		const { value: aValue, submenu: aSubmenu, extraCssClasses: aClasses, ...aRest } = a;
+		const { value: bValue, submenu: bSubmenu, extraCssClasses: bClasses, ...bRest } = b;
+		if (!this.config.equals(aValue, bValue)) return false;
+		// The array fields are rebuilt per refresh, so compare them by content.
+		if (!shallowEqualObjects(aRest, bRest) || !shallowEqualArrays(aSubmenu, bSubmenu) || !shallowEqualArrays(aClasses, bClasses)) return false;
+		if (aValue === bValue || typeof aValue !== 'object' || aValue === null || typeof bValue !== 'object' || bValue === null) return true;
+		return shallowEqualObjects(aValue as Record<string, unknown>, bValue as Record<string, unknown>);
 	}
 
 	resetDropdown() {

--- a/ui/core/components/pickers/dropdown_picker.tsx
+++ b/ui/core/components/pickers/dropdown_picker.tsx
@@ -106,7 +106,14 @@ export class DropdownPicker<ModObject, T, V = T> extends Input<ModObject, T, V> 
 			return;
 		}
 
-		this.valueConfigs = newValueConfigs.filter(vc => !vc.headerText);
+		const filtered = newValueConfigs.filter(vc => !vc.headerText);
+		// Keep the existing config objects when nothing changed: every APL
+		// action-id picker refreshes its options on each rotation change, and a
+		// fresh-but-equal list would force a button re-render per picker.
+		if (filtered.length === this.valueConfigs.length && filtered.every((vc, i) => this.config.equals(vc.value, this.valueConfigs[i].value))) {
+			return;
+		}
+		this.valueConfigs = filtered;
 		this.setInputValue(this.getSourceValue());
 		return;
 	}
@@ -243,7 +250,10 @@ export class DropdownPicker<ModObject, T, V = T> extends Input<ModObject, T, V> 
 		return this.valueToSource(this.currentSelection?.value as V);
 	}
 
+	private setValueSeq = 0;
+
 	setInputValue(newSrcValue: T) {
+		const seq = ++this.setValueSeq;
 		const newValue = this.sourceToValue(newSrcValue);
 		const newSelection = this.valueConfigs.find(v => this.config.equals(v.value, newValue))!;
 		if (newSelection) {
@@ -251,13 +261,22 @@ export class DropdownPicker<ModObject, T, V = T> extends Input<ModObject, T, V> 
 		} else if (newValue == null) {
 			this.updateValue(null);
 		} else if (this.config.createMissingValue) {
-			this.config.createMissingValue(newValue).then(newSelection => this.updateValue(newSelection));
+			this.config.createMissingValue(newValue).then(newSelection => {
+				// A newer setInputValue (or disposal) happened while awaiting.
+				if (seq !== this.setValueSeq || this.isDisposed) return;
+				this.updateValue(newSelection);
+			});
 		} else {
 			this.updateValue(null);
 		}
 	}
 
 	private updateValue(newValue: DropdownValueConfig<V> | null) {
+		// Same selection object as already rendered: nothing to do. This is the
+		// hot path when a rotation edit re-syncs every dropdown in the APL editor.
+		if (newValue && newValue === this.currentSelection) {
+			return;
+		}
 		this.currentSelection = newValue;
 
 		// Update button

--- a/ui/core/components/pickers/icon_enum_picker.tsx
+++ b/ui/core/components/pickers/icon_enum_picker.tsx
@@ -28,6 +28,7 @@ export interface IconEnumValueConfig<ModObject, T> {
 }
 
 export interface IconEnumPickerConfig<ModObject, T> extends InputConfig<ModObject, T> {
+	changedEvent: (obj: ModObject) => TypedEvent<any>;
 	numColumns?: number;
 	values: Array<IconEnumValueConfig<ModObject, T>>;
 	// Value that will be considered inactive.

--- a/ui/core/components/pickers/icon_picker.tsx
+++ b/ui/core/components/pickers/icon_picker.tsx
@@ -11,6 +11,7 @@ import { Input, InputConfig } from '../input.js';
 // ModObject is the object being modified (Sim, Player, or Target).
 // ValueType is either number or boolean.
 export interface IconPickerConfig<ModObject, ValueType> extends InputConfig<ModObject, ValueType> {
+	changedEvent: (obj: ModObject) => TypedEvent<any>;
 	actionId: ActionId;
 
 	// The number of possible 'states' this icon can have. Most inputs will use 2
@@ -85,10 +86,10 @@ export class IconPicker<ModObject, ValueType> extends Input<ModObject, ValueType
 		this.improvedAnchor2 = ia2.value!;
 		this.counterElem = ce.value!;
 
-		this.updateButtonImage()
+		this.updateButtonImage();
 
 		const event = this.config.changedEvent(this.modObject).on(() => {
-			this.updateButtonImage()
+			this.updateButtonImage();
 
 			if (this.showWhen()) {
 				this.rootElem.classList.remove('hide');

--- a/ui/core/components/pickers/list_picker.tsx
+++ b/ui/core/components/pickers/list_picker.tsx
@@ -30,36 +30,34 @@ export interface ListPickerExtraAction {
 	shouldShow?: (index: number) => boolean;
 }
 
-type CopyItemConfig<ItemType> =
-	| { copyItem: (oldItem: ItemType) => ItemType; onCopyItem?: never }
-	| { copyItem?: never; onCopyItem: (index: number) => void };
+type CopyItemConfig<ItemType> = { copyItem: (oldItem: ItemType) => ItemType; onCopyItem?: never } | { copyItem?: never; onCopyItem: (index: number) => void };
 
 export type ListPickerConfig<ModObject, ItemType> = Omit<InputConfig<ModObject, Array<ItemType>>, 'id'> &
 	CopyItemConfig<ItemType> & {
-	itemLabel: string;
-	newItem: () => ItemType;
-	newItemPicker: (
-		parent: HTMLElement,
-		listPicker: ListPicker<ModObject, ItemType>,
-		index: number,
-		config: ListItemPickerConfig<ModObject, ItemType>,
-	) => Input<ModObject, ItemType>;
-	actions?: ListPickerActionsConfig;
-	title?: string;
-	titleTooltip?: string;
-	inlineMenuBar?: boolean;
-	hideUi?: boolean;
-	horizontalLayout?: boolean;
-	// if set, will remove the border and padding of the list items
-	isCompact?: boolean;
-	// If set, will disable the delete button if the list is at the minimum.
-	minimumItems?: number;
-	// If set, only actions included in the list are allowed. Otherwise, all actions are allowed.
-	allowedActions?: Array<ListItemAction>;
-	dragGroup?: string;
-	// Additional custom action buttons to add to the popover menu
-	extraActions?: Array<ListPickerExtraAction>;
-}
+		itemLabel: string;
+		newItem: () => ItemType;
+		newItemPicker: (
+			parent: HTMLElement,
+			listPicker: ListPicker<ModObject, ItemType>,
+			index: number,
+			config: ListItemPickerConfig<ModObject, ItemType>,
+		) => Input<ModObject, ItemType>;
+		actions?: ListPickerActionsConfig;
+		title?: string;
+		titleTooltip?: string;
+		inlineMenuBar?: boolean;
+		hideUi?: boolean;
+		horizontalLayout?: boolean;
+		// if set, will remove the border and padding of the list items
+		isCompact?: boolean;
+		// If set, will disable the delete button if the list is at the minimum.
+		minimumItems?: number;
+		// If set, only actions included in the list are allowed. Otherwise, all actions are allowed.
+		allowedActions?: Array<ListItemAction>;
+		dragGroup?: string;
+		// Additional custom action buttons to add to the popover menu
+		extraActions?: Array<ListPickerExtraAction>;
+	};
 
 const DEFAULT_CONFIG = {
 	actions: {
@@ -281,10 +279,11 @@ export class ListPicker<ModObject, ItemType> extends Input<ModObject, Array<Item
 				deleteButton.addEventListener(
 					'click',
 					() => {
+						// Hide before setValue: the shrink below may dispose this item (and its tooltip) synchronously.
+						deleteButtonTooltip.hide();
 						const newList = this.config.getValue(this.modObject);
 						newList.splice(index, 1);
 						this.config.setValue(TypedEvent.nextEventID(), this.modObject, newList);
-						deleteButtonTooltip.hide();
 					},
 					{ signal: this.signal },
 				);

--- a/ui/core/components/pickers/list_picker.tsx
+++ b/ui/core/components/pickers/list_picker.tsx
@@ -164,9 +164,7 @@ export class ListPicker<ModObject, ItemType> extends Input<ModObject, Array<Item
 		// Add/remove pickers to make the lengths match.
 		if (newValue.length < this.itemPickerPairs.length) {
 			this.itemPickerPairs.slice(newValue.length).forEach(ipp => {
-				const childIdx = this.children.indexOf(ipp.picker);
-				if (childIdx >= 0) this.children.splice(childIdx, 1);
-				ipp.picker.dispose();
+				this.disposeChild(ipp.picker);
 				ipp.elem.remove();
 			});
 			this.itemPickerPairs = this.itemPickerPairs.slice(0, newValue.length);

--- a/ui/core/components/pickers/list_picker.tsx
+++ b/ui/core/components/pickers/list_picker.tsx
@@ -180,13 +180,8 @@ export class ListPicker<ModObject, ItemType> extends Input<ModObject, Array<Item
 		}
 
 		// Set all the values.
-		newValue.forEach((val, i) => {
-			const picker = this.itemPickerPairs[i].picker;
-			picker.setInputValue(val);
-			// Items may not subscribe themselves (see APL child pickers); keep
-			// their enable/show state in sync from the cascade.
-			picker.update();
-		});
+		// Items without their own changedEvent (APL pickers) are kept in sync from here.
+		newValue.forEach((_val, i) => this.itemPickerPairs[i].picker.refresh());
 	}
 
 	private actionEnabled(action: ListItemAction): boolean {
@@ -259,10 +254,7 @@ export class ListPicker<ModObject, ItemType> extends Input<ModObject, Array<Item
 		const item: ItemPickerPair<ItemType> = { elem: itemContainer, picker: itemPicker, idx: index };
 		this.addChild(itemPicker);
 		// Per-item resources (tooltips, document-level listeners) are released
-		// with the item picker, not with the whole list.
-		const itemAbort = new AbortController();
-		const itemSignal = itemAbort.signal;
-		itemPicker.addOnDisposeCallback(() => itemAbort.abort());
+		// with the item picker (its dispose callbacks / signal), not with the whole list.
 
 		if (this.actionEnabled('delete')) {
 			if (!this.config.minimumItems || index + 1 > this.config.minimumItems) {
@@ -408,7 +400,7 @@ export class ListPicker<ModObject, ItemType> extends Input<ModObject, Array<Item
 						itemContainer.removeAttribute('draggable');
 					}
 				},
-				{ signal: itemSignal },
+				{ signal: itemPicker.signal },
 			);
 
 			const droppingActionOnOtherList = () => {

--- a/ui/core/components/pickers/list_picker.tsx
+++ b/ui/core/components/pickers/list_picker.tsx
@@ -163,7 +163,12 @@ export class ListPicker<ModObject, ItemType> extends Input<ModObject, Array<Item
 	setInputValue(newValue: Array<ItemType>): void {
 		// Add/remove pickers to make the lengths match.
 		if (newValue.length < this.itemPickerPairs.length) {
-			this.itemPickerPairs.slice(newValue.length).forEach(ipp => ipp.elem.remove());
+			this.itemPickerPairs.slice(newValue.length).forEach(ipp => {
+				const childIdx = this.children.indexOf(ipp.picker);
+				if (childIdx >= 0) this.children.splice(childIdx, 1);
+				ipp.picker.dispose();
+				ipp.elem.remove();
+			});
 			this.itemPickerPairs = this.itemPickerPairs.slice(0, newValue.length);
 		} else if (newValue.length > this.itemPickerPairs.length) {
 			const numToAdd = newValue.length - this.itemPickerPairs.length;
@@ -179,7 +184,13 @@ export class ListPicker<ModObject, ItemType> extends Input<ModObject, Array<Item
 		}
 
 		// Set all the values.
-		newValue.forEach((val, i) => this.itemPickerPairs[i].picker.setInputValue(val));
+		newValue.forEach((val, i) => {
+			const picker = this.itemPickerPairs[i].picker;
+			picker.setInputValue(val);
+			// Items may not subscribe themselves (see APL child pickers); keep
+			// their enable/show state in sync from the cascade.
+			picker.update();
+		});
 	}
 
 	private actionEnabled(action: ListItemAction): boolean {
@@ -250,6 +261,12 @@ export class ListPicker<ModObject, ItemType> extends Input<ModObject, Array<Item
 		});
 
 		const item: ItemPickerPair<ItemType> = { elem: itemContainer, picker: itemPicker, idx: index };
+		this.addChild(itemPicker);
+		// Per-item resources (tooltips, document-level listeners) are released
+		// with the item picker, not with the whole list.
+		const itemAbort = new AbortController();
+		const itemSignal = itemAbort.signal;
+		itemPicker.addOnDisposeCallback(() => itemAbort.abort());
 
 		if (this.actionEnabled('delete')) {
 			if (!this.config.minimumItems || index + 1 > this.config.minimumItems) {
@@ -273,7 +290,7 @@ export class ListPicker<ModObject, ItemType> extends Input<ModObject, Array<Item
 					},
 					{ signal: this.signal },
 				);
-				this.addOnDisposeCallback(() => deleteButtonTooltip?.destroy());
+				itemPicker.addOnDisposeCallback(() => deleteButtonTooltip?.destroy());
 				this.addHoverListeners(deleteButton);
 			}
 		}
@@ -301,7 +318,7 @@ export class ListPicker<ModObject, ItemType> extends Input<ModObject, Array<Item
 					},
 					{ signal: this.signal },
 				);
-				this.addOnDisposeCallback(() => extraTooltip?.destroy());
+				itemPicker.addOnDisposeCallback(() => extraTooltip?.destroy());
 				this.addHoverListeners(extraButton);
 				if (extraAction.shouldShow) {
 					extraActionButtons.push({ elem: extraButton, shouldShow: extraAction.shouldShow });
@@ -332,7 +349,7 @@ export class ListPicker<ModObject, ItemType> extends Input<ModObject, Array<Item
 				},
 				{ signal: this.signal },
 			);
-			this.addOnDisposeCallback(() => copyButtonTooltip?.destroy());
+			itemPicker.addOnDisposeCallback(() => copyButtonTooltip?.destroy());
 			this.addHoverListeners(copyButton);
 		}
 
@@ -394,7 +411,7 @@ export class ListPicker<ModObject, ItemType> extends Input<ModObject, Array<Item
 						itemContainer.removeAttribute('draggable');
 					}
 				},
-				{ signal: this.signal },
+				{ signal: itemSignal },
 			);
 
 			const droppingActionOnOtherList = () => {

--- a/ui/core/components/raid_sim_action.tsx
+++ b/ui/core/components/raid_sim_action.tsx
@@ -142,6 +142,8 @@ export class RaidSimResultsManager {
 	}
 
 	setSimProgress(progress: ProgressMetrics) {
+		// Content is replaced below; release the previous content's tooltips/listeners.
+		this.reset();
 		if (progress.finalRaidResult && progress.finalRaidResult.error) {
 			this.simUI.resultsViewer.hideAll();
 			return;
@@ -168,6 +170,7 @@ export class RaidSimResultsManager {
 	}
 
 	setSimResult(eventID: EventID, simResult: SimResult) {
+		this.reset();
 		this.currentData = {
 			simResult: simResult,
 			settings: {

--- a/ui/core/components/saved_data_manager.tsx
+++ b/ui/core/components/saved_data_manager.tsx
@@ -42,6 +42,10 @@ export type SavedDataConfig<ModObject, T> = {
 type SavedData<ModObject, T> = {
 	name: string;
 	data: T;
+	// Serialized form of `data`, compared against the current value by string
+	// so an active-check costs one serialization per manager, not one deep
+	// proto equals per entry.
+	dataJson: string | null;
 	elem: HTMLElement;
 } & Pick<SavedDataConfig<ModObject, T>, 'enableWhen' | 'onLoad'>;
 
@@ -58,6 +62,7 @@ export class SavedDataManager<ModObject, T> extends Component {
 	private saveInput?: HTMLInputElement;
 
 	private frozen: boolean;
+	private checkPending = false;
 
 	constructor(parent: HTMLElement | null, modObject: ModObject, config: SavedDataManagerConfig<ModObject, T>) {
 		super(parent, 'saved-data-manager-root');
@@ -67,6 +72,12 @@ export class SavedDataManager<ModObject, T> extends Component {
 		this.userData = [];
 		this.presets = [];
 		this.frozen = false;
+
+		// One coalesced active-check per manager per change burst, deferred to
+		// the next frame: the old per-entry deep equals on every change was the
+		// dominant cost of an APL edit (~166 ms on a large rotation).
+		const emitters = this.config.changeEmitters.map(emitter => emitter.on(() => this.scheduleChecks()));
+		this.addOnDisposeCallback(() => emitters.forEach(emitter => emitter.dispose()));
 
 		if (config.extraCssClasses) this.rootElem.classList.add(...config.extraCssClasses);
 
@@ -168,33 +179,67 @@ export class SavedDataManager<ModObject, T> extends Component {
 			});
 		}
 
-		const checkActive = () => {
-			if (this.config.equals(config.data, this.config.getData(this.modObject))) {
-				dataElem.classList.add('active');
-				if (this.saveInput) this.saveInput.value = config.name;
-			} else {
-				dataElem.classList.remove('active');
-			}
-
-			if (config.enableWhen && !config.enableWhen(this.modObject)) {
-				dataElem.classList.add('disabled');
-			} else {
-				dataElem.classList.remove('disabled');
-			}
-		};
-
-		checkActive();
-		const emitters = this.config.changeEmitters.map(emitter => emitter.on(checkActive));
-		this.addOnDisposeCallback(() => emitters.map(emitter => emitter.dispose()));
-
-		return {
+		const savedData: SavedData<ModObject, T> = {
 			name: config.name,
 			data: config.data,
+			dataJson: this.serialize(config.data),
 			elem: dataElem,
 			enableWhen: config.enableWhen,
 			onLoad: config.onLoad,
 		};
+		// Initial render is synchronous, as before.
+		this.checkEntry(savedData, this.serialize(this.config.getData(this.modObject)));
+
+		return savedData;
 	}
+
+	private serialize(data: T): string | null {
+		try {
+			return JSON.stringify(this.config.toJson(data));
+		} catch {
+			return null;
+		}
+	}
+
+	private scheduleChecks() {
+		if (this.checkPending) return;
+		this.checkPending = true;
+		const run = () => {
+			this.checkPending = false;
+			this.runChecks();
+		};
+		if (typeof requestAnimationFrame === 'function') {
+			requestAnimationFrame(run);
+		} else {
+			setTimeout(run, 0);
+		}
+	}
+
+	private runChecks() {
+		const currentJson = this.serialize(this.config.getData(this.modObject));
+		this.presets.forEach(entry => this.checkEntry(entry, currentJson));
+		this.userData.forEach(entry => this.checkEntry(entry, currentJson));
+	}
+
+	private checkEntry(entry: SavedData<ModObject, T>, currentJson: string | null) {
+		const isActive =
+			entry.dataJson != null && currentJson != null
+				? entry.dataJson === currentJson
+				: this.config.equals(entry.data, this.config.getData(this.modObject));
+		if (isActive) {
+			entry.elem.classList.add('active');
+			if (this.saveInput) this.saveInput.value = entry.name;
+		} else {
+			entry.elem.classList.remove('active');
+		}
+
+		if (entry.enableWhen && !entry.enableWhen(this.modObject)) {
+			entry.elem.classList.add('disabled');
+		} else {
+			entry.elem.classList.remove('disabled');
+		}
+	}
+
 
 	// Save data to window.localStorage.
 	private saveUserData() {

--- a/ui/core/components/saved_data_manager.tsx
+++ b/ui/core/components/saved_data_manager.tsx
@@ -64,7 +64,7 @@ export class SavedDataManager<ModObject, T> extends Component {
 	private saveInput?: HTMLInputElement;
 
 	private frozen: boolean;
-	private checkPending = false;
+	private pendingCheckFrame: number | null = null;
 
 	constructor(parent: HTMLElement | null, modObject: ModObject, config: SavedDataManagerConfig<ModObject, T>) {
 		super(parent, 'saved-data-manager-root');
@@ -140,6 +140,8 @@ export class SavedDataManager<ModObject, T> extends Component {
 		dataElem?.addEventListener('click', () => {
 			this.config.setData(TypedEvent.nextEventID(), this.modObject, config.data);
 			config.onLoad?.(this.modObject);
+			// Run the deferred check now so the clicked entry's name is the one left in the input.
+			this.flushChecks();
 			if (this.saveInput) this.saveInput.value = config.name;
 			trackEvent({
 				action: 'settings',
@@ -196,25 +198,33 @@ export class SavedDataManager<ModObject, T> extends Component {
 		return savedData;
 	}
 
+	// Only consumed by the JSON-equality path; managers with a semantic `equals` skip the cost.
 	private serialize(data: T): string {
-		return JSON.stringify(this.config.toJson(data));
+		return this.config.equals ? '' : JSON.stringify(this.config.toJson(data));
 	}
 
 	private scheduleChecks() {
-		if (this.checkPending) return;
-		this.checkPending = true;
-		const run = () => {
-			this.checkPending = false;
+		if (this.pendingCheckFrame != null) return;
+		this.pendingCheckFrame = requestAnimationFrame(() => {
+			this.pendingCheckFrame = null;
 			this.runChecks();
-		};
-		requestAnimationFrame(run);
+		});
+	}
+
+	private flushChecks() {
+		if (this.pendingCheckFrame == null) return;
+		cancelAnimationFrame(this.pendingCheckFrame);
+		this.pendingCheckFrame = null;
+		this.runChecks();
 	}
 
 	private runChecks() {
+		if (!this.presets.length && !this.userData.length) return;
 		const current = this.config.getData(this.modObject);
 		const currentJson = this.serialize(current);
-		this.presets.forEach(entry => this.checkEntry(entry, current, currentJson));
+		// Presets last so, with identical data, the preset's name wins in the save input (as before).
 		this.userData.forEach(entry => this.checkEntry(entry, current, currentJson));
+		this.presets.forEach(entry => this.checkEntry(entry, current, currentJson));
 	}
 
 	private checkEntry(entry: SavedData<ModObject, T>, current: T, currentJson: string) {
@@ -232,7 +242,6 @@ export class SavedDataManager<ModObject, T> extends Component {
 			entry.elem.classList.remove('disabled');
 		}
 	}
-
 
 	// Save data to window.localStorage.
 	private saveUserData() {

--- a/ui/core/components/saved_data_manager.tsx
+++ b/ui/core/components/saved_data_manager.tsx
@@ -44,10 +44,10 @@ export type SavedDataConfig<ModObject, T> = {
 type SavedData<ModObject, T> = {
 	name: string;
 	data: T;
-	// Serialized form of `data`, compared against the current value by string
-	// so an active-check costs one serialization per manager, not one deep
-	// proto equals per entry.
-	dataJson: string;
+	// Serialized form of `data` (only when the manager has no semantic `equals`),
+	// compared against the current value by string so an active-check costs one
+	// serialization per manager, not one deep proto equals per entry.
+	dataJson?: string;
 	elem: HTMLElement;
 } & Pick<SavedDataConfig<ModObject, T>, 'enableWhen' | 'onLoad'>;
 
@@ -122,6 +122,7 @@ export class SavedDataManager<ModObject, T> extends Component {
 			dataArr[oldIdx].elem.replaceWith(newData.elem);
 			dataArr[oldIdx] = newData;
 		}
+		this.scheduleChecks();
 	}
 
 	private makeSavedData(config: SavedDataConfig<ModObject, T>): SavedData<ModObject, T> {
@@ -191,16 +192,11 @@ export class SavedDataManager<ModObject, T> extends Component {
 			enableWhen: config.enableWhen,
 			onLoad: config.onLoad,
 		};
-		// Initial render is synchronous, as before.
-		const current = this.config.getData(this.modObject);
-		this.checkEntry(savedData, current, this.serialize(current));
-
 		return savedData;
 	}
 
-	// Only consumed by the JSON-equality path; managers with a semantic `equals` skip the cost.
-	private serialize(data: T): string {
-		return this.config.equals ? '' : JSON.stringify(this.config.toJson(data));
+	private serialize(data: T): string | undefined {
+		return this.config.equals ? undefined : JSON.stringify(this.config.toJson(data));
 	}
 
 	private scheduleChecks() {
@@ -227,7 +223,7 @@ export class SavedDataManager<ModObject, T> extends Component {
 		this.presets.forEach(entry => this.checkEntry(entry, current, currentJson));
 	}
 
-	private checkEntry(entry: SavedData<ModObject, T>, current: T, currentJson: string) {
+	private checkEntry(entry: SavedData<ModObject, T>, current: T, currentJson: string | undefined) {
 		const isActive = this.config.equals ? this.config.equals(entry.data, current) : entry.dataJson === currentJson;
 		if (isActive) {
 			entry.elem.classList.add('active');

--- a/ui/core/components/saved_data_manager.tsx
+++ b/ui/core/components/saved_data_manager.tsx
@@ -15,7 +15,9 @@ export type SavedDataManagerConfig<ModObject, T> = {
 	loadOnly?: boolean;
 	storageKey: string;
 	changeEmitters: TypedEvent<any>[];
-	equals: (a: T, b: T) => boolean;
+	// Optional semantic equality (e.g. rotations, where the type/uuids may differ);
+	// without it entries compare by their `toJson` string.
+	equals?: (a: T, b: T) => boolean;
 	getData: (modObject: ModObject) => T;
 	setData: (eventID: EventID, modObject: ModObject, data: T) => void;
 	toJson: (a: T) => any;
@@ -45,7 +47,7 @@ type SavedData<ModObject, T> = {
 	// Serialized form of `data`, compared against the current value by string
 	// so an active-check costs one serialization per manager, not one deep
 	// proto equals per entry.
-	dataJson: string | null;
+	dataJson: string;
 	elem: HTMLElement;
 } & Pick<SavedDataConfig<ModObject, T>, 'enableWhen' | 'onLoad'>;
 
@@ -188,17 +190,14 @@ export class SavedDataManager<ModObject, T> extends Component {
 			onLoad: config.onLoad,
 		};
 		// Initial render is synchronous, as before.
-		this.checkEntry(savedData, this.serialize(this.config.getData(this.modObject)));
+		const current = this.config.getData(this.modObject);
+		this.checkEntry(savedData, current, this.serialize(current));
 
 		return savedData;
 	}
 
-	private serialize(data: T): string | null {
-		try {
-			return JSON.stringify(this.config.toJson(data));
-		} catch {
-			return null;
-		}
+	private serialize(data: T): string {
+		return JSON.stringify(this.config.toJson(data));
 	}
 
 	private scheduleChecks() {
@@ -208,24 +207,18 @@ export class SavedDataManager<ModObject, T> extends Component {
 			this.checkPending = false;
 			this.runChecks();
 		};
-		if (typeof requestAnimationFrame === 'function') {
-			requestAnimationFrame(run);
-		} else {
-			setTimeout(run, 0);
-		}
+		requestAnimationFrame(run);
 	}
 
 	private runChecks() {
-		const currentJson = this.serialize(this.config.getData(this.modObject));
-		this.presets.forEach(entry => this.checkEntry(entry, currentJson));
-		this.userData.forEach(entry => this.checkEntry(entry, currentJson));
+		const current = this.config.getData(this.modObject);
+		const currentJson = this.serialize(current);
+		this.presets.forEach(entry => this.checkEntry(entry, current, currentJson));
+		this.userData.forEach(entry => this.checkEntry(entry, current, currentJson));
 	}
 
-	private checkEntry(entry: SavedData<ModObject, T>, currentJson: string | null) {
-		const isActive =
-			entry.dataJson != null && currentJson != null
-				? entry.dataJson === currentJson
-				: this.config.equals(entry.data, this.config.getData(this.modObject));
+	private checkEntry(entry: SavedData<ModObject, T>, current: T, currentJson: string) {
+		const isActive = this.config.equals ? this.config.equals(entry.data, current) : entry.dataJson === currentJson;
 		if (isActive) {
 			entry.elem.classList.add('active');
 			if (this.saveInput) this.saveInput.value = entry.name;

--- a/ui/core/components/saved_data_managers/ep_weights.ts
+++ b/ui/core/components/saved_data_managers/ep_weights.ts
@@ -26,7 +26,6 @@ export const renderSavedEPWeights = (
 			});
 		},
 		changeEmitters: [simUI.player.epWeightsChangeEmitter],
-		equals: (a, b) => SavedEPWeights.equals(a, b),
 		toJson: a => SavedEPWeights.toJson(a),
 		fromJson: obj => SavedEPWeights.fromJson(obj),
 		...options,

--- a/ui/core/encounter.ts
+++ b/ui/core/encounter.ts
@@ -160,7 +160,7 @@ export class Encounter {
 			this.setExecuteProportion45(eventID, proto.executeProportion45);
 			this.setExecuteProportion90(eventID, proto.executeProportion90);
 			this.setUseHealth(eventID, proto.useHealth);
-			this.targets = proto.targets;
+			this.targets = proto.targets.map(t => TargetProto.clone(t));
 			this.targetsChangeEmitter.emit(eventID);
 		});
 	}

--- a/ui/core/individual_sim_ui.tsx
+++ b/ui/core/individual_sim_ui.tsx
@@ -427,9 +427,24 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 			// This needs to go last so it doesn't re-store things as they are initialized.
 			const events = [this.changeEmitter];
 			if (this.reforger?.changeEmitter) events.push(this.reforger.changeEmitter);
-			TypedEvent.onAny(events).on(_eventID => {
+			// Debounced: serializing + storing the full settings on every keystroke
+			// cost ~50 ms per APL edit. A pending write is flushed on page hide.
+			const persist = () => {
 				const jsonStr = IndividualSimSettings.toJsonString(this.toProto());
 				window.localStorage.setItem(this.getSettingsStorageKey(), jsonStr);
+			};
+			let persistTimer: ReturnType<typeof setTimeout> | null = null;
+			const flushPersist = () => {
+				if (persistTimer == null) return;
+				clearTimeout(persistTimer);
+				persistTimer = null;
+				persist();
+			};
+			window.addEventListener('pagehide', flushPersist);
+			window.addEventListener('beforeunload', flushPersist);
+			TypedEvent.onAny(events).on(_eventID => {
+				if (persistTimer != null) clearTimeout(persistTimer);
+				persistTimer = setTimeout(flushPersist, 300);
 			});
 
 			this.statWeightActionSettings.load(initEventID);

--- a/ui/core/individual_sim_ui.tsx
+++ b/ui/core/individual_sim_ui.tsx
@@ -429,21 +429,20 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 			if (this.reforger?.changeEmitter) events.push(this.reforger.changeEmitter);
 			// Debounced: serializing + storing the full settings on every keystroke
 			// cost ~50 ms per APL edit. A pending write is flushed on page hide.
+			let persistTimer: ReturnType<typeof setTimeout> | null = null;
 			const persist = () => {
+				persistTimer = null;
 				const jsonStr = IndividualSimSettings.toJsonString(this.toProto());
 				window.localStorage.setItem(this.getSettingsStorageKey(), jsonStr);
 			};
-			let persistTimer: ReturnType<typeof setTimeout> | null = null;
-			const flushPersist = () => {
+			window.addEventListener('pagehide', () => {
 				if (persistTimer == null) return;
 				clearTimeout(persistTimer);
-				persistTimer = null;
 				persist();
-			};
-			window.addEventListener('pagehide', flushPersist);
-			TypedEvent.onAny(events).on(_eventID => {
+			});
+			TypedEvent.onAny(events).on(() => {
 				if (persistTimer != null) clearTimeout(persistTimer);
-				persistTimer = setTimeout(flushPersist, 300);
+				persistTimer = setTimeout(persist, 300);
 			});
 
 			this.statWeightActionSettings.load(initEventID);

--- a/ui/core/individual_sim_ui.tsx
+++ b/ui/core/individual_sim_ui.tsx
@@ -441,7 +441,6 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 				persist();
 			};
 			window.addEventListener('pagehide', flushPersist);
-			window.addEventListener('beforeunload', flushPersist);
 			TypedEvent.onAny(events).on(_eventID => {
 				if (persistTimer != null) clearTimeout(persistTimer);
 				persistTimer = setTimeout(flushPersist, 300);

--- a/ui/core/typed_event.ts
+++ b/ui/core/typed_event.ts
@@ -98,7 +98,9 @@ export class TypedEvent<T> {
 	}
 
 	private fireEventInternal(eventID: EventID, event: T) {
-		this.listeners.forEach(listener => listener(eventID, event));
+		// Iterate a copy: a listener may off() itself (lazy self-dispose in Input),
+		// which would otherwise skip the next listener in the live array.
+		this.listeners.slice().forEach(listener => listener(eventID, event));
 	}
 
 	// Executes the provided callback while all TypedEvents are frozen.

--- a/ui/raid/raid_tab.ts
+++ b/ui/raid/raid_tab.ts
@@ -55,9 +55,6 @@ export class RaidTab extends SimTab {
 				});
 			},
 			changeEmitters: [this.simUI.changeEmitter, this.simUI.sim.changeEmitter],
-			equals: (a: SavedRaid, b: SavedRaid) => {
-				return SavedRaid.equals(a, b);
-			},
 			toJson: (a: SavedRaid) => SavedRaid.toJson(a),
 			fromJson: (obj: any) => SavedRaid.fromJson(obj),
 		});

--- a/ui/raid/settings_tab.ts
+++ b/ui/raid/settings_tab.ts
@@ -134,7 +134,6 @@ export class SettingsTab extends SimTab {
 			getData: (encounter: Encounter) => SavedEncounter.create({ encounter: encounter.toProto() }),
 			setData: (eventID: EventID, encounter: Encounter, newEncounter: SavedEncounter) => encounter.fromProto(eventID, newEncounter.encounter!),
 			changeEmitters: [this.simUI.sim.encounter.changeEmitter],
-			equals: (a: SavedEncounter, b: SavedEncounter) => SavedEncounter.equals(a, b),
 			toJson: (a: SavedEncounter) => SavedEncounter.toJson(a),
 			fromJson: (obj: any) => SavedEncounter.fromJson(obj),
 		});

--- a/ui/scss/core/components/detailed_results/_timeline.scss
+++ b/ui/scss/core/components/detailed_results/_timeline.scss
@@ -212,6 +212,12 @@
 	display: inline-flex;
 	border: 1px solid var(--bs-white);
 	margin: 3px;
+	padding: 0 0.375rem 0 0.25rem;
+	cursor: pointer;
+
+	&:hover .fas {
+		color: var(--bs-link-danger);
+	}
 }
 
 .rotation-label-icon {

--- a/ui/scss/core/components/detailed_results/_timeline.scss
+++ b/ui/scss/core/components/detailed_results/_timeline.scss
@@ -212,7 +212,8 @@
 	display: inline-flex;
 	border: 1px solid var(--bs-white);
 	margin: 3px;
-	padding: 0 0.375rem 0 0.25rem;
+	padding: 0 0.5rem;
+	gap: 0.25rem;
 	cursor: pointer;
 
 	&:hover .fas {


### PR DESCRIPTION
## Summary

Cleans up the APL editor and the detailed-results timeline so large rotations are cheap to edit and reference swaps keep their live DOM.

- **TypedEvent** dispatches over a snapshot of the listener array, so a listener that disposes itself no longer skips the next one.
- **Component** gets a child registry (`addChild` / `disposeChild` / `removeChild`) so disposing a parent cascades; the APL editor registers every nested picker.
- **APL editor**: nested pickers no longer subscribe to `rotationChangeEmitter` themselves (`InputConfig.changedEvent` is now optional and parents re-sync children via `Input.refresh()`); async option updates are sequence-guarded; the group-reference variables list reconciles once and keeps its rows in sync.
- **DropdownPicker** skips re-rendering when the option list and selection are unchanged (display fields compared with `shallow-equal`, new direct dependency).
- **Timeline** keeps the rendered rotation subtree live and parks one slot for the current ↔ reference swap instead of cloning DOM and snapshotting the canvas; tooltips and listeners survive the swap. Eye-icon hiding is fixed in three ways: pet and target header rows are no longer hideable (they used to hide without their label and misalign the rows below); hidden rows are keyed by section + action, so hiding a pet's "Attack (Main Hand)" no longer hides the player's; and the hidden chips are clickable as a whole to un-hide, with inner padding, while the spell icon keeps its Wowhead tooltip.
- **SavedDataManager** runs one coalesced active-check per manager per frame instead of a deep proto `equals` per entry per change; managers without a semantic `equals` compare by JSON string.
- **RaidSimResultsManager** resets before replacing content; settings autosave is debounced (300 ms, flushed on `pagehide`).

## Verification

`tsc --noEmit` clean; `oxlint` shows only pre-existing warnings. A 28-spec Playwright sweep (load, Simulate, real result, console/page errors) passes on the final tree (`07322f5dc`) and on the two intermediate commits. Targeted browser checks: APL numeric edit, current ↔ reference timeline swap with live tooltips, group-reference variable pick/delete, and an eye-icon hide sweep across every row on Arms, Beast Mastery, Demonology, Unholy and Elemental.

## Measured DOM impact vs master

Medians over two headless-Chromium sessions per checkout (master `f4a51fa06` vs this branch), same machine, run back to back. Instruments: a `longtask` `PerformanceObserver` plus a body-level `MutationObserver`. **Sync** = main-thread time inside the triggering event; **settle** = time to the last DOM mutation; **mutations** = observer record count.

| Interaction | Metric | master | branch | Δ |
|---|---|---:|---:|---:|
| APL numeric edit (Unholy, Festerblight, 317 items) | sync | 148 ms | 9 ms | -94% |
|  | settle | 287 ms | 186 ms | -35% |
|  | DOM mutations | 30,357 | 3,145 | -90% |
| Reference swap, cached (Arms, Timeline open) | sync | 302 ms | 104 ms | -65% |
|  | settle | 752 ms | 587 ms | -22% |
|  | DOM mutations | 42,337 | 6,194 | -85% |
| Reference swap, cold | sync | 656 ms | 485 ms | -26% |
|  | settle | 1,274 ms | 1,174 ms | -8% |
|  | DOM mutations | 63,406 | 51,338 | -19% |
| Preset swap (Festerblight ↔ Default) | sync | 499 ms | 498 ms | ±0% |
|  | settle | 733 ms | 774 ms | +6% |
|  | DOM mutations | 71,228 | 39,398 | -45% |
| | live tooltips after a cached swap | 0 | 2,506 | tooltips survive the swap |

Preset-swap settle overlaps between checkouts across the 8 samples (master 521–924 ms, branch 528–958 ms), so its +6% is run-to-run noise.

```mermaid
xychart-beta
    title "Sync main-thread cost per interaction (ms, lower is better)"
    x-axis ["APL edit", "Ref swap cached", "Ref swap cold", "Preset swap"]
    y-axis "ms" 0 --> 700
    bar [148, 302, 656, 499]
    bar [9, 104, 485, 498]
```

```mermaid
xychart-beta
    title "DOM mutations per interaction (thousands, lower is better)"
    x-axis ["APL edit", "Ref swap cached", "Ref swap cold", "Preset swap"]
    y-axis "k mutations" 0 --> 80
    bar [30.4, 42.3, 63.4, 71.2]
    bar [3.1, 6.2, 51.3, 39.4]
```

In both charts the first (taller) bar of each pair is master, the second is this branch; mermaid draws the two series overlapped, so the branch bar sits inside the master bar. Where the two are equal (preset-swap sync, 499 vs 498 ms) only one bar is visible.

Protocols: the `apl-edit-timing` / `reference-swap-timing` Playwright scripts from the pending state-ui-separation branch (`tools/browser-perf/` there, not on master) plus a preset-swap variant of the same harness.

https://claude.ai/code/session_016y947FgNKyqFWiApSLYbJe
