### PR TITLE
Fix two Demonology crashes around Drain Life in Metamorphosis

### DIFF
--- a/sim/warlock/demonology/drain_life.go
+++ b/sim/warlock/demonology/drain_life.go
@@ -8,7 +8,19 @@ func (demo *DemonologyWarlock) registerDrainLife() {
 			if demo.CanSpendDemonicFury(30) {
 				demo.SpendDemonicFury(sim, 30, spell.ActionID)
 			} else {
-				demo.ChanneledDot.Deactivate(sim)
+				// Can't afford the next tick. Deactivating from inside our own tick
+				// makes the dot's expire handler fire an extra tick and clears
+				// ChanneledDot under periodicTick, so end the channel right after
+				// this tick instead.
+				dot := demo.ChanneledDot
+				sim.AddPendingAction(&core.PendingAction{
+					NextActionAt: sim.CurrentTime,
+					OnAction: func(sim *core.Simulation) {
+						if dot.IsActive() {
+							dot.Deactivate(sim)
+						}
+					},
+				})
 			}
 		} else {
 			demo.GainDemonicFury(sim, 10, spell.ActionID)

--- a/sim/warlock/demonology/metamorphosis.go
+++ b/sim/warlock/demonology/metamorphosis.go
@@ -26,7 +26,7 @@ func (demo *DemonologyWarlock) registerMetamorphosis() {
 			queueMetaCost(sim)
 
 			// update cast cost
-			drainLifeManaCost = demo.DrainLife.Cost
+			drainLifeManaCost = demo.DrainLife.Cost.ResourceCostImpl
 			demo.DrainLife.Cost.ResourceCostImpl = NewDemonicFuryCost(0)
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {


### PR DESCRIPTION
# Fix two Demonology crashes around Drain Life in Metamorphosis

Two commits, both in `sim/warlock/demonology`. Neither is reachable from the default APL, which never casts Drain Life, so the test suite never saw them. Anyone who adds Drain Life to a demo rotation hits one or the other.

## Meta restores a self-referential cost

`metamorphosis.go` swaps Drain Life's cost to a Demonic Fury cost while Meta is up and restores the mana cost when it drops. The save read `demo.DrainLife.Cost`, the whole `*SpellCost` wrapper, which satisfies `ResourceCostImpl` through its embedded interface. On expire the restore made the wrapper's embedded impl point at the wrapper itself.

The next castability check on Drain Life then calls the promoted `MeetsRequirement`, which Go compiles as a tail jump into the embedded interface's method, which is the same function on the same receiver. It loops forever with a flat stack instead of overflowing, so the sim just hangs with no error. The fix saves `Cost.ResourceCostImpl` instead.

## Drain Life ends its own channel from inside a tick

With the first bug fixed, some seeds still crashed with a nil dereference in `shouldInterruptChannel`. When a Drain Life tick in Meta can't afford the next 30 fury, the callback in `drain_life.go` called `Deactivate` on the channel from inside its own tick. That has two consequences in `periodicTick`: the dot's expire handler sees a tick action due at the current time and fires a catch-up tick, so the starved tick lands twice, and `ChanneledDot` is cleared before `periodicTick` reaches the interrupt check, which dereferences it.

The fix defers the deactivate to a pending action at the current sim time. By the time it runs the tick action has been rescheduled, so no catch-up tick fires, and `periodicTick` finishes with `ChanneledDot` still set. Core is untouched.

## Verification

A throwaway rotation that casts Meta, cancels it, then channels Drain Life reproduced both failures on `master`: the hang first, then the nil dereference once the hang was fixed. With both fixes it runs clean across a range of seeds, and an instrumented run shows the deferred deactivate firing exactly once at the timestamps that used to crash. The affliction, demonology and destruction suites pass with unchanged results files.

Thanks @Rakizi for the report!
