### PR TITLE
fix DPET inflation for sub 1s casts in the rotation timeline

### DIFF
--- a/ui/core/proto_utils/combat_log/derive.ts
+++ b/ui/core/proto_utils/combat_log/derive.ts
@@ -360,10 +360,10 @@ function buildCastLog(
 	const threat = castCompletedLog?.threat || castCancelledLog?.threat || castBeganLog.threat;
 
 	let castTime = castBeganLog.castTime;
-	let effectiveTime = castBeganLog.effectiveTime;
+	// effectiveTime stays the began line's: it is the GCD time the tooltip and DPET report, not
+	// the cast's measured length.
 	if (castCompletedLog) {
 		castTime = castCompletedLog.timestamp - castBeganLog.timestamp;
-		effectiveTime = castCompletedLog.timestamp - castBeganLog.timestamp;
 	}
 	const cancelTime = castCancelledLog?.cancelTime ?? 0;
 

--- a/ui/core/proto_utils/combat_log/derive.ts
+++ b/ui/core/proto_utils/combat_log/derive.ts
@@ -362,6 +362,7 @@ function buildCastLog(
 	let castTime = castBeganLog.castTime;
 	// effectiveTime stays the began line's: it is the GCD time the tooltip and DPET report, not
 	// the cast's measured length.
+	const effectiveTime = castBeganLog.effectiveTime;
 	if (castCompletedLog) {
 		castTime = castCompletedLog.timestamp - castBeganLog.timestamp;
 	}


### PR DESCRIPTION
DPET in the rotation timeline is `totalDamage / (effectiveTime || 1)`.
but `effectiveTime` is set to the measured cast length, which isn't floored at the 1s GCD minimum. For any cast under 1s DPET is divided by a fraction and inflated.

changed to stop overwriting `effectiveTime` 

I encountered this while working on my backport of WoWSims to 3.3.5 private servers, and noted some change already exists in tbc-new repo but hasn't made it to MoP. 

<img width="359" height="163" alt="image" src="https://github.com/user-attachments/assets/50bd6a9e-af37-44a7-9216-0129871cd8dc" />
