### PR TITLE
[Core] Never disable the last active target

### DIFF
--- a/sim/core/target.go
+++ b/sim/core/target.go
@@ -267,6 +267,13 @@ func (target *Target) Disable(sim *Simulation, expireAuras bool) {
 		return
 	}
 
+	// A misconfigured encounter (e.g. a boss preset whose add was removed from the encounter,
+	// so the AI resolves its add unit to the boss itself) must never leave the sim with zero
+	// active targets. Keep the last one alive instead of panicking.
+	if len(sim.Encounter.ActiveTargets) == 1 {
+		return
+	}
+
 	target.CancelGCDTimer(sim)
 	target.AutoAttacks.CancelAutoSwing(sim)
 


### PR DESCRIPTION
Fixes #1253

A boss preset whose add has been removed from the encounter makes the AI resolve its add unit to the boss itself, so the scheduled add death disabled the only target and the sim panicked with "Cannot remove the only active target". Target.Disable now returns early when it would remove the last active target, so a misconfigured encounter keeps its final target alive instead of crashing. The linked Horridon export from the issue runs to completion with this change.