### PR TITLE
build(wasm): optimize module output, add opt-in wasm dev server

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,9 @@ jobs:
             - name: Install npm dependencies
               run: npm ci
 
+            - name: Install binaryen
+              run: sudo apt-get update && sudo apt-get install -y binaryen
+
             - name: Build 🔧
               run: |
                   make dist/mop/.dirstamp

--- a/makefile
+++ b/makefile
@@ -101,14 +101,6 @@ wasm: $(OUT_DIR)/lib.wasm.gz
 # Published gzipped: Cloudflare Pages caps files at 25 MiB and the raw module exceeds it.
 # The main thread decompresses and compiles it once (see getSharedWasmModule in
 # ui/core/worker_pool.ts) and shares the compiled module with every worker.
-#
-# GOWASM=satconv,signext lets the compiler emit the non-trapping float->int and
-# sign-extension opcodes instead of emulating them. Both are baseline in every browser
-# the sim supports (Chrome 75+, Firefox 64+, Safari 15+).
-#
-# WASM_FEATURES must stay in step with GOWASM: wasm-opt refuses a module that uses an
-# opcode it was not told to enable, and enabling more than the module needs would let it
-# introduce opcodes the browser baseline above does not cover.
 WASM_FEATURES := --enable-sign-ext --enable-nontrapping-float-to-int --enable-mutable-globals --enable-bulk-memory
 $(OUT_DIR)/lib.wasm.gz: sim/wasm/* sim/core/proto/api.pb.go $(filter-out sim/core/items/all_items.go, $(call rwildcard,sim,*.go))
 	@echo "Starting webassembly compile now..."
@@ -118,8 +110,6 @@ $(OUT_DIR)/lib.wasm.gz: sim/wasm/* sim/core/proto/api.pb.go $(filter-out sim/cor
 		printf "\033[1;31mWASM COMPILE FAILED\033[0m\n"; \
 		exit 1; \
 	fi
-	@# Go never runs its wasm output through a wasm optimizer. Optional so a checkout
-	@# without binaryen still builds -- the module is only unoptimized, never wrong.
 	@if command -v wasm-opt >/dev/null 2>&1; then \
 		echo "Optimizing wasm with wasm-opt..."; \
 		wasm-opt -O3 $(WASM_FEATURES) $(OUT_DIR)/lib.wasm -o $(OUT_DIR)/lib.wasm.tmp && mv -f $(OUT_DIR)/lib.wasm.tmp $(OUT_DIR)/lib.wasm; \

--- a/makefile
+++ b/makefile
@@ -101,13 +101,30 @@ wasm: $(OUT_DIR)/lib.wasm.gz
 # Published gzipped: Cloudflare Pages caps files at 25 MiB and the raw module exceeds it.
 # The main thread decompresses and compiles it once (see getSharedWasmModule in
 # ui/core/worker_pool.ts) and shares the compiled module with every worker.
+#
+# GOWASM=satconv,signext lets the compiler emit the non-trapping float->int and
+# sign-extension opcodes instead of emulating them. Both are baseline in every browser
+# the sim supports (Chrome 75+, Firefox 64+, Safari 15+).
+#
+# WASM_FEATURES must stay in step with GOWASM: wasm-opt refuses a module that uses an
+# opcode it was not told to enable, and enabling more than the module needs would let it
+# introduce opcodes the browser baseline above does not cover.
+WASM_FEATURES := --enable-sign-ext --enable-nontrapping-float-to-int --enable-mutable-globals --enable-bulk-memory
 $(OUT_DIR)/lib.wasm.gz: sim/wasm/* sim/core/proto/api.pb.go $(filter-out sim/core/items/all_items.go, $(call rwildcard,sim,*.go))
 	@echo "Starting webassembly compile now..."
-	@if GOOS=js GOARCH=wasm go build -ldflags "-w -s" -o ./$(OUT_DIR)/lib.wasm ./sim/wasm/; then \
+	@if GOWASM=satconv,signext GOOS=js GOARCH=wasm go build -ldflags "-w -s" -o ./$(OUT_DIR)/lib.wasm ./sim/wasm/; then \
 		printf "\033[1;32mWASM compile successful.\033[0m\n"; \
 	else \
 		printf "\033[1;31mWASM COMPILE FAILED\033[0m\n"; \
 		exit 1; \
+	fi
+	@# Go never runs its wasm output through a wasm optimizer. Optional so a checkout
+	@# without binaryen still builds -- the module is only unoptimized, never wrong.
+	@if command -v wasm-opt >/dev/null 2>&1; then \
+		echo "Optimizing wasm with wasm-opt..."; \
+		wasm-opt -O3 $(WASM_FEATURES) $(OUT_DIR)/lib.wasm -o $(OUT_DIR)/lib.wasm.tmp && mv -f $(OUT_DIR)/lib.wasm.tmp $(OUT_DIR)/lib.wasm; \
+	else \
+		printf "\033[1;33mwasm-opt not found -- skipping optimization (install binaryen to enable).\033[0m\n"; \
 	fi
 	gzip -9 -f -n $(OUT_DIR)/lib.wasm
 

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -19,10 +19,6 @@ export const BASE_PATH = path.resolve(__dirname, 'ui');
 export const OUT_DIR = path.join(__dirname, 'dist', 'mop');
 
 function serveExternalAssets() {
-	// The dev server normally swaps the wasm worker for the HTTP one, so sims run on the
-	// Go backend at :3333. Set WASM_WORKER=1 to serve the real wasm worker instead -- the
-	// only way to exercise the in-browser sim path locally. Needs `make wasm webworkers`
-	// first, since both artifacts are served straight off dist/.
 	const simWorker = process.env.WASM_WORKER ? '/mop/sim_worker.js' : '/mop/local_worker.js';
 	const workerMappings = {
 		'/mop/sim_worker.js': simWorker,

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -19,8 +19,13 @@ export const BASE_PATH = path.resolve(__dirname, 'ui');
 export const OUT_DIR = path.join(__dirname, 'dist', 'mop');
 
 function serveExternalAssets() {
+	// The dev server normally swaps the wasm worker for the HTTP one, so sims run on the
+	// Go backend at :3333. Set WASM_WORKER=1 to serve the real wasm worker instead -- the
+	// only way to exercise the in-browser sim path locally. Needs `make wasm webworkers`
+	// first, since both artifacts are served straight off dist/.
+	const simWorker = process.env.WASM_WORKER ? '/mop/sim_worker.js' : '/mop/local_worker.js';
 	const workerMappings = {
-		'/mop/sim_worker.js': '/mop/local_worker.js',
+		'/mop/sim_worker.js': simWorker,
 		'/mop/net_worker.js': '/mop/net_worker.js',
 		'/mop/lib.wasm.gz': '/mop/lib.wasm.gz',
 		'/mop/highs.wasm': '/mop/highs.wasm',


### PR DESCRIPTION
Three small build changes. None of them touch sim code.

## `GOWASM=satconv,signext`

Lets the Go compiler emit the non-trapping float→int and sign-extension opcodes instead of emulating them. Both are baseline in every browser the sim supports (Chrome 75+, Firefox 64+, Safari 15+).

## Optional `wasm-opt -O3`

Go's toolchain never runs its wasm output through a wasm optimizer. This adds that step, guarded by `command -v` — a checkout without binaryen builds exactly as before, just unoptimized, so this is not a new hard build dependency. CI installs binaryen so the deployed module gets it.

`WASM_FEATURES` is pinned to the opcodes Go actually emits rather than `--all-features`, so binaryen cannot introduce instructions outside the browser baseline above. It has to stay in step with `GOWASM`.

## `WASM_WORKER=1` for the dev server

`vite.config.mts` hard-mapped `/mop/sim_worker.js` → `/mop/local_worker.js`, which is `setupHttpWorker("http://localhost:3333")`. So the dev server always routed sims to the Go backend and **the in-browser wasm path could not be exercised locally at all**. `WASM_WORKER=1 npx vite serve` now serves the real wasm worker. Default behaviour unchanged.

Needs `make wasm webworkers` first, since both artifacts are served straight off `dist/`. Note that `make wasm` alone does not rebuild `sim_worker.js` — `wasm_exec.js` is baked into it at build time.

## On performance

I originally measured these flags as a ~7% throughput win. **That was wrong** — it compared against a baseline captured while the machine was loaded. Measured properly:

- Paired A/B, same commit, alternating control/variant, 8 pairs at 1 worker: **+0.79%, 95% CI −3.6% to +5.2%** (t = 0.43).
- Sweep across 1, 2, 4, 6, 8, 9, 12, 18 workers, 4 measured runs per arm: best-of mean **+2.2%** (se 2.3), median mean +4.7% (se 3.0). Sign flips with worker count.

So: **no measurable throughput change.** I'm proposing these as build hygiene, not as a performance fix, and the makefile comments make no perf claim.

## Verification

- Both build paths exercised end to end: with `wasm-opt` on `PATH` (optimizes) and without (warns, still produces a valid `lib.wasm.gz`).
- Optimized module verified running in a real browser — correct DPS (182,138 vs 182,161–182,224 baseline range, i.e. RNG noise), zero console errors.
- Gzipped module size essentially unchanged (−0.1%); the raw `.wasm` shrinks ~4.6% but gzip closes almost all of it.