### PR TITLE
fix(reforge): stop minimizeRegems trading away socket bonuses

### DIFF
--- a/sim/core/reforge_optimizer/gear.go
+++ b/sim/core/reforge_optimizer/gear.go
@@ -190,7 +190,7 @@ func (o *reforgeOptimizer) applyLPSolution(selectedVars []string) *proto.Equipme
 // minimizeRegems cuts the number of gems the player must actually buy. For each socket the
 // solver changed, it locates where that socket's original gem now lives (via findGem) and swaps
 // the two gems back — reusing a gem the player already owns instead of buying a new one — unless
-// doing so would drop a socket-color match the solver found.
+// doing so would cost the socket bonuses the solver claimed.
 func (o *reforgeOptimizer) minimizeRegems(newGear *core.Equipment) {
 	originalGear := o.originalEquipment
 	if originalGear == nil {
@@ -206,7 +206,7 @@ func (o *reforgeOptimizer) minimizeRegems(newGear *core.Equipment) {
 			continue
 		}
 
-		for socketIdx, socketColor := range currentSocketColors(*newItem, o.isBlacksmithing, o.settings) {
+		for socketIdx := range currentSocketColors(*newItem, o.isBlacksmithing, o.settings) {
 			socketKey := reforgeSocketKey{slot: slot, socketIdx: socketIdx}
 			if finalizedSocketKeys[socketKey] {
 				continue
@@ -218,15 +218,15 @@ func (o *reforgeOptimizer) minimizeRegems(newGear *core.Equipment) {
 			if newGemID == 0 || originalGemID == 0 || newGemID == originalGemID {
 				continue
 			}
-			newGem, newOk := core.GetGemByID(newGemID)
-			originalGem, originalOk := core.GetGemByID(originalGemID)
+			_, newOk := core.GetGemByID(newGemID)
+			_, originalOk := core.GetGemByID(originalGemID)
 			if !newOk || !originalOk {
 				continue
 			}
-			// The decision to keep or undo this swap is left entirely to the net-match comparison
-			// below, which weighs both sockets together. A per-socket short-circuit here — keeping
-			// the swap merely because the solver's gem matches this socket — would wrongly leave a
-			// match-neutral same-color swap in place (the brm-weapon-gem-desync scenario).
+			// The decision to keep or undo this swap is left entirely to the socket-bonus
+			// comparison below, which weighs both items together. A per-socket short-circuit here —
+			// keeping the swap merely because the solver's gem matches this socket — would wrongly
+			// leave a bonus-neutral same-color swap in place (the brm-weapon-gem-desync scenario).
 
 			for _, loc := range o.findGem(newGear, originalGemID) {
 				if o.frozenSlots[loc.slot] {
@@ -237,25 +237,30 @@ func (o *reforgeOptimizer) minimizeRegems(newGear *core.Equipment) {
 					continue
 				}
 				matchedItem := newGear.GetItemBySlot(loc.slot)
-				matchedColors := currentSocketColors(*matchedItem, o.isBlacksmithing, o.settings)
-				if loc.socketIdx >= len(matchedColors) {
+				if loc.socketIdx >= len(currentSocketColors(*matchedItem, o.isBlacksmithing, o.settings)) {
 					continue
 				}
-				matchedSocketColor := matchedColors[loc.socketIdx]
-				// Restore the original gem here only if it does not reduce the total socket-color
-				// matches across BOTH sockets involved. Weighing both sockets (not just the one the
-				// gem moved to) preserves a genuine color-match upgrade the solver found while still
-				// undoing a match-neutral shuffle (e.g. two same-color MH/OH weapon sockets) that
-				// would otherwise be a pointless regem.
-				matchesIfSwapped := boolToInt(core.GemMatchesSocket(originalGem.Color, socketColor)) + boolToInt(core.GemMatchesSocket(newGem.Color, matchedSocketColor))
-				matchesIfKept := boolToInt(core.GemMatchesSocket(newGem.Color, socketColor)) + boolToInt(core.GemMatchesSocket(originalGem.Color, matchedSocketColor))
-				if matchesIfSwapped < matchesIfKept {
+				// A swap moves gems between sockets without changing which gems are equipped, so
+				// the only stats at stake are the two items' socket bonuses. Those are all-or-
+				// nothing per ITEM, which is why a per-socket color-match count is not a safe
+				// guard: shuffling one match off a fully-matched item onto a partly-matched one is
+				// match-neutral yet loses a bonus outright. Require instead that the two items'
+				// earned bonuses come out IDENTICAL, which is the condition under which the swap
+				// is provably free. Scoring the two arrangements by EP would not be safe here: the
+				// solver's caps live in the LP's constraints, not in its weights, so a pre-cap EP
+				// comparison would happily trade an Intellect bonus for a Hit one the player is
+				// already capped on.
+				bonusIfKept := o.socketBonusStats(newItem).Add(o.socketBonusStats(matchedItem))
+				setGemIDAt(newItem, socketIdx, originalGemID)
+				setGemIDAt(matchedItem, loc.socketIdx, newGemID)
+				bonusIfSwapped := o.socketBonusStats(newItem).Add(o.socketBonusStats(matchedItem))
+				if bonusIfSwapped != bonusIfKept {
+					setGemIDAt(newItem, socketIdx, newGemID)
+					setGemIDAt(matchedItem, loc.socketIdx, originalGemID)
 					continue
 				}
 
 				finalizedSocketKeys[matchedKey] = true
-				setGemIDAt(newItem, socketIdx, originalGemID)
-				setGemIDAt(matchedItem, loc.socketIdx, newGemID)
 				break
 			}
 		}
@@ -297,11 +302,20 @@ func (o *reforgeOptimizer) findGem(equipment *core.Equipment, gemID int32) []gem
 	return locations
 }
 
-func boolToInt(b bool) int {
-	if b {
-		return 1
+// socketBonusStats returns an item's socket bonus, or zero stats when the bonus is not earned.
+// The bonus applies only when every colored socket holds a color-matching gem, mirroring the
+// all-or-nothing rule the LP models via its SocketBonusLink constraints.
+func (o *reforgeOptimizer) socketBonusStats(item *core.Item) stats.Stats {
+	for socketIdx, socketColor := range currentSocketColors(*item, o.isBlacksmithing, o.settings) {
+		if !isColoredSocket(socketColor) {
+			continue
+		}
+		gem, ok := core.GetGemByID(gemIDAt(item, socketIdx))
+		if !ok || !core.GemMatchesSocket(gem.Color, socketColor) {
+			return stats.Stats{}
+		}
 	}
-	return 0
+	return item.SocketBonus
 }
 
 var amplificationTrinketItemIDs = buildAmplificationTrinketItemIDSet()

--- a/sim/core/reforge_optimizer/gear_test.go
+++ b/sim/core/reforge_optimizer/gear_test.go
@@ -13,7 +13,7 @@ import (
 // the original (pre-optimize) gems on originalEquipment, gems enabled, nothing frozen.
 func minimizeRegemsHarness(original *proto.EquipmentSpec) *reforgeOptimizer {
 	return &reforgeOptimizer{
-		settings:          &proto.ReforgeSettings{IncludeGems: true},
+		settings:          &proto.ReforgeSettings{IncludeGems: true, IncludeEotbGemSocket: true},
 		frozenSlots:       map[proto.ItemSlot]bool{},
 		originalEquipment: equipmentFromProto(original),
 	}
@@ -86,5 +86,78 @@ func TestMinimizeRegemsIgnoresUnchangedSocketDecoy(t *testing.T) {
 	if gemIDAt(chest, 0) != deadly || gemIDAt(chest, 1) != deadly || gemIDAt(chest, 2) != deadly || gemIDAt(hands, 0) != crafty {
 		t.Fatalf("swap not cleanly undone (matched an unchanged decoy socket): chest=[%d %d %d] hands[0]=%d, want chest=[%d %d %d] hands[0]=%d",
 			gemIDAt(chest, 0), gemIDAt(chest, 1), gemIDAt(chest, 2), gemIDAt(hands, 0), deadly, deadly, deadly, crafty)
+	}
+}
+
+// minimizeRegems must never trade one socket bonus for a different one. Hands 99359 have two Red
+// sockets worth +120 Int; the legendary cloak 102246 has a single Red socket worth +60 Int. The
+// solver put both Orange (Red-matching) gems on the hands to claim the bigger bonus and left the
+// non-matching Yellow gem on the cloak. Undoing that cross-slot swap is socket-COLOR-match
+// neutral — one Red socket stays matched either way — but it moves the claim from the +120 Int
+// item to the +60 Int one, so it must be rejected.
+func TestMinimizeRegemsKeepsLargerSocketBonus(t *testing.T) {
+	sim.RegisterAll()
+
+	const backSlot, handsSlot = 3, 6
+	const quick, reckless = int32(76699), int32(76668) // Yellow (no Red match), Orange (Red match)
+
+	mkSpec := func(backGem int32, handsGems []int32) *proto.EquipmentSpec {
+		items := make([]*proto.ItemSpec, 16)
+		for i := range items {
+			items[i] = &proto.ItemSpec{}
+		}
+		items[backSlot] = &proto.ItemSpec{Id: 102246, Gems: []int32{backGem}}
+		items[handsSlot] = &proto.ItemSpec{Id: 99359, Gems: handsGems}
+		return &proto.EquipmentSpec{Items: items}
+	}
+
+	original := mkSpec(reckless, []int32{quick, quick})
+	solved := mkSpec(quick, []int32{reckless, reckless})
+	newGear := equipmentFromProto(solved)
+
+	minimizeRegemsHarness(original).minimizeRegems(newGear)
+
+	back := newGear.GetItemBySlot(proto.ItemSlot(backSlot))
+	hands := newGear.GetItemBySlot(proto.ItemSlot(handsSlot))
+	if gemIDAt(back, 0) != quick || gemIDAt(hands, 0) != reckless || gemIDAt(hands, 1) != reckless {
+		t.Fatalf("socket bonus downgraded: back=[%d] hands=[%d %d], want back=[%d] hands=[%d %d]",
+			gemIDAt(back, 0), gemIDAt(hands, 0), gemIDAt(hands, 1), quick, reckless, reckless)
+	}
+}
+
+// A socket bonus in a stat the player is already capped on is worth nothing, but the optimizer's
+// caps live in the LP's constraints, not in its EP weights — so minimizeRegems cannot score the
+// two arrangements by EP without happily trading a real Intellect bonus for a dead Hit one.
+// Shoulders 82857 (+60 Hit) and the legendary cloak 102246 (+60 Int) each have a single Red
+// socket, so the undo is socket-color-match neutral AND pre-cap-EP positive (Hit outweighs
+// Intellect), yet it must still be rejected: the bonuses are not the same stat, so the swap is
+// not provably free.
+func TestMinimizeRegemsKeepsDifferentStatSocketBonus(t *testing.T) {
+	sim.RegisterAll()
+
+	const shoulderSlot, backSlot = 2, 3
+	const quick, reckless = int32(76699), int32(76668) // Yellow (no Red match), Orange (Red match)
+
+	mkSpec := func(shoulderGem, backGem int32) *proto.EquipmentSpec {
+		items := make([]*proto.ItemSpec, 16)
+		for i := range items {
+			items[i] = &proto.ItemSpec{}
+		}
+		items[shoulderSlot] = &proto.ItemSpec{Id: 82857, Gems: []int32{shoulderGem}}
+		items[backSlot] = &proto.ItemSpec{Id: 102246, Gems: []int32{backGem}}
+		return &proto.EquipmentSpec{Items: items}
+	}
+
+	original := mkSpec(reckless, quick)
+	solved := mkSpec(quick, reckless)
+	newGear := equipmentFromProto(solved)
+
+	minimizeRegemsHarness(original).minimizeRegems(newGear)
+
+	shoulders := newGear.GetItemBySlot(proto.ItemSlot(shoulderSlot))
+	back := newGear.GetItemBySlot(proto.ItemSlot(backSlot))
+	if gemIDAt(shoulders, 0) != quick || gemIDAt(back, 0) != reckless {
+		t.Fatalf("Intellect bonus traded for a capped-stat Hit bonus: shoulders=[%d] back=[%d], want shoulders=[%d] back=[%d]",
+			gemIDAt(shoulders, 0), gemIDAt(back, 0), quick, reckless)
 	}
 }


### PR DESCRIPTION
## Problem

Reported against Shadow Priest: the Reforge Optimizer returns gear that leaves socket bonuses on the table, and the score it reports is better than the gear it hands back.

The LP is not at fault. It models socket bonuses correctly as all-or-nothing via its `SocketBonusLink_<slot>_<socket>` constraints, and on the reported set it claimed them: `SocketBonus_{0,2,6,8,9,10,14}`.

The damage happens afterwards, in `minimizeRegems` — the post-solve pass that permutes the solver's gems back into sockets the player already owns so a suggestion costs as few new gems as possible. Its guard compared socket-**colour-match counts** across the two sockets involved in a swap:

```go
matchesIfSwapped := boolToInt(...) + boolToInt(...)
matchesIfKept    := boolToInt(...) + boolToInt(...)
if matchesIfSwapped < matchesIfKept { continue }
```

Wrong invariant. Socket bonuses are all-or-nothing per **item**, so shuffling one match off a fully-matched item onto a partly-matched one is match-neutral (`1 == 1`, guard lets it through) and loses a bonus outright.

On the reported set the solver claimed +120 Int (hands 99359) and +60 Int (main hand 105614). `minimizeRegems` traded both away for +60 Int on the cloak (102246) — a net loss of **120 Intellect**, and it left the chest as `[yellow, orange, orange]`, which earns nothing and is strictly dominated by three yellows.

Secondary: the returned `score` is the LP objective and is never recomputed after this pass, so the number the user sees is not what the gear delivers.

## Fix

The guard now compares the two items' *earned* socket bonuses and permits the swap only when they come out identical:

```go
bonusIfKept := o.socketBonusStats(newItem).Add(o.socketBonusStats(matchedItem))
// apply swap
bonusIfSwapped := o.socketBonusStats(newItem).Add(o.socketBonusStats(matchedItem))
if bonusIfSwapped != bonusIfKept { /* revert */ continue }
```

A gem permutation is stat-neutral *modulo socket bonuses* — that is the only thing this pass can break, so it is the only thing the guard has to measure, and exact equality is precisely the condition under which the swap is free.

### Why not score the two arrangements by EP

Because the optimizer's caps live in the LP's **constraints**, not in its weights. Pre-cap EP ranks Hit (1.45) above Intellect (1.0) whether or not the player is sitting at the 15% hit cap, so an EP-scored guard would happily trade a live Intellect bonus for a dead Hit one — and would be more confident about it than the bug being fixed here. Same story for a haste threshold (pre-cap 1.0, post-cap 0.73). 48 items at ilvl ≥ 450 carry a Hit socket bonus, so the case is reachable, not theoretical.

Equality needs no weights and no cap knowledge. It costs a few extra regems in asymmetric cases — which are exactly the cases where freeness cannot be proven anyway.

`boolToInt` was left unused by the new guard and is removed.

## Tests

Two new cases in `gear_test.go`, both RED against the old guard:

```
--- FAIL: TestMinimizeRegemsKeepsLargerSocketBonus
    back=[76668] hands=[76699 76668], want back=[76699] hands=[76668 76668]
--- FAIL: TestMinimizeRegemsKeepsDifferentStatSocketBonus
    shoulders=[76668] back=[76699], want shoulders=[76699] back=[76668]
```

- `TestMinimizeRegemsKeepsLargerSocketBonus` — hands 99359 (+120 Int) vs cloak 102246 (+60 Int). Match-neutral undo that downgrades the claim.
- `TestMinimizeRegemsKeepsDifferentStatSocketBonus` — shoulders 82857 (+60 Hit) vs cloak 102246 (+60 Int). Match-neutral *and* pre-cap-EP-positive, still rejected.

Both pre-existing `minimizeRegems` tests still pass — bonus-neutral swaps still go through, so the pass keeps doing its job.

Full package green, all six `test-fixtures/*.test.json` included. No fixture touched.

```
--- PASS: TestReforgerOptimizer (18.04s)
    haste-thresholds  hybrid-caster  relative-stat-cap
    soft-caps-multi   stat-conversions  tank-caps
ok  github.com/wowsims/mop/sim/core/reforge_optimizer  21.575s
```

On the reported set, socket bonus total goes from `{Intellect: 480, Spirit: 120}` to `{Intellect: 600, Spirit: 120}`, with regem count still at 4 — the bonus-neutral cloak↔main-hand swap (+60 Int either side) is still taken.
