### PR TITLE
[Lock] Fix Destruction P5 preset off-hand enchant

### DIFF
--- a/sim/warlock/destruction/TestDestruction.results
+++ b/sim/warlock/destruction/TestDestruction.results
@@ -4,7 +4,7 @@ character_stats_results: {
   final_stats: 157
   final_stats: 161
   final_stats: 47422
-  final_stats: 30814
+  final_stats: 30952
   final_stats: 305
   final_stats: 2860
   final_stats: 5241
@@ -15,7 +15,7 @@ character_stats_results: {
   final_stats: 24108
   final_stats: 161.7
   final_stats: 0
-  final_stats: 50737.5
+  final_stats: 50889.3
   final_stats: 0
   final_stats: 0
   final_stats: 18104
@@ -26,2415 +26,2415 @@ character_stats_results: {
   final_stats: 8.41176
   final_stats: 15
   final_stats: 16.355
-  final_stats: 27.59698
+  final_stats: 27.65144
   final_stats: 0
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AgilePrimalDiamond"
  value: {
-  dps: 438019.09317
-  tps: 344770.96732
-  hps: 2152.59117
+  dps: 437710.18036
+  tps: 344435.26425
+  hps: 2154.81953
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AlacrityofXuen-103989"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ArcaneBadgeoftheShieldwall-93347"
  value: {
-  dps: 395935.76798
-  tps: 308939.73078
-  hps: 2238.01146
+  dps: 395910.87459
+  tps: 308655.70647
+  hps: 2235.04032
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ArrowflightMedallion-93258"
  value: {
-  dps: 389553.74253
-  tps: 304252.84606
-  hps: 2194.18714
+  dps: 390861.93417
+  tps: 305456.22994
+  hps: 2186.75929
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AssuranceofConsequence-105472"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AusterePrimalDiamond"
  value: {
-  dps: 429163.76165
-  tps: 336891.43254
-  hps: 2167.17004
+  dps: 428875.12571
+  tps: 336574.62408
+  hps: 2169.41349
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BadJuju-96781"
  value: {
-  dps: 394077.31769
-  tps: 308659.75022
-  hps: 2194.92992
+  dps: 394843.58742
+  tps: 309270.43583
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BadgeofKypariZar-84079"
  value: {
-  dps: 388106.20322
-  tps: 303254.55249
-  hps: 2194.92992
+  dps: 388864.8725
+  tps: 303858.56356
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BlossomofPureSnow-89081"
  value: {
-  dps: 397254.12676
-  tps: 310576.50676
-  hps: 2184.53093
+  dps: 398411.38331
+  tps: 311422.97579
+  hps: 2186.0165
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BottleofInfiniteStars-87057"
  value: {
-  dps: 391142.19216
-  tps: 306002.80336
-  hps: 2194.92992
+  dps: 391904.72586
+  tps: 306610.20807
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BraidofTenSongs-84072"
  value: {
-  dps: 388106.20322
-  tps: 303254.55249
-  hps: 2194.92992
+  dps: 388864.8725
+  tps: 303858.56356
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Brawler'sStatue-282039"
  value: {
-  dps: 384443.13218
-  tps: 300510.8336
+  dps: 385892.60972
+  tps: 301376.27295
   hps: 2203.10056
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BreathoftheHydra-96827"
  value: {
-  dps: 417594.16275
-  tps: 325555.60653
-  hps: 2281.83578
+  dps: 418648.66857
+  tps: 326456.43007
+  hps: 2278.86464
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BroochofMunificentDeeds-87500"
  value: {
-  dps: 384443.13218
-  tps: 300510.8336
-  hps: 2256.88881
+  dps: 385892.60972
+  tps: 301376.27295
+  hps: 2256.96526
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BrutalTalismanoftheShado-PanAssault-94508"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BurningPrimalDiamond"
  value: {
-  dps: 439687.17707
-  tps: 345813.3703
-  hps: 2152.59117
+  dps: 441104.64578
+  tps: 346927.22773
+  hps: 2153.33396
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CapacitivePrimalDiamond"
  value: {
-  dps: 430262.04114
-  tps: 337002.58433
-  hps: 2153.33396
+  dps: 430828.5253
+  tps: 337350.97793
+  hps: 2154.07674
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CarbonicCarbuncle-81138"
  value: {
-  dps: 391304.24805
-  tps: 305698.20588
-  hps: 2197.90106
+  dps: 392847.52958
+  tps: 306913.78031
+  hps: 2204.58613
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Cha-Ye'sEssenceofBrilliance-96888"
  value: {
-  dps: 420852.78653
-  tps: 329457.04657
-  hps: 2207.55727
+  dps: 422431.74827
+  tps: 330665.70194
+  hps: 2206.81448
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CharmofTenSongs-84071"
  value: {
-  dps: 390243.78411
-  tps: 304300.39008
-  hps: 2235.7831
+  dps: 391247.8694
+  tps: 305087.53733
+  hps: 2236.52589
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CommunalIdolofDestruction-101168"
  value: {
-  dps: 393568.58026
-  tps: 307488.47325
-  hps: 2242.46817
+  dps: 395033.03057
+  tps: 308930.14573
+  hps: 2240.9826
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CommunalStoneofDestruction-101171"
  value: {
-  dps: 404651.7881
-  tps: 317223.63276
-  hps: 2200.12942
+  dps: 406182.41562
+  tps: 318505.92583
+  hps: 2199.38663
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CommunalStoneofWisdom-101183"
  value: {
-  dps: 401312.65907
-  tps: 312826.79149
+  dps: 402340.83486
+  tps: 313625.26804
   hps: 2194.92992
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ContemplationofChi-Ji-103988"
  value: {
-  dps: 401107.74408
-  tps: 313582.15462
-  hps: 2194.92992
+  dps: 401896.10569
+  tps: 314308.71672
+  hps: 2188.98764
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Coren'sColdChromiumCoaster-282035"
  value: {
-  dps: 393433.7302
-  tps: 307424.13397
-  hps: 2188.98764
+  dps: 394982.69704
+  tps: 308805.39743
+  hps: 2187.50207
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CoreofDecency-87497"
  value: {
-  dps: 389815.84845
-  tps: 304058.19671
+  dps: 390871.25339
+  tps: 304878.423
   hps: 2187.50207
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CourageousPrimalDiamond"
  value: {
-  dps: 432037.67873
-  tps: 338873.27761
-  hps: 2153.33396
+  dps: 434036.97963
+  tps: 340534.21524
+  hps: 2154.07674
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedDreadfulGladiator'sBadgeofConquest-93419"
  value: {
-  dps: 383558.15599
-  tps: 299728.41534
-  hps: 2203.84334
+  dps: 385010.52785
+  tps: 300577.69613
+  hps: 2205.32891
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedDreadfulGladiator'sBadgeofDominance-93600"
  value: {
-  dps: 387711.75391
-  tps: 301495.90293
-  hps: 2197.15828
+  dps: 388723.72323
+  tps: 302562.22358
+  hps: 2191.95878
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedDreadfulGladiator'sBadgeofVictory-93606"
  value: {
-  dps: 383558.15599
-  tps: 299728.41534
-  hps: 2203.84334
+  dps: 385010.52785
+  tps: 300577.69613
+  hps: 2205.32891
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedDreadfulGladiator'sEmblemofCruelty-93485"
  value: {
-  dps: 389091.33941
-  tps: 303770.96682
-  hps: 2208.51558
+  dps: 390694.87023
+  tps: 305054.83266
+  hps: 2212.34135
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedDreadfulGladiator'sEmblemofMeditation-93487"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2212.37864
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2210.89307
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedDreadfulGladiator'sEmblemofTenacity-93486"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2256.29289
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2254.7776
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedDreadfulGladiator'sInsigniaofConquest-93424"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedDreadfulGladiator'sInsigniaofDominance-93601"
  value: {
-  dps: 395918.48973
-  tps: 309493.84416
-  hps: 2188.98764
+  dps: 396479.41786
+  tps: 309702.5761
+  hps: 2191.216
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedDreadfulGladiator'sInsigniaofVictory-93611"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedMalevolentGladiator'sBadgeofConquest-98755"
  value: {
-  dps: 383558.15599
-  tps: 299728.41534
-  hps: 2203.84334
+  dps: 385010.52785
+  tps: 300577.69613
+  hps: 2205.32891
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedMalevolentGladiator'sBadgeofDominance-98910"
  value: {
-  dps: 388730.71828
-  tps: 302640.64741
-  hps: 2191.95878
+  dps: 390134.8408
+  tps: 303624.23096
+  hps: 2190.47321
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedMalevolentGladiator'sBadgeofVictory-98912"
  value: {
-  dps: 383558.15599
-  tps: 299728.41534
-  hps: 2203.84334
+  dps: 385010.52785
+  tps: 300577.69613
+  hps: 2205.32891
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedMalevolentGladiator'sEmblemofCruelty-98811"
  value: {
-  dps: 389928.68405
-  tps: 304409.70541
-  hps: 2215.47621
+  dps: 392521.07459
+  tps: 306500.60113
+  hps: 2221.46258
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedMalevolentGladiator'sEmblemofMeditation-98813"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2215.56439
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2214.07882
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedMalevolentGladiator'sEmblemofTenacity-98812"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2267.44237
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2265.92169
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedMalevolentGladiator'sInsigniaofConquest-98760"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedMalevolentGladiator'sInsigniaofDominance-98911"
  value: {
-  dps: 397042.4857
-  tps: 309850.781
-  hps: 2186.75929
+  dps: 397830.29213
+  tps: 310414.95604
+  hps: 2187.50207
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CraftedMalevolentGladiator'sInsigniaofVictory-98917"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CurseofHubris-105645"
  value: {
-  dps: 394773.07688
-  tps: 308743.32679
-  hps: 2353.51915
+  dps: 396303.92375
+  tps: 309957.62144
+  hps: 2350.3301
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CutstitcherMedallion-93255"
  value: {
-  dps: 392014.05555
-  tps: 305729.3607
-  hps: 2186.0165
+  dps: 393031.35579
+  tps: 306484.02743
+  hps: 2186.75929
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Daelo'sFinalWords-87496"
  value: {
-  dps: 381753.4021
-  tps: 297626.18332
+  dps: 383264.67391
+  tps: 298992.82157
   hps: 2197.15828
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkglowEmbroidery(Rank3)-4893"
  value: {
-  dps: 440565.98694
-  tps: 344480.65974
-  hps: 2252.12437
+  dps: 442146.66663
+  tps: 345823.95983
+  hps: 2255.09551
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmistVortex-87172"
  value: {
-  dps: 395569.24487
-  tps: 307819.0682
-  hps: 2285.5497
+  dps: 397430.34742
+  tps: 309186.49302
+  hps: 2292.23477
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DeadeyeBadgeoftheShieldwall-93346"
  value: {
-  dps: 384795.00996
-  tps: 299818.73462
-  hps: 2198.64385
+  dps: 385987.00105
+  tps: 300861.90293
+  hps: 2200.12942
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DelicateVialoftheSanguinaire-96895"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DestructivePrimalDiamond"
  value: {
-  dps: 433397.51352
-  tps: 339454.04412
-  hps: 2155.56231
+  dps: 436087.5481
+  tps: 341682.77285
+  hps: 2153.33396
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DisciplineofXuen-103986"
  value: {
-  dps: 400901.42994
-  tps: 314725.92423
-  hps: 2194.92992
+  dps: 401651.39283
+  tps: 315319.60974
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Dominator'sArcaneBadge-93342"
  value: {
-  dps: 395935.76798
-  tps: 308939.73078
-  hps: 2238.01146
+  dps: 395910.87459
+  tps: 308655.70647
+  hps: 2235.04032
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Dominator'sDeadeyeBadge-93341"
  value: {
-  dps: 384795.00996
-  tps: 299818.73462
-  hps: 2198.64385
+  dps: 385987.00105
+  tps: 300861.90293
+  hps: 2200.12942
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Dominator'sDurableBadge-93345"
  value: {
-  dps: 384795.00996
-  tps: 299818.73462
-  hps: 2198.64385
+  dps: 385987.00105
+  tps: 300861.90293
+  hps: 2200.12942
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Dominator'sKnightlyBadge-93344"
  value: {
-  dps: 384795.00996
-  tps: 299818.73462
-  hps: 2198.64385
+  dps: 385987.00105
+  tps: 300861.90293
+  hps: 2200.12942
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Dominator'sMendingBadge-93343"
  value: {
-  dps: 390471.21146
-  tps: 304581.70829
-  hps: 2196.41549
+  dps: 391119.54883
+  tps: 304988.52207
+  hps: 2194.92992
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DreadfulGladiator'sBadgeofConquest-84344"
  value: {
-  dps: 383558.15599
-  tps: 299728.41534
-  hps: 2203.84334
+  dps: 385010.52785
+  tps: 300577.69613
+  hps: 2205.32891
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DreadfulGladiator'sBadgeofDominance-84488"
  value: {
-  dps: 387711.75391
-  tps: 301495.90293
-  hps: 2197.15828
+  dps: 388723.72323
+  tps: 302562.22358
+  hps: 2191.95878
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DreadfulGladiator'sBadgeofVictory-84490"
  value: {
-  dps: 383558.15599
-  tps: 299728.41534
-  hps: 2203.84334
+  dps: 385010.52785
+  tps: 300577.69613
+  hps: 2205.32891
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DreadfulGladiator'sEmblemofCruelty-84399"
  value: {
-  dps: 389091.33941
-  tps: 303770.96682
-  hps: 2208.51558
+  dps: 390694.87023
+  tps: 305054.83266
+  hps: 2212.34135
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DreadfulGladiator'sEmblemofMeditation-84401"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2212.37864
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2210.89307
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DreadfulGladiator'sEmblemofTenacity-84400"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2256.29289
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2254.7776
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DreadfulGladiator'sInsigniaofConquest-84349"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DreadfulGladiator'sInsigniaofDominance-84489"
  value: {
-  dps: 395328.80999
-  tps: 308536.02088
-  hps: 2185.27372
+  dps: 396263.30392
+  tps: 309154.59921
+  hps: 2186.0165
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DreadfulGladiator'sInsigniaofVictory-84495"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DurableBadgeoftheShieldwall-93350"
  value: {
-  dps: 384795.00996
-  tps: 299818.73462
-  hps: 2198.64385
+  dps: 385987.00105
+  tps: 300861.90293
+  hps: 2200.12942
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DysmorphicSamophlangeofDiscontinuity-105615"
  value: {
-  dps: 406089.95962
-  tps: 317241.83344
+  dps: 407387.1037
+  tps: 318338.39717
   hps: 2186.0165
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EffulgentPrimalDiamond"
  value: {
-  dps: 429163.76165
-  tps: 336891.43254
-  hps: 2167.17004
+  dps: 428875.12571
+  tps: 336574.62408
+  hps: 2169.41349
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EmberPrimalDiamond"
  value: {
-  dps: 430785.6579
-  tps: 337900.99421
-  hps: 2152.59117
+  dps: 432178.67871
+  tps: 338985.3445
+  hps: 2153.33396
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EmblemofKypariZar-84077"
  value: {
-  dps: 388707.24155
-  tps: 303852.18314
-  hps: 2188.98764
+  dps: 389974.67662
+  tps: 304617.60678
+  hps: 2184.53093
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EmblemoftheCatacombs-83733"
  value: {
-  dps: 386436.59376
-  tps: 300645.37442
-  hps: 2235.7831
+  dps: 388271.94353
+  tps: 302421.06693
+  hps: 2229.09804
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EmptyFruitBarrel-81133"
  value: {
-  dps: 389478.1274
-  tps: 303897.79937
+  dps: 390467.31661
+  tps: 304615.09874
   hps: 2198.64385
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnchantWeapon-BloodyDancingSteel-5125"
  value: {
-  dps: 431653.74116
-  tps: 336863.07835
-  hps: 2256.58108
+  dps: 434027.76956
+  tps: 338915.02027
+  hps: 2255.8383
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnchantWeapon-Colossus-4445"
  value: {
-  dps: 431653.74116
-  tps: 336863.07835
-  hps: 2256.58108
+  dps: 434027.76956
+  tps: 338915.02027
+  hps: 2255.8383
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnchantWeapon-DancingSteel-4444"
  value: {
-  dps: 431653.74116
-  tps: 336863.07835
-  hps: 2256.58108
+  dps: 434027.76956
+  tps: 338915.02027
+  hps: 2255.8383
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnchantWeapon-ElementalForce-4443"
  value: {
-  dps: 431278.16414
-  tps: 337059.2399
-  hps: 2245.43931
+  dps: 432281.01023
+  tps: 337770.93878
+  hps: 2249.15323
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnchantWeapon-River'sSong-4446"
  value: {
-  dps: 431653.74116
-  tps: 336863.07835
-  hps: 2256.58108
+  dps: 434027.76956
+  tps: 338915.02027
+  hps: 2255.8383
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnchantWeapon-SpiritofConquest-5124"
  value: {
-  dps: 441241.92064
-  tps: 344815.34572
-  hps: 2245.43931
+  dps: 442121.61504
+  tps: 345343.78049
+  hps: 2249.15323
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnchantWeapon-Windsong-4441"
  value: {
-  dps: 434716.02891
-  tps: 338918.09461
+  dps: 436069.23716
+  tps: 339943.79497
   hps: 2258.06665
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnigmaticPrimalDiamond"
  value: {
-  dps: 433397.51352
-  tps: 339454.04412
-  hps: 2155.56231
+  dps: 436087.5481
+  tps: 341682.77285
+  hps: 2153.33396
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EssenceofTerror-87175"
  value: {
-  dps: 406093.30643
-  tps: 315910.03046
-  hps: 2279.60742
+  dps: 407452.70608
+  tps: 317170.49842
+  hps: 2276.63628
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EternalPrimalDiamond"
  value: {
-  dps: 429163.76165
-  tps: 336891.43254
-  hps: 2152.59117
+  dps: 428875.12571
+  tps: 336574.62408
+  hps: 2154.81953
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EvilEyeofGalakras-105491"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FabledFeatherofJi-Kun-96842"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FearwurmBadge-84074"
  value: {
-  dps: 388707.24155
-  tps: 303852.18314
-  hps: 2188.98764
+  dps: 389974.67662
+  tps: 304617.60678
+  hps: 2184.53093
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FearwurmRelic-84070"
  value: {
-  dps: 390855.89691
-  tps: 305063.89058
-  hps: 2232.06918
+  dps: 391518.48962
+  tps: 305461.01724
+  hps: 2234.29753
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FelsoulIdolofDestruction-101263"
  value: {
-  dps: 396062.26092
-  tps: 309456.59552
+  dps: 397258.93774
+  tps: 310415.09717
   hps: 2241.72538
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FelsoulStoneofDestruction-101266"
  value: {
-  dps: 405133.84236
-  tps: 317615.19735
-  hps: 2200.12942
+  dps: 406610.42239
+  tps: 318849.22572
+  hps: 2199.38663
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Fen-Yu,FuryofXuen-102248"
  value: {
-  dps: 392592.64576
-  tps: 302451.18587
-  hps: 2236.40248
+  dps: 394126.3287
+  tps: 303605.54186
+  hps: 2245.27709
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FlashfrozenResinGlobule-100951"
  value: {
-  dps: 387669.38603
-  tps: 302032.90293
-  hps: 2191.95878
+  dps: 388738.41865
+  tps: 302743.51397
+  hps: 2194.92992
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FlashingSteelTalisman-81265"
  value: {
-  dps: 383995.31053
-  tps: 299510.9087
-  hps: 2191.216
+  dps: 385246.08757
+  tps: 300322.38316
+  hps: 2194.92992
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FleetPrimalDiamond"
  value: {
-  dps: 431783.23023
-  tps: 339271.79187
-  hps: 2152.59117
+  dps: 431493.36718
+  tps: 338953.99959
+  hps: 2154.81953
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ForlornPrimalDiamond"
  value: {
-  dps: 430785.6579
-  tps: 337900.99421
-  hps: 2152.59117
+  dps: 432178.67871
+  tps: 338985.3445
+  hps: 2153.33396
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FortitudeoftheZandalari-96793"
  value: {
-  dps: 394077.31769
-  tps: 308659.75022
-  hps: 2232.74584
+  dps: 394843.58742
+  tps: 309270.43583
+  hps: 2231.26027
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FrenziedCrystalofRage-105572"
  value: {
-  dps: 410998.1215
-  tps: 321056.90061
-  hps: 2192.70157
+  dps: 412403.12955
+  tps: 322001.56482
+  hps: 2190.47321
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Fusion-FireCore-105459"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GazeoftheTwins-96915"
  value: {
-  dps: 395148.53416
-  tps: 309370.31424
-  hps: 2200.8722
+  dps: 396837.63259
+  tps: 310858.36496
+  hps: 2204.58613
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Gerp'sPerfectArrow-87495"
  value: {
-  dps: 387305.49199
-  tps: 303144.64366
-  hps: 2188.24486
+  dps: 389019.28963
+  tps: 304361.65686
+  hps: 2191.216
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Gong-Lu,StrengthofXuen-102249"
  value: {
-  dps: 392592.64576
-  tps: 302451.18587
-  hps: 2236.40248
+  dps: 394126.3287
+  tps: 303605.54186
+  hps: 2245.27709
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sBadgeofConquest-103145"
  value: {
-  dps: 383558.15599
-  tps: 299728.41534
-  hps: 2203.84334
+  dps: 385010.52785
+  tps: 300577.69613
+  hps: 2205.32891
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sBadgeofDominance-103308"
  value: {
-  dps: 391798.74617
-  tps: 304735.71878
-  hps: 2193.44435
+  dps: 393669.38496
+  tps: 306572.47375
+  hps: 2191.95878
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sBadgeofVictory-103314"
  value: {
-  dps: 383558.15599
-  tps: 299728.41534
-  hps: 2203.84334
+  dps: 385010.52785
+  tps: 300577.69613
+  hps: 2205.32891
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sEmblemofCruelty-103210"
  value: {
-  dps: 392983.14936
-  tps: 306717.75269
+  dps: 394129.31568
+  tps: 307630.7175
   hps: 2222.89507
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sEmblemofMeditation-103212"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2226.609
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2225.12343
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sEmblemofTenacity-103211"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2306.24625
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2304.70678
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sInsigniaofConquest-103150"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sInsigniaofDominance-103309"
  value: {
-  dps: 405490.75547
-  tps: 316790.77797
-  hps: 2191.216
+  dps: 407239.73462
+  tps: 318202.93699
+  hps: 2192.70157
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GrievousGladiator'sInsigniaofVictory-103319"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Haromm'sTalisman-105527"
  value: {
-  dps: 404438.05101
-  tps: 319932.92869
-  hps: 2194.92992
+  dps: 404977.95112
+  tps: 320318.73756
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Hawkmaster'sTalon-89082"
  value: {
-  dps: 388999.2037
-  tps: 302721.50466
-  hps: 2256.58108
+  dps: 390498.78969
+  tps: 304175.61415
+  hps: 2254.35273
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Heart-LesionDefenderIdol-100999"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2265.16239
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2263.62929
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Heart-LesionDefenderStone-101002"
  value: {
-  dps: 393543.26991
-  tps: 308137.80239
-  hps: 2265.16239
+  dps: 394355.42934
+  tps: 308794.40244
+  hps: 2263.62929
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Heart-LesionIdolofBattle-100991"
  value: {
-  dps: 391609.44882
-  tps: 305764.33986
-  hps: 2197.15828
+  dps: 392924.98443
+  tps: 306676.63443
+  hps: 2195.67271
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Heart-LesionStoneofBattle-100990"
  value: {
-  dps: 393271.02471
-  tps: 307958.13963
-  hps: 2194.92992
+  dps: 394076.55475
+  tps: 308607.79048
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofFire-81181"
  value: {
-  dps: 389096.90931
-  tps: 304724.969
+  dps: 390564.33497
+  tps: 305606.56281
   hps: 2203.10056
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartwarmerMedallion-93260"
  value: {
-  dps: 392014.05555
-  tps: 305729.3607
-  hps: 2186.0165
+  dps: 393031.35579
+  tps: 306484.02743
+  hps: 2186.75929
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HelmbreakerMedallion-93261"
  value: {
-  dps: 389553.74253
-  tps: 304252.84606
-  hps: 2194.18714
+  dps: 390861.93417
+  tps: 305456.22994
+  hps: 2186.75929
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Horridon'sLastGasp-96757"
  value: {
-  dps: 401335.40027
-  tps: 313989.00227
-  hps: 2185.27372
+  dps: 402510.94369
+  tps: 314894.70411
+  hps: 2184.53093
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpassivePrimalDiamond"
  value: {
-  dps: 433397.51352
-  tps: 339454.04412
-  hps: 2155.56231
+  dps: 436087.5481
+  tps: 341682.77285
+  hps: 2153.33396
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-IndomitablePrimalDiamond"
  value: {
-  dps: 429163.76165
-  tps: 336891.43254
-  hps: 2167.17004
+  dps: 428875.12571
+  tps: 336574.62408
+  hps: 2169.41349
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InscribedBagofHydra-Spawn-96828"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InsigniaofKypariZar-84078"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-IronBellyWok-89083"
  value: {
-  dps: 388999.2037
-  tps: 302721.50466
-  hps: 2256.58108
+  dps: 390498.78969
+  tps: 304175.61415
+  hps: 2254.35273
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-IronProtectorTalisman-85181"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2246.58037
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2245.05984
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JadeBanditFigurine-86772"
  value: {
-  dps: 388145.09141
-  tps: 302076.9532
+  dps: 389027.13415
+  tps: 302862.99842
   hps: 2258.80944
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JadeCharioteerFigurine-86771"
  value: {
-  dps: 388145.09141
-  tps: 302076.9532
+  dps: 389027.13415
+  tps: 302862.99842
   hps: 2258.80944
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JadeCourtesanFigurine-86774"
  value: {
-  dps: 391299.98954
-  tps: 305131.20479
+  dps: 392292.96796
+  tps: 305898.08585
   hps: 2194.92992
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JadeMagistrateFigurine-86773"
  value: {
-  dps: 396142.62806
-  tps: 309296.28442
-  hps: 2177.84586
+  dps: 397555.05147
+  tps: 310526.73305
+  hps: 2180.817
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JadeWarlordFigurine-86775"
  value: {
-  dps: 385616.96907
-  tps: 300559.48522
-  hps: 2264.55071
+  dps: 386811.0491
+  tps: 301604.81243
+  hps: 2266.08082
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Ji-Kun'sRisingWinds-96843"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Juggernaut'sFocusingCrystal-105514"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 13063.0361
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 13082.52573
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Kardris'ToxicTotem-105540"
  value: {
-  dps: 438099.4801
-  tps: 346277.02825
-  hps: 2203.84334
+  dps: 438530.36236
+  tps: 346382.289
+  hps: 2203.10056
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-KnightlyBadgeoftheShieldwall-93349"
  value: {
-  dps: 384795.00996
-  tps: 299818.73462
-  hps: 2198.64385
+  dps: 385987.00105
+  tps: 300861.90293
+  hps: 2200.12942
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-KnotofTenSongs-84073"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Kor'kronBookofHurting-92785"
  value: {
-  dps: 382222.61741
-  tps: 297835.3836
+  dps: 383571.01146
+  tps: 299225.49631
   hps: 2211.27119
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Lao-Chin'sLiquidCourage-89079"
  value: {
-  dps: 386305.2638
-  tps: 301179.77732
-  hps: 2273.05973
+  dps: 387501.09308
+  tps: 302226.91234
+  hps: 2274.59558
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LeiShen'sFinalOrders-87072"
  value: {
-  dps: 390482.47176
-  tps: 304544.57247
-  hps: 2249.89602
+  dps: 391598.41408
+  tps: 305380.62336
+  hps: 2246.92488
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LessonsoftheDarkmaster-81268"
  value: {
-  dps: 384201.97881
-  tps: 300331.29168
+  dps: 385650.94715
+  tps: 301196.32338
   hps: 2202.35777
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LightdrinkerIdolofRage-101200"
  value: {
-  dps: 390062.95357
-  tps: 305025.85039
-  hps: 2194.92992
+  dps: 390824.11354
+  tps: 305632.04873
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LightdrinkerStoneofRage-101203"
  value: {
-  dps: 393683.17124
-  tps: 308287.88473
-  hps: 2194.92992
+  dps: 394461.75192
+  tps: 308916.06442
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LightoftheCosmos-87065"
  value: {
-  dps: 406486.31204
-  tps: 318115.2702
-  hps: 2231.32639
+  dps: 406587.74889
+  tps: 318160.00778
+  hps: 2230.58361
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LightweaveEmbroidery(Rank3)-4892"
  value: {
-  dps: 446587.90393
-  tps: 349542.36162
-  hps: 2249.15323
+  dps: 447082.76955
+  tps: 349805.78131
+  hps: 2258.06665
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LordBlastington'sScopeofDoom-4699"
  value: {
-  dps: 431653.74116
-  tps: 336863.07835
-  hps: 2256.58108
+  dps: 434027.76956
+  tps: 338915.02027
+  hps: 2255.8383
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MalevolentGladiator'sBadgeofConquest-91452"
  value: {
-  dps: 383558.15599
-  tps: 299728.41534
-  hps: 2203.84334
+  dps: 385010.52785
+  tps: 300577.69613
+  hps: 2205.32891
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MalevolentGladiator'sBadgeofDominance-91753"
  value: {
-  dps: 388730.71828
-  tps: 302640.64741
-  hps: 2191.95878
+  dps: 390134.8408
+  tps: 303624.23096
+  hps: 2190.47321
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MalevolentGladiator'sBadgeofVictory-91763"
  value: {
-  dps: 383558.15599
-  tps: 299728.41534
-  hps: 2203.84334
+  dps: 385010.52785
+  tps: 300577.69613
+  hps: 2205.32891
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MalevolentGladiator'sEmblemofCruelty-91562"
  value: {
-  dps: 389928.68405
-  tps: 304409.70541
-  hps: 2215.47621
+  dps: 392521.07459
+  tps: 306500.60113
+  hps: 2221.46258
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MalevolentGladiator'sEmblemofMeditation-91564"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2215.56439
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2214.07882
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MalevolentGladiator'sEmblemofTenacity-91563"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2267.44237
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2265.92169
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MalevolentGladiator'sInsigniaofConquest-91457"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MalevolentGladiator'sInsigniaofDominance-91754"
  value: {
-  dps: 397549.67364
-  tps: 310266.91769
-  hps: 2180.817
+  dps: 398172.95194
+  tps: 310806.24312
+  hps: 2185.27372
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MalevolentGladiator'sInsigniaofVictory-91768"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MarkoftheCatacombs-83731"
  value: {
-  dps: 391979.23953
-  tps: 306790.64569
-  hps: 2186.0165
+  dps: 393565.74558
+  tps: 308107.46718
+  hps: 2187.50207
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MarkoftheHardenedGrunt-92783"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MedallionofMystifyingVapors-93257"
  value: {
-  dps: 386712.40243
-  tps: 301546.69117
-  hps: 2198.64385
+  dps: 387909.26642
+  tps: 302594.89554
+  hps: 2200.12942
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MedallionoftheCatacombs-83734"
  value: {
-  dps: 387838.91515
-  tps: 303012.59685
-  hps: 2194.92992
+  dps: 388597.24421
+  tps: 303616.30914
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MendingBadgeoftheShieldwall-93348"
  value: {
-  dps: 390471.21146
-  tps: 304581.70829
-  hps: 2196.41549
+  dps: 391119.54883
+  tps: 304988.52207
+  hps: 2194.92992
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MirrorScope-4700"
  value: {
-  dps: 431653.74116
-  tps: 336863.07835
-  hps: 2256.58108
+  dps: 434027.76956
+  tps: 338915.02027
+  hps: 2255.8383
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MistdancerDefenderIdol-101089"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2265.16239
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2263.62929
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MistdancerDefenderStone-101087"
  value: {
-  dps: 393449.27625
-  tps: 308095.16126
-  hps: 2265.16239
+  dps: 394250.01778
+  tps: 308741.55846
+  hps: 2263.62929
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MistdancerIdolofRage-101113"
  value: {
-  dps: 390062.95357
-  tps: 305025.85039
-  hps: 2194.92992
+  dps: 390824.11354
+  tps: 305632.04873
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MistdancerStoneofRage-101117"
  value: {
-  dps: 393511.83396
-  tps: 308197.07182
-  hps: 2194.92992
+  dps: 394293.32178
+  tps: 308829.84415
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MistdancerStoneofWisdom-101107"
  value: {
-  dps: 402553.69632
-  tps: 314508.04586
-  hps: 2191.95878
+  dps: 403431.09398
+  tps: 314993.45433
+  hps: 2190.47321
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MithrilWristwatch-282033"
  value: {
-  dps: 404815.70263
-  tps: 316223.88973
-  hps: 2188.98764
+  dps: 406257.23642
+  tps: 317524.31881
+  hps: 2187.50207
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MountainsageIdolofDestruction-101069"
  value: {
-  dps: 392478.19662
-  tps: 306021.93015
-  hps: 2238.01146
+  dps: 393455.33808
+  tps: 306771.15793
+  hps: 2239.49703
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MountainsageStoneofDestruction-101072"
  value: {
-  dps: 404779.74602
-  tps: 317308.42861
-  hps: 2200.12942
+  dps: 406340.0543
+  tps: 318605.21658
+  hps: 2199.38663
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Nazgrim'sBurnishedInsignia-105549"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-NitroBoosts-4223"
  value: {
-  dps: 442767.0637
-  tps: 346319.53082
-  hps: 2255.8383
+  dps: 443474.46122
+  tps: 346528.07952
+  hps: 2252.86716
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-OathswornDefenderIdol-101303"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2265.16239
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2263.62929
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-OathswornDefenderStone-101306"
  value: {
-  dps: 393179.67294
-  tps: 307862.16751
-  hps: 2265.16239
+  dps: 393931.60531
+  tps: 308453.50052
+  hps: 2263.62929
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-OathswornIdolofBattle-101295"
  value: {
-  dps: 391609.44882
-  tps: 305764.33986
-  hps: 2197.15828
+  dps: 392924.98443
+  tps: 306676.63443
+  hps: 2195.67271
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-OathswornStoneofBattle-101294"
  value: {
-  dps: 393185.81738
-  tps: 307846.48606
-  hps: 2194.92992
+  dps: 393989.03044
+  tps: 308493.80973
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PhaseFingers-4697"
  value: {
-  dps: 440293.66713
-  tps: 343424.16163
+  dps: 441394.53156
+  tps: 344301.06728
   hps: 2266.23729
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PouchofWhiteAsh-103639"
  value: {
-  dps: 382222.61741
-  tps: 297835.3836
+  dps: 383571.01146
+  tps: 299225.49631
   hps: 2211.27119
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PowerfulPrimalDiamond"
  value: {
-  dps: 429163.76165
-  tps: 336891.43254
-  hps: 2167.17004
+  dps: 428875.12571
+  tps: 336574.62408
+  hps: 2169.41349
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PriceofProgress-81266"
  value: {
-  dps: 393034.96166
-  tps: 306795.69934
-  hps: 2192.70157
+  dps: 394213.29962
+  tps: 307822.0241
+  hps: 2197.15828
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PridefulGladiator'sBadgeofConquest-103342"
  value: {
-  dps: 383558.15599
-  tps: 299728.41534
-  hps: 2203.84334
+  dps: 385010.52785
+  tps: 300577.69613
+  hps: 2205.32891
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PridefulGladiator'sBadgeofDominance-103505"
  value: {
-  dps: 396710.78045
-  tps: 308710.45435
-  hps: 2195.67271
+  dps: 398810.36703
+  tps: 310621.81643
+  hps: 2191.216
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PridefulGladiator'sBadgeofVictory-103511"
  value: {
-  dps: 383558.15599
-  tps: 299728.41534
-  hps: 2203.84334
+  dps: 385010.52785
+  tps: 300577.69613
+  hps: 2205.32891
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PridefulGladiator'sEmblemofCruelty-103407"
  value: {
-  dps: 395472.86564
-  tps: 308894.30286
-  hps: 2237.28221
+  dps: 397151.64083
+  tps: 310581.30743
+  hps: 2236.45154
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PridefulGladiator'sEmblemofMeditation-103409"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2236.0603
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2234.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PridefulGladiator'sEmblemofTenacity-103408"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2339.47495
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2337.91939
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PridefulGladiator'sInsigniaofConquest-103347"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PridefulGladiator'sInsigniaofDominance-103506"
  value: {
-  dps: 411268.241
-  tps: 321596.90013
-  hps: 2183.04536
+  dps: 411868.80282
+  tps: 322100.57683
+  hps: 2186.75929
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PridefulGladiator'sInsigniaofVictory-103516"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Primordius'TalismanofRage-96873"
  value: {
-  dps: 394902.50766
-  tps: 308339.30203
-  hps: 2195.67271
+  dps: 396057.28708
+  tps: 309272.29474
+  hps: 2196.41549
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PrismaticPrisonofPride-105474"
  value: {
-  dps: 409977.9486
-  tps: 322157.6831
-  hps: 2233.55475
+  dps: 410928.42664
+  tps: 322910.4023
+  hps: 2227.61246
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Qian-Le,CourageofNiuzao-102245"
  value: {
-  dps: 393542.3417
-  tps: 302865.94676
-  hps: 2196.46672
+  dps: 394797.15703
+  tps: 303636.13131
+  hps: 2195.72717
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Qian-Ying,FortitudeofNiuzao-102250"
  value: {
-  dps: 385353.95805
-  tps: 296100.47063
-  hps: 2209.77864
+  dps: 386663.54457
+  tps: 297197.62552
+  hps: 2207.55998
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Qin-xi'sPolarizingSeal-87075"
  value: {
-  dps: 394724.1743
-  tps: 308216.8994
-  hps: 2173.38915
+  dps: 396418.74394
+  tps: 309357.8547
+  hps: 2181.55979
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RegaliaoftheHornedNightmare"
  value: {
-  dps: 332656.98963
-  tps: 258211.67612
-  hps: 1835.89963
+  dps: 333769.76224
+  tps: 258927.626
+  hps: 1839.89796
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RegaliaoftheThousandfoldHells"
  value: {
-  dps: 325303.48793
-  tps: 252675.74345
+  dps: 326580.53073
+  tps: 253626.58707
   hps: 1811.02329
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RelicofChi-Ji-79330"
  value: {
-  dps: 396399.78692
-  tps: 309603.92867
-  hps: 2200.8722
+  dps: 397134.80794
+  tps: 310072.42747
+  hps: 2195.67271
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RelicofKypariZar-84075"
  value: {
-  dps: 392154.2824
-  tps: 305887.10324
-  hps: 2232.06918
+  dps: 393101.94245
+  tps: 306679.56748
+  hps: 2234.29753
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RelicofNiuzao-79329"
  value: {
-  dps: 381419.69896
-  tps: 297378.22166
-  hps: 2258.43031
+  dps: 382468.23994
+  tps: 298006.15526
+  hps: 2260.72546
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RelicofXuen-79327"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RelicofXuen-79328"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RelicofYu'lon-79331"
  value: {
-  dps: 402777.76401
-  tps: 314877.08532
+  dps: 404039.63287
+  tps: 315987.27151
   hps: 2194.92992
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Renataki'sSoulCharm-96741"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ResolveofNiuzao-103990"
  value: {
-  dps: 393557.87107
-  tps: 308189.53454
-  hps: 2194.92992
+  dps: 394323.47962
+  tps: 308799.63951
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ReverberatingPrimalDiamond"
  value: {
-  dps: 438019.09317
-  tps: 344770.96732
-  hps: 2152.59117
+  dps: 437710.18036
+  tps: 344435.26425
+  hps: 2154.81953
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RevitalizingPrimalDiamond"
  value: {
-  dps: 438019.09317
-  tps: 344770.96732
-  hps: 2152.59117
+  dps: 437710.18036
+  tps: 344435.26425
+  hps: 2154.81953
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RuneofRe-Origination-96918"
  value: {
-  dps: 383957.93935
-  tps: 299737.25611
-  hps: 2181.55979
+  dps: 384748.64038
+  tps: 300306.26289
+  hps: 2182.30257
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SI:7Operative'sManual-92784"
  value: {
-  dps: 382222.61741
-  tps: 297835.3836
+  dps: 383571.01146
+  tps: 299225.49631
   hps: 2211.27119
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ScrollofReveredAncestors-89080"
  value: {
-  dps: 392277.4548
-  tps: 305885.82863
-  hps: 2194.92992
+  dps: 392411.11309
+  tps: 305999.79493
+  hps: 2186.75929
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SearingWords-81267"
  value: {
-  dps: 389803.6555
-  tps: 304380.10545
+  dps: 390620.78558
+  tps: 305154.22991
   hps: 2194.92992
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Sha-SkinRegalia"
  value: {
-  dps: 312667.30668
-  tps: 242041.83351
-  hps: 1679.81166
+  dps: 313760.06638
+  tps: 242918.43303
+  hps: 1680.42969
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ShadowflameRegalia"
  value: {
-  dps: 246854.0249
-  tps: 188793.29291
+  dps: 247662.13037
+  tps: 189446.66113
   hps: 1360.12581
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Shock-ChargerMedallion-93259"
  value: {
-  dps: 396971.11034
-  tps: 308874.58369
-  hps: 2253.60994
+  dps: 397776.83145
+  tps: 309626.50598
+  hps: 2251.38159
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SigilofCompassion-83736"
  value: {
-  dps: 388284.592
-  tps: 303361.25103
-  hps: 2194.18714
+  dps: 388590.71153
+  tps: 303576.78401
+  hps: 2190.47321
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SigilofDevotion-83740"
  value: {
-  dps: 387829.2784
-  tps: 302997.27859
-  hps: 2186.0165
+  dps: 389399.45492
+  tps: 304297.91451
+  hps: 2187.50207
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SigilofFidelity-83737"
  value: {
-  dps: 392612.27857
-  tps: 306427.2319
-  hps: 2227.61246
+  dps: 393325.89222
+  tps: 306870.95499
+  hps: 2226.86968
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SigilofGrace-83738"
  value: {
-  dps: 387838.91515
-  tps: 303012.59685
-  hps: 2194.92992
+  dps: 388597.24421
+  tps: 303616.30914
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SigilofKypariZar-84076"
  value: {
-  dps: 392933.10019
-  tps: 307712.17703
-  hps: 2188.98764
+  dps: 394195.46887
+  tps: 308470.51743
+  hps: 2184.53093
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SigilofPatience-83739"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SigilofRampage-105580"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SigiloftheCatacombs-83732"
  value: {
-  dps: 389926.49411
-  tps: 303787.22421
+  dps: 390975.66341
+  tps: 304594.63201
   hps: 2232.81196
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SinisterPrimalDiamond"
  value: {
-  dps: 442767.0637
-  tps: 346319.53082
-  hps: 2255.8383
+  dps: 443474.46122
+  tps: 346528.07952
+  hps: 2252.86716
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Skeer'sBloodsoakedTalisman-105632"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SkullrenderMedallion-93256"
  value: {
-  dps: 389553.74253
-  tps: 304252.84606
-  hps: 2194.18714
+  dps: 390861.93417
+  tps: 305456.22994
+  hps: 2186.75929
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SoothingTalismanoftheShado-PanAssault-94509"
  value: {
-  dps: 399170.40273
-  tps: 311836.55567
+  dps: 400335.00037
+  tps: 312847.65675
   hps: 2194.18714
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SoulBarrier-96927"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2315.52347
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2313.95628
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SparkofZandalar-96770"
  value: {
-  dps: 392370.27882
-  tps: 305812.29103
-  hps: 2275.15071
+  dps: 393351.74225
+  tps: 306670.54821
+  hps: 2273.66514
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SpiritsoftheSun-87163"
  value: {
-  dps: 397597.88539
-  tps: 310479.56325
+  dps: 398778.08268
+  tps: 311419.23525
   hps: 2194.18714
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SpringrainIdolofDestruction-101023"
  value: {
-  dps: 397512.15083
-  tps: 310513.21446
-  hps: 2248.41045
+  dps: 398634.03255
+  tps: 311503.08432
+  hps: 2246.18209
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SpringrainIdolofRage-101009"
  value: {
-  dps: 390062.95357
-  tps: 305025.85039
-  hps: 2194.92992
+  dps: 390824.11354
+  tps: 305632.04873
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SpringrainStoneofDestruction-101026"
  value: {
-  dps: 404387.12337
-  tps: 316913.17434
-  hps: 2200.12942
+  dps: 405821.90489
+  tps: 318102.22769
+  hps: 2199.38663
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SpringrainStoneofRage-101012"
  value: {
-  dps: 393974.97635
-  tps: 308595.03276
-  hps: 2194.92992
+  dps: 394734.92136
+  tps: 309192.13192
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SpringrainStoneofWisdom-101041"
  value: {
-  dps: 402508.77759
-  tps: 314317.55848
-  hps: 2197.15828
+  dps: 403265.02433
+  tps: 315029.82778
+  hps: 2194.18714
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Static-Caster'sMedallion-93254"
  value: {
-  dps: 396971.11034
-  tps: 308874.58369
-  hps: 2253.60994
+  dps: 397776.83145
+  tps: 309626.50598
+  hps: 2251.38159
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SteadfastFootman'sMedallion-92782"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SteadfastTalismanoftheShado-PanAssault-94507"
  value: {
-  dps: 392513.93467
-  tps: 307244.53797
-  hps: 2194.92992
+  dps: 393278.21443
+  tps: 307853.47603
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StreamtalkerIdolofDestruction-101222"
  value: {
-  dps: 395584.98772
-  tps: 308538.68542
-  hps: 2262.52336
+  dps: 396869.8513
+  tps: 309687.21845
+  hps: 2258.80944
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StreamtalkerIdolofRage-101217"
  value: {
-  dps: 390062.95357
-  tps: 305025.85039
-  hps: 2194.92992
+  dps: 390824.11354
+  tps: 305632.04873
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StreamtalkerStoneofDestruction-101225"
  value: {
-  dps: 404221.54794
-  tps: 316741.32027
-  hps: 2200.12942
+  dps: 405732.11676
+  tps: 318010.22354
+  hps: 2199.38663
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StreamtalkerStoneofRage-101220"
  value: {
-  dps: 393637.53891
-  tps: 308203.73281
-  hps: 2194.92992
+  dps: 394449.25832
+  tps: 308861.05204
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StreamtalkerStoneofWisdom-101250"
  value: {
-  dps: 400903.05243
-  tps: 312774.24353
-  hps: 2191.95878
+  dps: 401956.92063
+  tps: 313658.15858
+  hps: 2189.73043
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StuffofNightmares-87160"
  value: {
-  dps: 391596.07755
-  tps: 306413.67143
-  hps: 2194.92992
+  dps: 392359.18899
+  tps: 307021.5835
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SunsoulDefenderIdol-101160"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2265.16239
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2263.62929
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SunsoulDefenderStone-101163"
  value: {
-  dps: 393736.44226
-  tps: 308322.69117
-  hps: 2265.16239
+  dps: 394508.21228
+  tps: 308940.8093
+  hps: 2263.62929
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SunsoulIdolofBattle-101152"
  value: {
-  dps: 391609.44882
-  tps: 305764.33986
-  hps: 2197.15828
+  dps: 392924.98443
+  tps: 306676.63443
+  hps: 2195.67271
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SunsoulStoneofBattle-101151"
  value: {
-  dps: 393112.95669
-  tps: 307785.41615
-  hps: 2194.92992
+  dps: 393900.10085
+  tps: 308416.76293
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SunsoulStoneofWisdom-101138"
  value: {
-  dps: 403223.76499
-  tps: 314816.75717
-  hps: 2193.44435
+  dps: 404024.00115
+  tps: 315365.3558
+  hps: 2192.70157
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SwordguardEmbroidery(Rank3)-4894"
  value: {
-  dps: 440565.98694
-  tps: 344480.65974
-  hps: 2252.12437
+  dps: 442146.66663
+  tps: 345823.95983
+  hps: 2255.09551
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SymboloftheCatacombs-83735"
  value: {
-  dps: 387838.91515
-  tps: 303012.59685
-  hps: 2194.92992
+  dps: 388597.24421
+  tps: 303616.30914
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SynapseSprings(MarkII)-4898"
  value: {
-  dps: 441701.08698
-  tps: 345354.66438
-  hps: 2255.8383
+  dps: 442407.44487
+  tps: 345562.52644
+  hps: 2252.86716
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TalismanofBloodlust-96864"
  value: {
-  dps: 394114.04208
-  tps: 307403.30399
+  dps: 395312.57709
+  tps: 308407.62651
   hps: 2288.52084
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TerrorintheMists-87167"
  value: {
-  dps: 395822.71537
-  tps: 309151.36727
-  hps: 2200.8722
+  dps: 396983.16024
+  tps: 310134.33894
+  hps: 2202.35777
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Thok'sAcid-GroovedTooth-105607"
  value: {
-  dps: 410199.82517
-  tps: 320106.42336
+  dps: 412544.19497
+  tps: 322047.53565
   hps: 2189.73043
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Thok'sTailTip-105609"
  value: {
-  dps: 409977.9486
-  tps: 322157.6831
-  hps: 2233.55475
+  dps: 410928.42664
+  tps: 322910.4023
+  hps: 2227.61246
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Thousand-YearPickledEgg-282031"
  value: {
-  dps: 405401.64774
-  tps: 315569.20011
+  dps: 406499.91413
+  tps: 316514.97636
   hps: 2261.03779
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TickingEbonDetonator-105612"
  value: {
-  dps: 397304.94713
-  tps: 311581.47872
-  hps: 2194.92992
+  dps: 398075.32522
+  tps: 312195.77219
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Time-LostArtifact-103678"
  value: {
-  dps: 390779.08385
-  tps: 305674.1089
-  hps: 2194.92992
+  dps: 391541.15536
+  tps: 306281.10773
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TrailseekerIdolofRage-101054"
  value: {
-  dps: 390062.95357
-  tps: 305025.85039
-  hps: 2194.92992
+  dps: 390824.11354
+  tps: 305632.04873
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TrailseekerStoneofRage-101057"
  value: {
-  dps: 393511.21718
-  tps: 308120.91723
-  hps: 2194.92992
+  dps: 394205.7547
+  tps: 308651.34939
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sBadgeofConquest-100043"
  value: {
-  dps: 383558.15599
-  tps: 299728.41534
-  hps: 2203.84334
+  dps: 385010.52785
+  tps: 300577.69613
+  hps: 2205.32891
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sBadgeofDominance-100016"
  value: {
-  dps: 389592.87136
-  tps: 302916.15148
-  hps: 2187.50207
+  dps: 391675.99978
+  tps: 304930.10628
+  hps: 2188.98764
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sBadgeofVictory-100019"
  value: {
-  dps: 383558.15599
-  tps: 299728.41534
-  hps: 2203.84334
+  dps: 385010.52785
+  tps: 300577.69613
+  hps: 2205.32891
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sEmblemofCruelty-100066"
  value: {
-  dps: 391368.87808
-  tps: 305553.94355
-  hps: 2207.64837
+  dps: 392921.69744
+  tps: 306671.22247
+  hps: 2213.59065
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sEmblemofMeditation-99990"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2219.79862
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2218.31305
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sEmblemofTenacity-100092"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2282.33282
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2280.80493
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sInsigniaofConquest-100026"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sInsigniaofDominance-100152"
  value: {
-  dps: 401216.12108
-  tps: 313446.99367
-  hps: 2191.216
+  dps: 401935.61751
+  tps: 314041.93955
+  hps: 2194.18714
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalGladiator'sInsigniaofVictory-100085"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TyrannicalPrimalDiamond"
  value: {
-  dps: 429163.76165
-  tps: 336891.43254
-  hps: 2152.59117
+  dps: 428875.12571
+  tps: 336574.62408
+  hps: 2154.81953
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-UnerringVisionofLeiShen-96930"
  value: {
-  dps: 414975.90454
-  tps: 325511.96067
-  hps: 2198.64385
+  dps: 415130.24462
+  tps: 325356.86041
+  hps: 2200.12942
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VaporshieldMedallion-93262"
  value: {
-  dps: 386712.40243
-  tps: 301546.69117
-  hps: 2198.64385
+  dps: 387909.26642
+  tps: 302594.89554
+  hps: 2200.12942
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VialofDragon'sBlood-87063"
  value: {
-  dps: 391142.19216
-  tps: 306002.80336
-  hps: 2194.92992
+  dps: 391904.72586
+  tps: 306610.20807
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VialofIchorousBlood-100963"
  value: {
-  dps: 392197.82102
-  tps: 306054.17813
-  hps: 2190.47321
+  dps: 393377.45176
+  tps: 307149.17542
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VialofLivingCorruption-105568"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2355.91093
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2354.31641
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousTalismanoftheShado-PanAssault-94511"
  value: {
-  dps: 384449.90424
-  tps: 299944.78192
-  hps: 2194.92992
+  dps: 385203.91952
+  tps: 300544.70596
+  hps: 2193.44435
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VisionofthePredator-81192"
  value: {
-  dps: 400321.26591
-  tps: 313192.91218
+  dps: 401547.39543
+  tps: 314196.44081
   hps: 2190.47321
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VolatileTalismanoftheShado-PanAssault-94510"
  value: {
-  dps: 403952.12542
-  tps: 314472.82232
-  hps: 2261.03779
+  dps: 405167.60782
+  tps: 315490.31376
+  hps: 2263.26615
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WindsweptPages-81125"
  value: {
-  dps: 384048.60062
-  tps: 298606.51551
+  dps: 385223.15724
+  tps: 299560.5202
   hps: 2225.38411
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WoundripperMedallion-93253"
  value: {
-  dps: 389553.74253
-  tps: 304252.84606
-  hps: 2194.18714
+  dps: 390861.93417
+  tps: 305456.22994
+  hps: 2186.75929
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Wushoolay'sFinalChoice-96785"
  value: {
-  dps: 407117.42964
-  tps: 317674.98217
-  hps: 2193.44435
+  dps: 408876.50445
+  tps: 319073.00035
+  hps: 2194.92992
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Yu'lon'sBite-103987"
  value: {
-  dps: 415877.44813
-  tps: 325481.27089
-  hps: 2197.90106
+  dps: 416879.12853
+  tps: 326255.92313
+  hps: 2197.15828
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ZenAlchemistStone-75274"
  value: {
-  dps: 403075.6552
-  tps: 315836.72944
+  dps: 403818.15829
+  tps: 316299.61584
   hps: 2200.12942
  }
 }
 dps_results: {
  key: "TestDestruction-Average-Default"
  value: {
-  dps: 435386.43279
-  tps: 339657.70316
-  hps: 2260.6423
+  dps: 436674.2144
+  tps: 340687.33815
+  hps: 2260.88632
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p5-Destruction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1.02518928451e+06
-  tps: 855927.86159
+  dps: 1.02797598946e+06
+  tps: 858231.79756
   hps: 6475.48848
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p5-Destruction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 438120.87541
-  tps: 343248.7349
-  hps: 2255.05655
+  dps: 438779.38569
+  tps: 343414.30594
+  hps: 2252.08546
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p5-Destruction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 662374.26152
-  tps: 481851.74718
+  dps: 663854.93062
+  tps: 482948.4913
   hps: 2818.82069
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p5-Destruction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 680147.55813
-  tps: 574683.36176
+  dps: 682060.68191
+  tps: 576277.29897
   hps: 5364.84224
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p5-Destruction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 285090.86458
-  tps: 223259.55434
+  dps: 286307.16441
+  tps: 224152.34039
   hps: 1870.54533
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p5-Destruction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 387816.28207
-  tps: 288745.31501
+  dps: 388845.55265
+  tps: 289455.65727
   hps: 1904.23027
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p5-Destruction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1.03020432096e+06
-  tps: 858473.82897
+  dps: 1.03296773988e+06
+  tps: 860770.20628
   hps: 6477.82871
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p5-Destruction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 442767.0637
-  tps: 346319.53082
-  hps: 2255.8383
+  dps: 443474.46122
+  tps: 346528.07952
+  hps: 2252.86716
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p5-Destruction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 672123.21741
-  tps: 487863.56517
+  dps: 673609.60892
+  tps: 488961.41767
   hps: 2818.86939
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p5-Destruction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 688811.95502
-  tps: 582000.16435
+  dps: 690814.87364
+  tps: 583683.27435
   hps: 5338.81889
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p5-Destruction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 288606.82615
-  tps: 225570.32663
+  dps: 289806.82474
+  tps: 226443.0291
   hps: 1871.26771
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p5-Destruction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 394015.51149
-  tps: 292731.70064
+  dps: 395049.07435
+  tps: 293441.89892
   hps: 1904.26582
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p5-Destruction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 1.03856127656e+06
-  tps: 862422.96058
+  dps: 1.04157427283e+06
+  tps: 864892.61938
   hps: 6658.21045
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p5-Destruction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 445155.68479
-  tps: 344751.32358
-  hps: 2344.18922
+  dps: 446121.68862
+  tps: 345511.47867
+  hps: 2346.41754
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p5-Destruction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 687916.61349
-  tps: 491083.36023
+  dps: 689525.71901
+  tps: 492231.40707
   hps: 3082.50484
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p5-Destruction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 702840.51402
-  tps: 588619.05485
+  dps: 704820.75229
+  tps: 590274.02958
   hps: 5444.58618
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p5-Destruction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 288866.62042
-  tps: 224567.91958
-  hps: 1939.2901
+  dps: 289187.50217
+  tps: 224824.19932
+  hps: 1938.60266
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p5-Destruction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 389150.51086
-  tps: 283095.14348
+  dps: 390942.8798
+  tps: 284468.36454
   hps: 2096.71564
  }
 }
 dps_results: {
  key: "TestDestruction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 442767.0637
-  tps: 346319.53082
-  hps: 2255.8383
+  dps: 443474.46122
+  tps: 346528.07952
+  hps: 2252.86716
  }
 }

--- a/ui/warlock/destruction/gear_sets/p5.gear.json
+++ b/ui/warlock/destruction/gear_sets/p5.gear.json
@@ -15,6 +15,6 @@
 		{ "id": 105422, "upgradeStep": "UpgradeStepTwo" },
 		{ "id": 105648, "reforging": 154, "upgradeStep": "UpgradeStepTwo" },
 		{ "id": 105550, "enchant": 4442, "gems": [76671], "reforging": 147, "upgradeStep": "UpgradeStepTwo" },
-		{ "id": 105650, "enchant": 4091, "gems": [76671], "upgradeStep": "UpgradeStepTwo" }
+		{ "id": 105650, "enchant": 4434, "gems": [76671], "upgradeStep": "UpgradeStepTwo" }
 	]
 }


### PR DESCRIPTION
Fixes #1512

The Destruction P5 BIS preset had Superior Intellect (+40) on the off-hand where Affliction and Demonology use Major Intellect (+165). This switches it to Major Intellect and regenerates the Destruction test results.