### PR TITLE
fix(sim): stop strict sequences double-hooking the spell queue

### DIFF
--- a/sim/core/apl_actions_sequences.go
+++ b/sim/core/apl_actions_sequences.go
@@ -119,6 +119,10 @@ type APLActionStrictSequence struct {
 	curIdx     int
 
 	subactionSpells []*Spell
+
+	// The queue action currently hooked to advance this sequence, and the callback it replaced.
+	hookedQueueAction *PendingAction
+	hookedOnAction    func(*Simulation)
 }
 
 func (rot *APLRotation) newActionStrictSequence(config *proto.APLActionStrictSequence) APLActionImpl {
@@ -151,6 +155,7 @@ func (action *APLActionStrictSequence) PostFinalize(rot *APLRotation) {
 }
 func (action *APLActionStrictSequence) Reset(*Simulation) {
 	action.curIdx = 0
+	action.unhookQueueAction()
 	action.unit.Rotation.inSequence = false
 }
 func (action *APLActionStrictSequence) IsReady(sim *Simulation) bool {
@@ -179,6 +184,7 @@ func (action *APLActionStrictSequence) Execute(sim *Simulation) {
 }
 func (action *APLActionStrictSequence) relinquishControl() {
 	action.curIdx = 0
+	action.unhookQueueAction()
 	action.unit.Rotation.inSequence = false
 	action.unit.Rotation.popControllingAction(action)
 }
@@ -207,12 +213,7 @@ func (action *APLActionStrictSequence) GetNextAction(sim *Simulation) *APLAction
 		// The spell was already queued at this timestep; modify it to advance the sequence when it executes
 		// and return nil to wait for the GCD to become ready.
 		queueAction := action.unit.QueuedSpell.queueAction
-		oldFunc := queueAction.OnAction
-		queueAction.OnAction = func(sim *Simulation) {
-			oldFunc(sim)
-			action.advanceSequence()
-			queueAction.OnAction = oldFunc
-		}
+		action.hookQueueAction(queueAction)
 		action.unit.SetRotationTimer(sim, queueAction.NextActionAt+time.Duration(1))
 
 		return nil
@@ -225,6 +226,37 @@ func (action *APLActionStrictSequence) GetNextAction(sim *Simulation) *APLAction
 		// Return nil to wait for the GCD to become ready.
 		return nil
 	}
+}
+
+// hookQueueAction makes the queued spell's action advance this sequence when it fires.
+// Must stay idempotent: the rotation can be re-evaluated within a timestep, and a second
+// wrapper would advance twice and strand a stale hook on the queue action, which is reused
+// for later unrelated spells. The wrapper unhooks itself first, so any callback that manages
+// OnAction gets the last word; the guard keeps it off another action's hook.
+func (action *APLActionStrictSequence) hookQueueAction(queueAction *PendingAction) {
+	if action.hookedQueueAction == queueAction {
+		return
+	}
+	action.unhookQueueAction()
+
+	oldFunc := queueAction.OnAction
+	action.hookedQueueAction = queueAction
+	action.hookedOnAction = oldFunc
+	queueAction.OnAction = func(sim *Simulation) {
+		if action.hookedQueueAction == queueAction {
+			action.unhookQueueAction()
+		}
+		oldFunc(sim)
+		action.advanceSequence()
+	}
+}
+func (action *APLActionStrictSequence) unhookQueueAction() {
+	if action.hookedQueueAction == nil {
+		return
+	}
+	action.hookedQueueAction.OnAction = action.hookedOnAction
+	action.hookedQueueAction = nil
+	action.hookedOnAction = nil
 }
 func (action *APLActionStrictSequence) String() string {
 	return "Strict Sequence(" + strings.Join(MapSlice(action.subactions, func(subaction *APLAction) string { return fmt.Sprintf("(%s)", subaction) }), "+") + ")"


### PR DESCRIPTION
Port of wowsims/tbc-new#508. The code in `sim/core/apl_actions_sequences.go` is byte-identical between the two repos here, so the defect exists in MoP by construction.

## Root cause

When a `StrictSequence` subaction gets spell-queued rather than cast, `GetNextAction` wraps the queued spell's `PendingAction.OnAction` so the sequence advances when the spell actually fires. That wrap is unconditional — and the rotation can be evaluated more than once within a single timestep, so the hook can be installed twice on the same `PendingAction`.

Traced in the TBC sim (protection warrior vs Archimonde, single iteration):

1. **93.673s** — the strict sequence pushes itself as controlling action, casts Berserker Rage (1.5s GCD), `curIdx` → 1. Defensive Stance can't cast yet, so it is queued. **Hook #1** installed.
2. Still **93.673s** — off-GCD Heroic Strike casts and the rotation is re-evaluated. Subaction 1 is still not ready (`CanQueueSpell` false), so it lands in the same queue branch → **hook #2 wraps hook #1**.
3. **93.733s** — the PA fires. W2 → W1 → cast → advance → 2/2 → `relinquishControl` (pop succeeds) → W1 restores the original callback. W2 then advances a **second** time (sequence state corrupt) and restores `OnAction = W1` — a stale hook left on the PA.
4. `QueuedSpell.InitiateQueue` reuses a consumed `PendingAction`. At **95.653s** an unrelated top-level action queues onto it, the stale hook fires, advances a sequence that no longer holds control, and `popControllingAction` panics with `Wrong APL controllingAction in pop()`.

Two defects from one cause: the crash, and a silent sequence-step skip whenever the double-hook occurs without later panicking.

MoP's `StrictSequence.IsReady` has an extra gate TBC lacks (every subaction spell must be `IsReady`), but that gates *entry* to the sequence — `GetNextAction` never re-checks it, so it does not prevent the double-hook once the sequence holds control.

## Fix

Track the hooked `PendingAction` on the action so the install is idempotent; unhook on fire, on `relinquishControl`, and on `Reset`. The wrapper restores before invoking the callback it replaced, so a callback that manages `OnAction` itself (a plain `Sequence`'s wrapper, or a re-queue re-arming the same PA) gets the last word.

## Verification

- `go build --tags=with_db ./sim/...` — clean.
- `go test --tags=with_db ./sim/...` — passes, **no `.results` drift**. (`TestProtoVersioning` fails from `buf breaking` both with and without this change — pre-existing here, confirmed by stashing.)
- **Instrumented measurement across the full MoP suite: 94,670 hook installs, 0 same-PA re-hooks.** The queue branch is heavily exercised, and the new idempotency guard never fires — so this change is behaviourally inert on current content and purely defensive against the crash class demonstrated in TBC.

## Scope

The crash itself was reproduced in TBC (first failing seed 24944; 500k iterations panicked in under a second), not in MoP — that would need a MoP-shaped fixture whose rotation re-evaluates in the same timestep as a strict-sequence subaction gets queued. 22 of 75 shipped MoP APLs use `strictSequence`, so the exposure is wider here than in TBC.

No regression test — exercising this needs a strict-sequence test harness that doesn't exist in either repo yet.

https://claude.ai/code/session_01JLYfnAjyPNwvpMHRb8PV5k
