### PR TITLE
fix(sim): warriors lost ranged weapons in MoP, so stop offering them

### DIFF
--- a/sim/core/character_constants.go
+++ b/sim/core/character_constants.go
@@ -105,7 +105,9 @@ var ClassWeaponTypeCapabilities = map[proto.Class]map[proto.WeaponType]EligibleW
 }
 
 var ClassRangedWeaponTypeCapabilities = map[proto.Class][]proto.RangedWeaponType{
-	proto.Class_ClassWarrior:     {proto.RangedWeaponType_RangedWeaponTypeBow, proto.RangedWeaponType_RangedWeaponTypeCrossbow, proto.RangedWeaponType_RangedWeaponTypeGun, proto.RangedWeaponType_RangedWeaponTypeThrown},
+	// MoP 5.0 removed the ranged slot: warriors lost bows, guns and thrown entirely, which is why no
+	// class here lists Thrown any more and rogues and paladins are already empty.
+	proto.Class_ClassWarrior:     {},
 	proto.Class_ClassPaladin:     {},
 	proto.Class_ClassHunter:      {proto.RangedWeaponType_RangedWeaponTypeBow, proto.RangedWeaponType_RangedWeaponTypeCrossbow, proto.RangedWeaponType_RangedWeaponTypeGun},
 	proto.Class_ClassRogue:       {},

--- a/sim/core/character_constants_test.go
+++ b/sim/core/character_constants_test.go
@@ -1,0 +1,43 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/wowsims/mop/sim/core/proto"
+)
+
+// MoP 5.0 removed the ranged weapon slot. Warriors kept a pre-MoP set here — bows, crossbows, guns
+// and thrown — which put ranged weapons into their main-hand item pool, since that is the slot MoP
+// resolves ranged weapons to. Nothing caught it because the table is generated data that no test
+// read for its own sake.
+func TestNoClassCanUseThrownWeapons(t *testing.T) {
+	for class, types := range ClassRangedWeaponTypeCapabilities {
+		for _, rangedType := range types {
+			if rangedType == proto.RangedWeaponType_RangedWeaponTypeThrown {
+				t.Errorf("%v lists Thrown, which no class can equip in MoP", class)
+			}
+		}
+	}
+}
+
+// Hunters are the only class with a real ranged weapon; the caster classes keep wands.
+func TestOnlyHuntersAndCastersHaveRangedWeapons(t *testing.T) {
+	wandOnly := map[proto.Class]bool{proto.Class_ClassPriest: true, proto.Class_ClassMage: true, proto.Class_ClassWarlock: true}
+
+	for class, types := range ClassRangedWeaponTypeCapabilities {
+		switch {
+		case class == proto.Class_ClassHunter:
+			if len(types) == 0 {
+				t.Error("hunters must keep their ranged weapons")
+			}
+		case wandOnly[class]:
+			for _, rangedType := range types {
+				if rangedType != proto.RangedWeaponType_RangedWeaponTypeWand {
+					t.Errorf("%v lists %v; casters hold wands only", class, rangedType)
+				}
+			}
+		case len(types) != 0:
+			t.Errorf("%v lists %v; every other class lost ranged weapons in MoP", class, types)
+		}
+	}
+}


### PR DESCRIPTION
`ClassRangedWeaponTypeCapabilities` still gives warriors bows, crossbows, guns and thrown. MoP 5.0 removed the ranged slot, and this table resolves ranged weapons into the **main hand** — so those items are offered in a warrior's main-hand pool today.

### What a user sees

Opening the gear picker on a warrior's main-hand slot on current `master`:

| | rows in the list |
|---|---|
| `master` | **1,658** |
| with this fix | **1,460** |

The 198 extra rows are all ranged weapons — *Arathar, the Eye of Flame*, *Death Lotus Crossbow*, *Kor'kron Hand Cannon*, *Cataclysmic Gladiator's Rifle* and 174 more distinct names. None of them are equippable. The same table also drives the Filters menu, which shows a warrior a "Ranged Weapon Type" section with four checked boxes, and `sim/core/bulk/item_rules.go:165`, so bulk generates warrior candidates from the same bad pool.

Hunters are unaffected — their row in the table is correct, and their main-hand list is identical before and after.

### Why this is the right row to change

The table is its own evidence. Paladins, rogues, death knights, shamans, monks and druids are already empty; hunters keep bow/crossbow/gun; the three caster classes keep wands. Warrior was the only row still carrying its pre-MoP set, and `Thrown` appears nowhere else at all.

### Tests

Two new tests hold the table to that shape — no class lists `Thrown`, and only hunters and the wand casters list anything. Reverting the warrior row fails both:

```
--- FAIL: TestNoClassCanUseThrownWeapons
    ClassWarrior lists Thrown, which no class can equip in MoP
--- FAIL: TestOnlyHuntersAndCastersHaveRangedWeapons
    ClassWarrior lists [RangedWeaponTypeBow RangedWeaponTypeThrown]; every other class lost ranged weapons in MoP
```

These are generated data, which is exactly why nothing caught this: no test read the table for its own sake.

`go test -tags with_db ./sim/core/...` — 82 pass, 1 skip. `TestProtoVersioning` fails identically on unmodified `master` in this environment (buf breaking check), so it is unrelated.

### Note for reviewers

Only the Go source is edited. `vite.config.mts` runs `gen_db -gen=go-to-ts` through `watchAndRun` on every build, so `capabilities_auto_gen.ts` regenerates itself. That generated file is gitignored, so hand-editing it would have been silently undone by the next build — and it is also why this never showed up in a branch diff.

Cherry-picked out of the React migration branch (#1567), where it was buried among UI commits. It is Go-only and independent of that work.